### PR TITLE
Fix for #497: support deletion of last line of file

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/AppliedFix.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/AppliedFix.java
@@ -93,10 +93,16 @@ public class AppliedFix {
           lineNumberReader.readLine();
         }
         // TODO: this is over-simplified; need a failing test case
-        snippet = lineNumberReader.readLine().trim();
-        // snip comment from line
-        if (snippet.contains("//")) {
-          snippet = snippet.substring(0, snippet.indexOf("//")).trim();
+        snippet = lineNumberReader.readLine();
+        if (snippet == null) {
+          // The file's last line was removed.
+          snippet = "";
+        } else {
+          snippet = snippet.trim();
+          // snip comment from line
+          if (snippet.contains("//")) {
+            snippet = snippet.substring(0, snippet.indexOf("//")).trim();
+          }
         }
         if (snippet.isEmpty()) {
           isRemoveLine = true;

--- a/check_api/src/test/java/com/google/errorprone/fixes/AppliedFixTest.java
+++ b/check_api/src/test/java/com/google/errorprone/fixes/AppliedFixTest.java
@@ -113,4 +113,16 @@ public class AppliedFixTest {
     AppliedFix.fromSource("public class Foo {}", endPositions)
         .apply(SuggestedFix.replace(0, -1, ""));
   }
+
+  @Test
+  public void shouldSuggestToRemoveLastLineIfAsked() {
+    when(node.getStartPosition()).thenReturn(21);
+    when(node.getEndPosition(same(endPositions))).thenReturn(42);
+
+    AppliedFix fix = AppliedFix.fromSource(
+        "package com.example;\n" +
+        "import java.util.Map;\n", endPositions)
+        .apply(SuggestedFix.delete(node));
+    assertThat(fix.getNewCodeSnippet().toString(), equalTo("to remove this line"));
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/RemoveUnusedImportsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/RemoveUnusedImportsTest.java
@@ -15,6 +15,8 @@
  */
 package com.google.errorprone.bugpatterns;
 
+import static com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH;
+
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import java.io.IOException;
@@ -240,5 +242,19 @@ public class RemoveUnusedImportsTest {
             "}")
         .expectUnchanged()
         .doTest();
+  }
+
+  @Test
+  public void unusedInPackageInfo() throws IOException {
+    testHelper
+        .addInputLines(
+            "in/com/example/package-info.java",
+            "package com.example;",
+            "import java.util.Map;")
+        .addOutputLines(
+            "out/com/example/package-info.java",
+            "package com.example;",
+            "") // The package statement's trailing newline is retained
+        .doTest(TEXT_MATCH);
   }
 }

--- a/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
+++ b/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
@@ -34,6 +34,7 @@ import com.google.errorprone.bugpatterns.BugChecker.LiteralTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.ReturnTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.bugpatterns.RemoveUnusedImports;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.doctree.LinkTree;
@@ -485,4 +486,14 @@ public class SuggestedFixesTest {
         .doTest();
   }
 
+  @Test
+  public void unusedImportInPackageInfo() throws IOException {
+	  CompilationTestHelper.newInstance(RemoveUnusedImports.class, getClass())
+        .addSourceLines(
+            "in/com/example/package-info.java",
+            "package com.example;",
+            "// BUG: Diagnostic contains: Did you mean to remove this line?",
+            "import java.util.Map;")
+        .doTest();
+  }
 }

--- a/test_helpers/src/main/java/com/google/errorprone/BugCheckerRefactoringTestHelper.java
+++ b/test_helpers/src/main/java/com/google/errorprone/BugCheckerRefactoringTestHelper.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
 import com.google.common.io.CharStreams;
 import com.google.errorprone.apply.DescriptionBasedDiff;
 import com.google.errorprone.apply.SourceFile;
@@ -42,6 +43,7 @@ import com.sun.tools.javac.util.Context;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import javax.tools.Diagnostic;
@@ -235,13 +237,18 @@ public class BugCheckerRefactoringTestHelper {
     diff.applyDifferences(sourceFile);
 
     JavaFileObject transformed =
-        JavaFileObjects.forSourceString(
-            Iterables.getOnlyElement(Iterables.filter(tree.getTypeDecls(), JCClassDecl.class))
-                .sym
-                .getQualifiedName()
-                .toString(),
-            sourceFile.getSourceText());
+        JavaFileObjects.forSourceString(getFullyQualifiedName(tree), sourceFile.getSourceText());
     return transformed;
+  }
+
+  private String getFullyQualifiedName(JCCompilationUnit tree) {
+    Iterator<JCClassDecl> types = Iterables.filter(tree.getTypeDecls(), JCClassDecl.class).iterator();
+    if (types.hasNext()) {
+      return Iterators.getOnlyElement(types).sym.getQualifiedName().toString();
+    }
+
+    // Fallback: if no class is declared, then assume we're looking at a `package-info.java`.
+    return tree.getPackage().packge.package_info.toString();
   }
 
   private ErrorProneScannerTransformer transformer(BugChecker bugChecker) {


### PR DESCRIPTION
This PR proposes a fix for issue #497. The problem turns out not to be specific to `package-info.java`, though perhaps cannot reasonably be triggered in other contexts.

Some notes about the tests I added:
1. The test added to `AppliedFixTest` matches the call made by `RemoveUnusedImports` when the issue is triggered. I added this test because `AppliedFix` is the class that is actually being fixed.
2. The test added to `RemoveUnusedImportsTest` uses text-matching rather than AST-matching because the latter simply isn't supported for `package-info.java` files, it seems. (This appears to be a limitation of the `compile-testing` library.)
3. The test added to `SuggestedFixesTest` is arguably redundant, and a bit out of place, since it's the only test in that class which references a "real"/non-test bug pattern. If you want me to delete it, let me know. On the other hand, it does test the "Did you mean to remove this line" phrasing, which is otherwise only tested in `NonOverridingEqualsTest`, which arguably should not be the primary/only place to test this.
