### PR TITLE
Turn down travis JDK7 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 
 jdk:
-  - oraclejdk7
   - oraclejdk8
 
 # use travis-ci docker based infrastructure


### PR DESCRIPTION
We only support JDK8 as of 884eec772c13541a7b1af249a68373cd9f30e488.