### PR TITLE
Fix source and target values in Maven example pom.xml

### DIFF
--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -34,8 +34,8 @@
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
           <!-- maven-compiler-plugin defaults to targeting Java 5, but our
                javac only supports >=6 -->
-          <source>7</source>
-          <target>7</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
         <dependencies>
           <dependency>


### PR DESCRIPTION
The source and target versions are set as `7`, which is not recognized.

As a result, no source level is set. Generating the Eclipse project with:

  mvn eclipse:eclipse

and writing code like:

  List<String> myList = new ArrayList<>();

results in the errors:

  '<>' operator is not allowed for source level below 1.7
  Incorrect number of arguments for type ArrayList<E>; it cannot be parameterized with arguments <>
  Syntax error, parameterized types are only available if source level is 1.5 or greater

Change the values to `1.7`.

Change-Id: I476555d28e6e8da477f8f46a3403d248219cf3ec