### PR TITLE
Update Gradle example to use latest plugin release

### DIFF
--- a/examples/gradle/build.gradle
+++ b/examples/gradle/build.gradle
@@ -1,17 +1,21 @@
-apply plugin: 'java'
-
 // See https://github.com/tbroyer/gradle-errorprone-plugin
-apply plugin: 'errorprone'
+buildscript {
+  repositories {
+    maven {
+      url "https://plugins.gradle.org/m2/"
+    }
+  }
+  dependencies {
+    classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.7.1'
+  }
+}
+
+apply plugin: 'java'
+apply plugin: 'net.ltgt.errorprone'
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:latest.release'
-    }
+configurations.errorprone {
+  resolutionStrategy.force 'com.google.errorprone:error_prone_core:2.0.3'
 }
-


### PR DESCRIPTION
Uses fixed versions as `latest.release` no longer works with the Gradle Plugin Portal.
Also uses a fixed version for EP as a “best practice” to make the build reproducible.

Note: changes tested locally, but it was just simpler doing the edit through GitHub.