### PR TITLE
Update pattern index to use correct template.

### DIFF
--- a/docgen/src/main/java/com/google/errorprone/BugPatternIndexWriter.java
+++ b/docgen/src/main/java/com/google/errorprone/BugPatternIndexWriter.java
@@ -104,7 +104,7 @@ public class BugPatternIndexWriter {
       Map<String, String> frontmatterData =
           ImmutableMap.<String, String>builder()
               .put("title", "Bug Patterns")
-              .put("layout", "master")
+              .put("layout", "bugpatterns")
               .build();
       DumperOptions options = new DumperOptions();
       options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);


### PR DESCRIPTION
`master` doesn't select the "Bug Patterns" tab whereas `bugpatterns` does.