### PR TITLE
Use hamcrest 1.3's TypeSafeDiagnosingMatcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 **/.gitignore
 *.iml
 .java-version
+.idea

--- a/core/src/test/java/com/google/errorprone/ErrorProneCompilerIntegrationTest.java
+++ b/core/src/test/java/com/google/errorprone/ErrorProneCompilerIntegrationTest.java
@@ -104,7 +104,7 @@ public class ErrorProneCompilerIntegrationTest {
         "bugpatterns/BadShiftAmountPositiveCases.java"));
     assertThat(outputStream.toString(), exitCode, is(Result.ERROR));
 
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher = hasItem(
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher = hasItem(
         diagnosticMessage(containsString("[BadShiftAmount]")));
     assertTrue("Error should be found. " + diagnosticHelper.describe(),
         matcher.matches(diagnosticHelper.getDiagnostics()));
@@ -118,7 +118,7 @@ public class ErrorProneCompilerIntegrationTest {
         "bugpatterns/NonAtomicVolatileUpdatePositiveCases.java"));
     assertThat(outputStream.toString(), exitCode, is(Result.OK));
 
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher = hasItem(
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher = hasItem(
         diagnosticMessage(containsString("[NonAtomicVolatileUpdate]")));
     assertTrue("Warning should be found. " + diagnosticHelper.describe(),
         matcher.matches(diagnosticHelper.getDiagnostics()));
@@ -150,7 +150,7 @@ public class ErrorProneCompilerIntegrationTest {
         compiler.fileManager().sources(getClass(), "MultipleTopLevelClassesWithErrors.java",
             "ExtendedMultipleTopLevelClassesWithErrors.java"));
     assertThat(outputStream.toString(), exitCode, is(Result.ERROR));
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher = hasItem(
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher = hasItem(
         diagnosticMessage(containsString("[SelfAssignment]")));
     assertTrue("Warning should be found. " + diagnosticHelper.describe(),
         matcher.matches(diagnosticHelper.getDiagnostics()));
@@ -174,7 +174,7 @@ public class ErrorProneCompilerIntegrationTest {
         compiler.fileManager().sources(getClass(), "MultipleTopLevelClassesWithErrors.java",
             "ExtendedMultipleTopLevelClassesWithErrors.java"));
     assertThat(outputStream.toString(), exitCode, is(Result.ERROR));
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher = hasItem(
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher = hasItem(
         diagnosticMessage(CoreMatchers.<String>allOf(
             containsString("IllegalStateException: test123"),
             containsString("unhandled exception was thrown by the Error Prone"))));
@@ -263,7 +263,7 @@ public class ErrorProneCompilerIntegrationTest {
     Result exitCode = compiler.compile(
         Arrays.asList(compiler.fileManager().forSourceLines("Test.java", "public class Test {}")));
 
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher = not(hasItem(
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher = not(hasItem(
         diagnosticMessage(containsString("[ConstructorMatcher]"))));
     assertTrue(
         "Warning should be found. " + diagnosticHelper.describe(),
@@ -304,7 +304,7 @@ public class ErrorProneCompilerIntegrationTest {
             "  public Test() {}",
             "}")));
 
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher = not(hasItem(
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher = not(hasItem(
         diagnosticMessage(containsString("[SuperCallMatcher]"))));
     assertTrue(
         "Warning should be found. " + diagnosticHelper.describe(),
@@ -345,7 +345,7 @@ public class ErrorProneCompilerIntegrationTest {
         Arrays.asList(compiler.fileManager().forSourceLines("Test.java", testFile)));
     outputStream.flush();
 
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher = hasItem(
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher = hasItem(
         diagnosticMessage(containsString("[EmptyIf]")));
     assertTrue(
         "Error should be found. " + diagnosticHelper.describe(),
@@ -364,7 +364,7 @@ public class ErrorProneCompilerIntegrationTest {
     Result exitCode = compiler.compile(args,
         Arrays.asList(compiler.fileManager().forSourceLines("Test.java", testFile)));
     outputStream.flush();
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher = hasItem(
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher = hasItem(
         diagnosticMessage(containsString("[LongLiteralLowerCaseSuffix]")));
     assertThat(outputStream.toString(), exitCode, is(Result.OK));
     assertTrue(
@@ -390,7 +390,7 @@ public class ErrorProneCompilerIntegrationTest {
     Result exitCode = compiler.compile(args,
         Arrays.asList(compiler.fileManager().forSourceLines("Test.java", testFile)));
     outputStream.flush();
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher = hasItem(
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher = hasItem(
         diagnosticMessage(containsString("[EmptyIf]")));
     assertThat(outputStream.toString(), exitCode, is(Result.ERROR));
     assertTrue(

--- a/core/src/test/java/com/google/errorprone/ErrorProneJavaCompilerTest.java
+++ b/core/src/test/java/com/google/errorprone/ErrorProneJavaCompilerTest.java
@@ -131,7 +131,7 @@ public class ErrorProneJavaCompilerTest {
         Collections.<String>emptyList(),
         Collections.<Class<? extends BugChecker>>emptyList());
     assertThat(result.succeeded).isFalse();
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher =
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher =
         hasItem(diagnosticMessage(containsString("[DepAnn]")));
     assertTrue(matcher.matches(result.diagnosticHelper.getDiagnostics()));
   }
@@ -162,7 +162,7 @@ public class ErrorProneJavaCompilerTest {
         Collections.<Class<? extends BugChecker>>emptyList());
     assertThat(result.succeeded).isTrue();
     assertThat(result.diagnosticHelper.getDiagnostics().size()).isGreaterThan(0);
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher =
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher =
         hasItem(diagnosticMessage(containsString("[WaitNotInLoop]")));
     assertTrue(matcher.matches(result.diagnosticHelper.getDiagnostics()));
 
@@ -185,7 +185,7 @@ public class ErrorProneJavaCompilerTest {
         Collections.<Class<? extends BugChecker>>emptyList());
     assertThat(result.succeeded).isFalse();
     assertThat(result.diagnosticHelper.getDiagnostics().size()).isGreaterThan(0);
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher =
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher =
         hasItem(diagnosticMessage(containsString("[DepAnn]")));
     assertTrue(matcher.matches(result.diagnosticHelper.getDiagnostics()));
 
@@ -216,7 +216,7 @@ public class ErrorProneJavaCompilerTest {
         Collections.<Class<? extends BugChecker>>emptyList());
     assertThat(result.succeeded).isFalse();
     assertThat(result.diagnosticHelper.getDiagnostics().size()).isGreaterThan(0);
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher =
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher =
         hasItem(diagnosticMessage(containsString("[EmptyIf]")));
     assertTrue(matcher.matches(result.diagnosticHelper.getDiagnostics()));
   }
@@ -264,7 +264,7 @@ public class ErrorProneJavaCompilerTest {
         Arrays.<Class<? extends BugChecker>>asList(BadShiftAmount.class));
     assertThat(result.succeeded).isFalse();
     assertThat(result.diagnosticHelper.getDiagnostics().size()).isGreaterThan(0);
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher =
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher =
         hasItem(diagnosticMessage(containsString("[BadShiftAmount]")));
     assertTrue(matcher.matches(result.diagnosticHelper.getDiagnostics()));
   }
@@ -304,7 +304,7 @@ public class ErrorProneJavaCompilerTest {
         sources);
     boolean succeeded = task.call();
     assertThat(succeeded).isTrue();
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher =
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher =
         hasItem(diagnosticMessage(containsString("[ChainingConstructorIgnoresParameter]")));
     assertTrue(matcher.matches(diagnosticHelper.getDiagnostics()));
 
@@ -352,7 +352,7 @@ public class ErrorProneJavaCompilerTest {
         sources);
     boolean succeeded = task.call();
     assertThat(succeeded).isFalse();
-    Matcher<? super Iterable<Diagnostic<JavaFileObject>>> matcher =
+    Matcher<? super Iterable<Diagnostic<? extends JavaFileObject>>> matcher =
         hasItem(diagnosticMessage(containsString("[EmptyIf]")));
     assertTrue(matcher.matches(diagnosticHelper.getDiagnostics()));
 


### PR DESCRIPTION
We don't need to preserve compatibility with 1.1 any more.

This backs out a change I made in
ef2223477951f70bfb1395f356a60bee68a9625c.