### PR TITLE
Ant external adapter to launch error-prone in a separate process

### DIFF
--- a/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
+++ b/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
@@ -1,0 +1,113 @@
+package com.google.errorprone;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.taskdefs.compilers.DefaultCompilerAdapter;
+import org.apache.tools.ant.types.Commandline;
+import org.apache.tools.ant.types.Commandline.Argument;
+import org.apache.tools.ant.types.Path;
+import org.apache.tools.ant.types.Reference;
+import org.apache.tools.ant.util.JavaEnvUtils;
+import org.apache.tools.ant.util.LoaderUtils;
+
+/**
+ * Ant component to launch an external javac with error-prone enabled.
+ */
+public class ErrorProneExternalCompilerAdapter extends DefaultCompilerAdapter {
+  private Path classpath;
+  private boolean suggestFixes;
+  private String memoryStackSize;
+  private List<Argument> jvmArgs = new ArrayList<Argument>();
+
+  public void setClasspath(Path classpath) {
+    this.classpath = classpath;
+  }
+
+  public Path createClasspath() {
+    if (classpath == null) {
+      classpath = new Path(getProject());
+    }
+
+    return classpath.createPath();
+  }
+
+  public void setClasspathRef(Reference r) {
+    createClasspath().setRefid(r);
+  }
+
+  public void setSuggestFixes(boolean suggestFixes) {
+    this.suggestFixes = suggestFixes;
+  }
+
+  public void setMemoryStackSize(String memoryStackSize) {
+    this.memoryStackSize = memoryStackSize;
+  }
+
+  public Argument createJvmArg() {
+    Argument arg = new Argument();
+    jvmArgs.add(arg);
+    return arg;
+  }
+
+  @Override
+  public boolean execute() throws BuildException {
+    if (getJavac().isForkedJavac()) {
+      attributes.log("Using external error-prone compiler", Project.MSG_VERBOSE);
+      Commandline cmd = new Commandline();
+      cmd.setExecutable(JavaEnvUtils.getJdkExecutable("java"));
+      if (memoryStackSize != null) {
+        cmd.createArgument().setValue("-Xss" + memoryStackSize);
+      }
+      String memoryParameterPrefix = "-X";
+      if (memoryInitialSize != null) {
+        cmd.createArgument().setValue(memoryParameterPrefix + "ms" + this.memoryInitialSize);
+        // Prevent setupModernJavacCommandlineSwitches() from doing it also
+        memoryInitialSize = null;
+      }
+      if (memoryMaximumSize != null) {
+        cmd.createArgument().setValue(memoryParameterPrefix + "mx" + this.memoryMaximumSize);
+        // Prevent setupModernJavacCommandlineSwitches() from doing it also
+        memoryMaximumSize = null;
+      }
+      for (Argument arg : jvmArgs) {
+        for (String part : arg.getParts()) {
+          cmd.createArgument().setValue(part);
+        }
+      }
+
+      cmd.createArgument().setValue("-classpath");
+      if (classpath == null) {
+        classpath = new Path(getProject());
+      }
+      // Usually redundant, but check two resources in case Ant stuff is in a different jar
+      addResourceSource(classpath, "com/google/errorprone/ErrorProneExternalCompilerAdapter.class");
+      addResourceSource(classpath, "com/google/errorprone/ErrorProneCompiler.class");
+      addResourceSource(classpath, "com/sun/tools/javac/Main.class");
+      cmd.createArgument().setPath(classpath);
+      cmd.createArgument().setValue(ErrorProneCompiler.class.getName());
+      if (suggestFixes) {
+        cmd.createArgument().setValue("-Xjcov");
+      }
+      setupModernJavacCommandlineSwitches(cmd);
+      logAndAddFilesToCompile(cmd);
+      return executeExternalCompile(cmd.getCommandline(), cmd.size(), true) == 0;
+    } else {
+      attributes.log("You must set fork=\"yes\" to use the external error-prone compiler", Project.MSG_ERR);
+      return false;
+    }
+  }
+
+  private void addResourceSource(Path classpath, String resource) {
+    final File f = LoaderUtils.getResourceSource(ErrorProneExternalCompilerAdapter.class.getClassLoader(), resource);
+    if (f != null) {
+      attributes.log("Found " + f.getAbsolutePath(), Project.MSG_DEBUG);
+      classpath.createPath().setLocation(f);
+    } else {
+      attributes.log("Couldn't find " + resource, Project.MSG_DEBUG);
+    }
+  }
+}

