### PR TITLE
Re-enable publishing snapshots and documentation

### DIFF
--- a/util/generate-latest-docs.sh
+++ b/util/generate-latest-docs.sh
@@ -1,7 +1,7 @@
 # https://github.com/google/dagger/blob/master/util/generate-latest-docs.sh
 
 if [ "$TRAVIS_REPO_SLUG" == "google/error-prone" ] && \
-   [ "$TRAVIS_JDK_VERSION" == "oraclejdk7" ] && \
+   [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ] && \
    [ "$TRAVIS_PULL_REQUEST" == "false" ] && \
    [ "$TRAVIS_BRANCH" == "master" ]; then
   echo -e "Publishing docs...\n"

--- a/util/publish-snapshot-on-commit.sh
+++ b/util/publish-snapshot-on-commit.sh
@@ -1,7 +1,7 @@
 # https://github.com/google/dagger/blob/master/util/publish-snapshot-on-commit.sh
 
 if [ "$TRAVIS_REPO_SLUG" == "google/error-prone" ] && \
-   [ "$TRAVIS_JDK_VERSION" == "oraclejdk7" ] && \
+   [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ] && \
    [ "$TRAVIS_PULL_REQUEST" == "false" ] && \
    [ "$TRAVIS_BRANCH" == "master" ]; then
   echo -e "Publishing maven snapshot...\n"


### PR DESCRIPTION
These were only enabled for jdk7 builds, so they haven't been running
since 425b9c167800332da711299e7a7ca8211f728889.