### PR TITLE
Fix active navigation tab on index and logo link.

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -7,7 +7,7 @@
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>
     </button>
-    <a class="navbar-brand" href="{{ site.baseurl }}">Error Prone</a>
+    <a class="navbar-brand" href="/index">Error Prone</a>
   </div>
 
   <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">

--- a/_layouts/master.html
+++ b/_layouts/master.html
@@ -2,7 +2,7 @@
 <html>
   {% include header.html %}
   <body>
-    {% include nav.html active="bugpatterns" %}
+    {% include nav.html %}
     <div class="container">
       {{ content }}
     </div>

--- a/bugpatterns.md
+++ b/bugpatterns.md
@@ -1,6 +1,6 @@
 ---
 title: Bug Patterns
-layout: master
+layout: bugpatterns
 ---
 
 


### PR DESCRIPTION
Before on `index.html`, note the activated tab:

![screen shot 2017-02-16 at 6 50 13 pm](https://cloud.githubusercontent.com/assets/66577/23046686/07390c80-f479-11e6-9269-f563c0692c45.png)

After:

![screen shot 2017-02-16 at 6 50 36 pm](https://cloud.githubusercontent.com/assets/66577/23046691/0fbe0afe-f479-11e6-9b34-8937d3dcc3ad.png)

----

Before on any page, note the link preview at the bottom while hovered on the logo:

![screen shot 2017-02-16 at 6 50 26 pm](https://cloud.githubusercontent.com/assets/66577/23046707/31bc6948-f479-11e6-9106-325e28b1cf80.png)

After:

![screen shot 2017-02-16 at 6 50 42 pm](https://cloud.githubusercontent.com/assets/66577/23046708/3719028e-f479-11e6-998e-1655b9d45325.png)
