### PR TITLE
Unshade dependencies in error_prone_core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -283,6 +283,8 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>with-dependencies</shadedClassifierName>
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <artifactSet>
                 <!-- Include only dependencies with compatible licenses.

--- a/refaster/pom.xml
+++ b/refaster/pom.xml
@@ -33,6 +33,7 @@
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_core</artifactId>
             <version>${project.version}</version>
+            <classifier>with-dependencies</classifier>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -60,7 +61,7 @@
                                 <!-- Include only dependencies with compatible licenses.
                                      Apache, BSD, and MIT are OK; others are not. -->
                                 <includes>
-                                    <include>com.google.errorprone:error_prone_core</include>
+                                    <include>com.google.errorprone:error_prone_core:with-dependencies</include>
                                 </includes>
                             </artifactSet>
                             <transformers>


### PR DESCRIPTION
error_prone_core had some dependencies shaded that caused problems
with build-system integrations. Moreover, they were still referenced
them in its POM, leading to unnecessary duplications in the classpath.

This commit changes the default error_prone_core artifact to no
longer use shaded dependencies, and moves the shaded artifact to
an additional JAR with 'with-dependencies' classifier. This JAR
is needed to keep the error_prone_refaster JAR identical.

An alternative would be to move the list of the dependencies we want to shade from `core` to `refaster`; that means splitting the information into 2 files, and the shade configuration would have to be duplicated somehow if a new module is added that needs the same shading as `refaster` (that being said, I'm not familiar with Refaster and maybe the shading isn't even necessary/useful)

Fixes #501
Updates #482