### PR TITLE
minor travis-ci improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ notifications:
       - https://webhooks.gitter.im/e/74d33a22fbfb1942920e
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
-    on_start: false     # default: false
 
 # Store encrypted credentials for gh-pages and sonatype:
 # travis encrypt -r google/error-prone GH_TOKEN=<github access token>

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ jdk:
 # use travis-ci docker based infrastructure
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.m2
+
 notifications:
   #email: error-prone-team@google.com
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ jdk:
   - oraclejdk7
   - oraclejdk8
 
+# use travis-ci docker based infrastructure
+sudo: false
+
 notifications:
   #email: error-prone-team@google.com
   webhooks:


### PR DESCRIPTION
Moving the travis-ci build to their new docker container based infrastructure should be slightly faster and allows caching (maven) in public repos.