### PR TITLE
Add static convenience method for compiling without exit.

### DIFF
--- a/ant/src/main/java/com/google/errorprone/ErrorProneAntCompilerAdapter.java
+++ b/ant/src/main/java/com/google/errorprone/ErrorProneAntCompilerAdapter.java
@@ -27,6 +27,6 @@ public class ErrorProneAntCompilerAdapter extends DefaultCompilerAdapter {
   @Override
   public boolean execute() throws BuildException {
     String[] args = setupModernJavacCommand().getArguments();
-    return new ErrorProneCompiler.Builder().build().compile(args).isOK();
+    return ErrorProneCompiler.compile(args).isOK();
   }
 }

--- a/core/src/main/java/com/google/errorprone/ErrorProneCompiler.java
+++ b/core/src/main/java/com/google/errorprone/ErrorProneCompiler.java
@@ -60,7 +60,7 @@ public class ErrorProneCompiler {
    * @param args the same args which could be passed to javac on the command line
    */
   public static void main(String[] args) {
-    System.exit(new ErrorProneCompiler.Builder().build().compile(args).exitCode);
+    System.exit(compile(args).exitCode);
   }
 
   /**
@@ -68,13 +68,23 @@ public class ErrorProneCompiler {
    *
    * @param listener listens to the diagnostics produced by error-prone
    * @param args the same args which would be passed to javac on the command line
-   * @return exit code from the compiler invocation
+   * @return result from the compiler invocation
    */
   public static Result compile(DiagnosticListener<JavaFileObject> listener, String[] args) {
     ErrorProneCompiler compiler = new ErrorProneCompiler.Builder()
         .listenToDiagnostics(listener)
         .build();
-    return compiler.compile(args);
+    return compiler.run(args);
+  }
+
+  /**
+   * Programmatic interface to the error-prone Java compiler.
+   *
+   * @param args the same args which would be passed to javac on the command line
+   * @return result from the compiler invocation
+   */
+  public static Result compile(String[] args) {
+    return new Builder().build().run(args);
   }
 
   /**
@@ -82,13 +92,13 @@ public class ErrorProneCompiler {
    *
    * @param args the same args which would be passed to javac on the command line
    * @param out a {@link PrintWriter} to which to send diagnostic output
-   * @return exit code from the compiler invocation
+   * @return result from the compiler invocation
    */
   public static Result compile(String[] args, PrintWriter out) {
     ErrorProneCompiler compiler = new ErrorProneCompiler.Builder()
         .redirectOutputTo(out)
         .build();
-    return compiler.compile(args);
+    return compiler.run(args);
   }
 
   private final DiagnosticListener<? super JavaFileObject> diagnosticListener;
@@ -142,10 +152,10 @@ public class ErrorProneCompiler {
     }
   }
 
-  public Result compile(String[] args) {
+  public Result run(String[] args) {
     Context context = new Context();
     JavacFileManager.preRegister(context);
-    return compile(args, context);
+    return run(args, context);
   }
 
   /**
@@ -198,7 +208,7 @@ public class ErrorProneCompiler {
     return argv;
   }
 
-  private Result compile(String[] argv, Context context) {
+  private Result run(String[] argv, Context context) {
     try {
       argv = prepareCompilation(argv, context);
     } catch (InvalidCommandLineOptionException e) {
@@ -210,15 +220,15 @@ public class ErrorProneCompiler {
     return new Main(compilerName, errOutput).compile(argv, context);
   }
 
-  public Result compile(
+  public Result run(
     String[] argv,
     List<JavaFileObject> javaFileObjects) {
 
     Context context = new Context();
-    return compile(argv, context, null, javaFileObjects, Collections.<Processor>emptyList());
+    return run(argv, context, null, javaFileObjects, Collections.<Processor>emptyList());
   }
 
-  public Result compile(
+  public Result run(
       String[] argv,
       Context context,
       JavaFileManager fileManager,

--- a/core/src/test/java/com/google/errorprone/CompilationTestHelper.java
+++ b/core/src/test/java/com/google/errorprone/CompilationTestHelper.java
@@ -218,7 +218,7 @@ public class CompilationTestHelper {
   Result compile(Iterable<JavaFileObject> sources, String[] args) {
     checkWellFormed(sources, args);
     Context context = new Context();
-    return compiler.compile(args, context, fileManager, asJavacList(sources), null);
+    return compiler.run(args, context, fileManager, asJavacList(sources), null);
   }
 
   private void checkWellFormed(Iterable<JavaFileObject> sources, String[] args) {

--- a/core/src/test/java/com/google/errorprone/DogfoodErrorProne.java
+++ b/core/src/test/java/com/google/errorprone/DogfoodErrorProne.java
@@ -34,7 +34,7 @@ public class DogfoodErrorProne {
 
   private void compile() throws URISyntaxException {
     long start = System.currentTimeMillis();
-    new ErrorProneCompiler.Builder().build().compile(findSources());
+    ErrorProneCompiler.compile(findSources());
     System.out.printf("Finished compiling in %d millis\n", System.currentTimeMillis() - start);
   }
 

--- a/core/src/test/java/com/google/errorprone/ErrorProneTestCompiler.java
+++ b/core/src/test/java/com/google/errorprone/ErrorProneTestCompiler.java
@@ -95,6 +95,6 @@ public class ErrorProneTestCompiler {
     List<String> processedArgs =
         CompilationTestHelper.disableImplicitProcessing(Arrays.asList(args));
     String[] argsArray = processedArgs.toArray(new String[processedArgs.size()]);
-    return compiler.compile(argsArray, context, fileManager, asJavacList(sources), processors);
+    return compiler.run(argsArray, context, fileManager, asJavacList(sources), processors);
   }
 }

--- a/core/src/test/java/com/google/errorprone/matchers/DescendantOfTransitiveTest.java
+++ b/core/src/test/java/com/google/errorprone/matchers/DescendantOfTransitiveTest.java
@@ -76,7 +76,7 @@ public class DescendantOfTransitiveTest extends DescendantOfAbstractTest {
     ErrorProneCompiler compiler = new ErrorProneCompiler.Builder()
         .report(ScannerSupplier.fromScanner(scanner))
         .build();
-    Assert.assertThat(compiler.compile(args.toArray(new String[0])), is(Result.OK));
+    Assert.assertThat(compiler.run(args.toArray(new String[0])), is(Result.OK));
   }
 
   @Before


### PR DESCRIPTION
As this method would result in a collision with an instance method of the same signature, that method has been renamed to 'run'.

Closes #284.