### PR TITLE
Make ant work with javac8 and JDK7

### DIFF
--- a/ant/src/main/java/com/google/errorprone/ErrorProneAntCompilerAdapter.java
+++ b/ant/src/main/java/com/google/errorprone/ErrorProneAntCompilerAdapter.java
@@ -16,6 +16,8 @@
 
 package com.google.errorprone;
 
+import com.google.common.base.Function;
+import com.google.errorprone.internal.NonDelegatingClassLoaderRunner;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.taskdefs.compilers.DefaultCompilerAdapter;
 
@@ -24,9 +26,16 @@ import org.apache.tools.ant.taskdefs.compilers.DefaultCompilerAdapter;
  * @author alexeagle@google.com (Alex Eagle)
  */
 public class ErrorProneAntCompilerAdapter extends DefaultCompilerAdapter {
+  public static class AntRunner implements Function<String[], Boolean> {
+    @Override
+    public Boolean apply(String[] args) {
+      return ErrorProneCompiler.compile(args).isOK();
+    }
+  }
+
   @Override
   public boolean execute() throws BuildException {
     String[] args = setupModernJavacCommand().getArguments();
-    return ErrorProneCompiler.compile(args).isOK();
+    return NonDelegatingClassLoaderRunner.run(args, Boolean.class, AntRunner.class.getName());
   }
 }

--- a/core/src/main/java/com/google/errorprone/internal/NonDelegatingClassLoader.java
+++ b/core/src/main/java/com/google/errorprone/internal/NonDelegatingClassLoader.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.internal;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.net.URLClassLoader;
+import java.util.Set;
+
+/**
+ * A non-delegating {@link java.net.URLClassLoader} that searches its own
+ * resource path <i>before</i> the runtime classpath, reversing the usual
+ * classloader delegation model. This makes it possible to override runtime
+ * classes.
+ *
+ * <p>The classloader is also given the classloader from the environment it is
+ * created in, and a whitelist of classes that it should load from that
+ * environment. This list must include anything that crosses classloader
+ * boundaries (for example, the input or return types of the callback).
+ *
+ * @author cushon@google.com
+ */
+public class NonDelegatingClassLoader extends URLClassLoader {
+  private final ClassLoader original;
+  private final ImmutableSet<String> whiteList;
+
+  public static NonDelegatingClassLoader create(Set<String> whiteList) {
+    ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
+    if (!(contextLoader instanceof URLClassLoader)) {
+      throw new IllegalStateException("Expected a URLClassLoader!");
+    }
+    return new NonDelegatingClassLoader((URLClassLoader) contextLoader, whiteList);
+  }
+
+  public NonDelegatingClassLoader(URLClassLoader original, Set<String> whiteList) {
+    super(original.getURLs(), null);
+    this.original = original;
+    this.whiteList = ImmutableSet.copyOf(whiteList);
+  }
+
+  @Override
+  public Class<?> loadClass(String name, boolean complete) throws ClassNotFoundException {
+    if (whiteList.contains(name)) {
+      return original.loadClass(name);
+    }
+
+    try {
+      synchronized (getClassLoadingLock(name)) {
+        Class c = findLoadedClass(name);
+        if (c != null) {
+          return c;
+        }
+        return findClass(name);
+      }
+    } catch (ClassNotFoundException e) {
+      return super.loadClass(name, complete);
+    }
+  }
+}

--- a/core/src/main/java/com/google/errorprone/internal/NonDelegatingClassLoaderRunner.java
+++ b/core/src/main/java/com/google/errorprone/internal/NonDelegatingClassLoaderRunner.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.internal;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Executes a function inside a special classloader that searches its own resource path
+ * <i>before</i> delegating to the runtime classpath. This allows error-prone's javac8 to be run on
+ * JDK7, and is morally equivalent to invoking java with
+ * {@code -Xbootclasspath/p:<path to javac.jar>}.
+ *
+ * @author cushon@google.com
+ */
+public class NonDelegatingClassLoaderRunner {
+  public static <T, R> R run(T input, Class<R> outClass, String runnerClassName) {
+    ClassLoader loader =
+        NonDelegatingClassLoader.create(ImmutableSet.<String>of(Function.class.getName()));
+    try {
+      Class<?> runnerClass = Class.forName(runnerClassName, true, loader);
+      Function<T, R> runner = Function.class.cast(runnerClass.newInstance());
+      return runner.apply(input);
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError("Unable to create runner.", e);
+    }
+  }
+}


### PR DESCRIPTION
This generalizes some classloading infrastructure that could be shared
with maven.