### PR TITLE
Ant forked compile fixes

### DIFF
--- a/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
+++ b/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
@@ -101,8 +101,9 @@ public class ErrorProneExternalCompilerAdapter extends DefaultCompilerAdapter {
       cmd.createArgument().setPath(classpath);
       cmd.createArgument().setValue(ErrorProneCompiler.class.getName());
       setupModernJavacCommandlineSwitches(cmd);
+      int firstFile = cmd.size();
       logAndAddFilesToCompile(cmd);
-      return executeExternalCompile(cmd.getCommandline(), cmd.size(), true) == 0;
+      return executeExternalCompile(cmd.getCommandline(), firstFile, true) == 0;
     } else {
       attributes.log("You must set fork=\"yes\" to use the external error-prone compiler",
           Project.MSG_ERR);

--- a/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
+++ b/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
@@ -67,7 +67,7 @@ public class ErrorProneExternalCompilerAdapter extends DefaultCompilerAdapter {
   @Override
   public boolean execute() throws BuildException {
     if (getJavac().isForkedJavac()) {
-      attributes.log("Using external error-prone compiler", Project.MSG_VERBOSE);
+      attributes.log("Using external Error Prone compiler", Project.MSG_VERBOSE);
       Commandline cmd = new Commandline();
       cmd.setExecutable(JavaEnvUtils.getJdkExecutable("java"));
       if (memoryStackSize != null) {
@@ -90,21 +90,22 @@ public class ErrorProneExternalCompilerAdapter extends DefaultCompilerAdapter {
         }
       }
 
-      cmd.createArgument().setValue("-classpath");
-      if (classpath == null) {
-        classpath = new Path(getProject());
+      Path bootclasspath = new Path(getProject());
+      addResourceSource(bootclasspath, "com/google/errorprone/ErrorProneExternalCompilerAdapter.class");
+      cmd.createArgument().setValue("-Xbootclasspath/p:" + bootclasspath);
+
+      if (classpath != null) {
+        cmd.createArgument().setValue("-classpath");
+        cmd.createArgument().setPath(classpath);
       }
-      // Usually redundant, but check two resources in case Ant stuff is in a different jar
-      addResourceSource(classpath, "com/google/errorprone/ErrorProneExternalCompilerAdapter.class");
-      addResourceSource(classpath, "com/google/errorprone/ErrorProneCompiler.class");
-      cmd.createArgument().setPath(classpath);
+
       cmd.createArgument().setValue(ErrorProneCompiler.class.getName());
       setupModernJavacCommandlineSwitches(cmd);
       int firstFile = cmd.size();
       logAndAddFilesToCompile(cmd);
       return executeExternalCompile(cmd.getCommandline(), firstFile, true) == 0;
     } else {
-      attributes.log("You must set fork=\"yes\" to use the external error-prone compiler",
+      attributes.log("You must set fork=\"yes\" to use the external Error Prone compiler",
           Project.MSG_ERR);
       return false;
     }

--- a/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
+++ b/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
@@ -97,7 +97,6 @@ public class ErrorProneExternalCompilerAdapter extends DefaultCompilerAdapter {
       // Usually redundant, but check two resources in case Ant stuff is in a different jar
       addResourceSource(classpath, "com/google/errorprone/ErrorProneExternalCompilerAdapter.class");
       addResourceSource(classpath, "com/google/errorprone/ErrorProneCompiler.class");
-      addResourceSource(classpath, "com/sun/tools/javac/Main.class");
       cmd.createArgument().setPath(classpath);
       cmd.createArgument().setValue(ErrorProneCompiler.class.getName());
       setupModernJavacCommandlineSwitches(cmd);

--- a/core/src/main/java/com/google/errorprone/ErrorProneCompiler.java
+++ b/core/src/main/java/com/google/errorprone/ErrorProneCompiler.java
@@ -19,7 +19,10 @@ package com.google.errorprone;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.StandardSystemProperty.JAVA_SPECIFICATION_VERSION;
 
+import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.internal.NonDelegatingClassLoader;
 import com.google.errorprone.scanner.BuiltInCheckerSuppliers;
 import com.google.errorprone.scanner.Scanner;
 import com.google.errorprone.scanner.ScannerSupplier;
@@ -36,6 +39,8 @@ import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.JavacMessages;
 
 import java.io.PrintWriter;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -52,6 +57,12 @@ import javax.tools.JavaFileObject;
  * @author alexeagle@google.com (Alex Eagle)
  */
 public class ErrorProneCompiler {
+  public static class AntRunner implements Function<String[], Integer> {
+    @Override
+    public Integer apply(String[] args) {
+      return ErrorProneCompiler.compile(args).exitCode;
+    }
+  }
 
   /**
    * Entry point for compiling Java code with error-prone enabled.
@@ -60,7 +71,25 @@ public class ErrorProneCompiler {
    * @param args the same args which could be passed to javac on the command line
    */
   public static void main(String[] args) {
-    System.exit(compile(args).exitCode);
+    ClassLoader originalLoader = ErrorProneCompiler.class.getClassLoader();
+    if (originalLoader instanceof URLClassLoader) {
+      URL[] urls = ((URLClassLoader) originalLoader).getURLs();
+      ClassLoader loader = NonDelegatingClassLoader.create(
+          ImmutableSet.of(Function.class.getName()), urls, originalLoader);
+
+      try {
+        Class<?> runnerClass = Class.forName(AntRunner.class.getName(), true, loader);
+        @SuppressWarnings("unchecked")
+        Function<String[], Integer> runner = (Function<String[], Integer>) runnerClass.newInstance();
+        Integer exitCode = runner.apply(args);
+        System.exit(exitCode == null ? -1 : exitCode);
+      } catch (ReflectiveOperationException e) {
+        throw new LinkageError("Unable to create runner.", e);
+      }
+    } else {
+      System.err.println("Unexpected ClassLoader: " + originalLoader.getClass());
+      System.exit(1);
+    }
   }
 
   /**

--- a/examples/ant/ant_fork/build.xml
+++ b/examples/ant/ant_fork/build.xml
@@ -19,7 +19,7 @@
     <mkdir dir="build"/>
     <!-- external compile (fork="yes") -->
     <componentdef name="errorprone" classname="com.google.errorprone.ErrorProneExternalCompilerAdapter"
-      classpath="../../../ant/target/error_prone_ant-2.0.2-SNAPSHOT.jar"/>
+      classpath="../../../ant/target/error_prone_ant-2.0.5-SNAPSHOT.jar"/>
     <javac srcdir="src" destdir="build" fork="yes" includeantruntime="no">
       <errorprone/>
     </javac>


### PR DESCRIPTION
Fix a few issues with the ant_fork example. This improves matters, but it still isn't working for me on Java 7u79 because of:

java.lang.NoSuchFieldError: NATIVE_HEADER_OUTPUT

Looks to be similar to #287, so I tried copying some of the NonDelegatingClassLoader stuff from the other adapter into ErrorProneCompiler, but didn't have much luck.