### PR TITLE
Add javac.jar to bootclasspath for ant forked.

### DIFF
--- a/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
+++ b/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
@@ -67,7 +67,7 @@ public class ErrorProneExternalCompilerAdapter extends DefaultCompilerAdapter {
   @Override
   public boolean execute() throws BuildException {
     if (getJavac().isForkedJavac()) {
-      attributes.log("Using external error-prone compiler", Project.MSG_VERBOSE);
+      attributes.log("Using external Error Prone compiler", Project.MSG_VERBOSE);
       Commandline cmd = new Commandline();
       cmd.setExecutable(JavaEnvUtils.getJdkExecutable("java"));
       if (memoryStackSize != null) {
@@ -90,6 +90,18 @@ public class ErrorProneExternalCompilerAdapter extends DefaultCompilerAdapter {
         }
       }
 
+      // Put javac.jar on bootclasspath to avoid version skew between Error Prone's javac and the
+      // system javac.
+      String javacJar = getJavac().getExecutable();
+      if (javacJar == null) {
+        attributes.log(
+            "You must set the executable attribute of the javac task to the path to the Error "
+                + "Prone javac jar to use the external Error Prone compiler",
+            Project.MSG_ERR);
+        return false;
+      }
+      cmd.createArgument().setValue("-Xbootclasspath/p:" + javacJar);
+
       cmd.createArgument().setValue("-classpath");
       if (classpath == null) {
         classpath = new Path(getProject());
@@ -104,7 +116,7 @@ public class ErrorProneExternalCompilerAdapter extends DefaultCompilerAdapter {
       logAndAddFilesToCompile(cmd);
       return executeExternalCompile(cmd.getCommandline(), cmd.size(), true) == 0;
     } else {
-      attributes.log("You must set fork=\"yes\" to use the external error-prone compiler",
+      attributes.log("You must set fork=\"yes\" to use the external Error Prone compiler",
           Project.MSG_ERR);
       return false;
     }

--- a/examples/ant/ant_fork/README
+++ b/examples/ant/ant_fork/README
@@ -1,0 +1,11 @@
+This example runs the version of the ant integration that forks Error Prone
+into a different process.  To run:
+
+1) Go into the error-prone/ant directory and run "mvn package" to build the
+   error_prone_ant snapshot jar.
+
+2) Download the latest verson of our javac jar from Maven Central into this 
+   directory.  The latest version is available under:
+   https://repo1.maven.org/maven2/com/google/errorprone/javac/
+
+Now you should be able to build by typing "ant" at the prompt.

--- a/examples/ant/ant_fork/build.xml
+++ b/examples/ant/ant_fork/build.xml
@@ -19,8 +19,8 @@
     <mkdir dir="build"/>
     <!-- external compile (fork="yes") -->
     <componentdef name="errorprone" classname="com.google.errorprone.ErrorProneExternalCompilerAdapter"
-      classpath="../../../ant/target/error_prone_ant-2.0.2-SNAPSHOT.jar"/>
-    <javac srcdir="src" destdir="build" fork="yes" includeantruntime="no">
+      classpath="../../../ant/target/error_prone_ant-2.0.5-SNAPSHOT.jar"/>
+    <javac srcdir="src" destdir="build" fork="yes" executable="javac-1.9.0-dev-r2644-2.jar" includeantruntime="no">
       <errorprone/>
     </javac>
   </target>


### PR DESCRIPTION
This fixes the "java.lang.NoSuchFieldError: NATIVE_HEADER_OUTPUT" error that
people were seeing when running on JDK7.