### PR TITLE
Support suppressions on MockitoCast detector

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/MockitoCastTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MockitoCastTest.java
@@ -290,4 +290,38 @@ public class MockitoCastTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void supportsClassLevelSuppression() throws Exception {
+    compilationHelper
+        .addSourceLines("Box.java", "public class Box<T> {", "  T f() { return null; }", "}")
+        .addSourceLines(
+            "Test.java",
+            "import org.mockito.Mockito;",
+            "@SuppressWarnings(\"MockitoCast\")",
+            "class Test {",
+            "  Box<Boolean> box = Mockito.mock(Box.class, Mockito.RETURNS_SMART_NULLS);",
+            "  void m() {",
+            "    Mockito.when(box.f()).thenReturn(false);",
+            "  }",
+            "}")
+        .doTest();
+  }
+  
+  @Test
+  public void supportsMethodLevelSuppression() throws Exception {
+    compilationHelper
+        .addSourceLines("Box.java", "public class Box<T> {", "  T f() { return null; }", "}")
+        .addSourceLines(
+            "Test.java",
+            "import org.mockito.Mockito;",
+            "class Test {",
+            "  Box<Boolean> box = Mockito.mock(Box.class, Mockito.RETURNS_SMART_NULLS);",
+            "  @SuppressWarnings(\"MockitoCast\")",
+            "  void m() {",
+            "    Mockito.when(box.f()).thenReturn(false);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
MockitoCast detector is currently unsuppressable, because it's a compilation unit matcher and the viable attachment points for suppression (class/method level) are children of a compilation unit. I've added two unit tests which demonstrate the issue.

As far as I can see there's no need to it to be a compilation unit matcher: on the contrary, we're looking specifically for invocations of a specific method, and we have access to all the state we need. Trivial modifications to make it a MethodInvocationTreeMatcher give us a detector which passes all the existing unit tests and also the additional unit tests.