### PR TITLE
Support suppressions on MockitoCast detector

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/MockitoCastTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MockitoCastTest.java
@@ -290,4 +290,38 @@ public class MockitoCastTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void supportsClassLevelSuppression() throws Exception {
+    compilationHelper
+        .addSourceLines("Box.java", "public class Box<T> {", "  T f() { return null; }", "}")
+        .addSourceLines(
+            "Test.java",
+            "import org.mockito.Mockito;",
+            "@SuppressWarnings(\"MockitoCast\")",
+            "class Test {",
+            "  Box<Boolean> box = Mockito.mock(Box.class, Mockito.RETURNS_SMART_NULLS);",
+            "  void m() {",
+            "    Mockito.when(box.f()).thenReturn(false);",
+            "  }",
+            "}")
+        .doTest();
+  }
+  
+  @Test
+  public void supportsMethodLevelSuppression() throws Exception {
+    compilationHelper
+        .addSourceLines("Box.java", "public class Box<T> {", "  T f() { return null; }", "}")
+        .addSourceLines(
+            "Test.java",
+            "import org.mockito.Mockito;",
+            "class Test {",
+            "  Box<Boolean> box = Mockito.mock(Box.class, Mockito.RETURNS_SMART_NULLS);",
+            "  @SuppressWarnings(\"MockitoCast\")",
+            "  void m() {",
+            "    Mockito.when(box.f()).thenReturn(false);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
The MockitoCast detector can't be suppressed: it's a compilation unit matcher, which means we haven't visited the code which could suppress the detector before we start analysing it. See the added unit tests to demonstrate the problem.

This is easily rectified by making it a MethodInvocationTreeMatcher and putting all the logic in matchInvocation(). I can't see any reason why it needs to act at the compilation unit level (and nor can its unit tests - they all continue to pass with this change).