--- a/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
+++ b/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.errorprone;
 
 import java.io.File;
@@ -19,7 +35,6 @@ import org.apache.tools.ant.util.LoaderUtils;
  */
 public class ErrorProneExternalCompilerAdapter extends DefaultCompilerAdapter {
   private Path classpath;
-  private boolean suggestFixes;
   private String memoryStackSize;
   private List<Argument> jvmArgs = new ArrayList<Argument>();
 
@@ -37,10 +52,6 @@ public class ErrorProneExternalCompilerAdapter extends DefaultCompilerAdapter {
 
   public void setClasspathRef(Reference r) {
     createClasspath().setRefid(r);
-  }
-
-  public void setSuggestFixes(boolean suggestFixes) {
-    this.suggestFixes = suggestFixes;
   }
 
   public void setMemoryStackSize(String memoryStackSize) {
@@ -89,9 +100,6 @@ public class ErrorProneExternalCompilerAdapter extends DefaultCompilerAdapter {
       addResourceSource(classpath, "com/sun/tools/javac/Main.class");
       cmd.createArgument().setPath(classpath);
       cmd.createArgument().setValue(ErrorProneCompiler.class.getName());
-      if (suggestFixes) {
-        cmd.createArgument().setValue("-Xjcov");
-      }
       setupModernJavacCommandlineSwitches(cmd);
       logAndAddFilesToCompile(cmd);
       return executeExternalCompile(cmd.getCommandline(), cmd.size(), true) == 0;

--- a/examples/ant/build.xml
+++ b/examples/ant/build.xml
@@ -15,10 +15,22 @@
   -->
 <project name="error prone example" default="compile">
   <target name="compile">
+    <delete dir="build"/>
     <mkdir dir="build"/>
-    <!--NOTE: error_prone_ant.jar must be installed in ANT_HOME/lib -->
+    <!-- For external compiles (fork="yes") you can do it this way -->
+    <componentdef name="errorprone" classname="com.google.errorprone.ErrorProneExternalCompilerAdapter"
+                  classpath="../../ant/target/error_prone_ant-1.1.3-SNAPSHOT.jar"/>
+    <javac srcdir="src" destdir="build" fork="yes" includeantruntime="no">
+      <errorprone suggestfixes="yes"/>
+    </javac>
+  </target>
+  <target name="compile.internal">
+    <delete dir="build"/>
+    <mkdir dir="build"/>
+    <!--NOTE: error_prone_ant.jar must be installed in ANT_HOME/lib for the internal compiler -->
     <javac srcdir="src" destdir="build" includeantruntime="false"
            compiler="com.google.errorprone.ErrorProneAntCompilerAdapter">
+      <compilerarg value="-Xjcov"/> <!-- for suggested fixes, increases compiler memory requirements -->
     </javac>
   </target>
 </project>

--- a/examples/ant/build.xml
+++ b/examples/ant/build.xml
@@ -19,9 +19,9 @@
     <mkdir dir="build"/>
     <!-- For external compiles (fork="yes") you can do it this way -->
     <componentdef name="errorprone" classname="com.google.errorprone.ErrorProneExternalCompilerAdapter"
-                  classpath="../../ant/target/error_prone_ant-1.1.3-SNAPSHOT.jar"/>
+                  classpath="../../ant/target/error_prone_ant-2.0.2-SNAPSHOT.jar"/>
     <javac srcdir="src" destdir="build" fork="yes" includeantruntime="no">
-      <errorprone suggestfixes="yes"/>
+      <errorprone/>
     </javac>
   </target>
   <target name="compile.internal">
@@ -30,7 +30,6 @@
     <!--NOTE: error_prone_ant.jar must be installed in ANT_HOME/lib for the internal compiler -->
     <javac srcdir="src" destdir="build" includeantruntime="false"
            compiler="com.google.errorprone.ErrorProneAntCompilerAdapter">
-      <compilerarg value="-Xjcov"/> <!-- for suggested fixes, increases compiler memory requirements -->
     </javac>
   </target>
 </project>


### PR DESCRIPTION
This adds an Ant compiler adapter that can work in forked mode. Should be the same as pull request 270 but without the messed up rebase.