### PR TITLE
Add an option to exclude paths from being analyzed

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java
@@ -138,17 +138,15 @@ public class ErrorProneAnalyzer implements TaskListener {
     DescriptionListener descriptionListener =
         descriptionListenerFactory.getDescriptionListener(log, compilation);
     try {
-      if (path.getLeaf().getKind() == Tree.Kind.COMPILATION_UNIT) {
-        // We only get TaskEvents for compilation units if they contain no package declarations
-        // (e.g. package-info.java files).  In this case it's safe to analyze the
-        // CompilationUnitTree immediately.
-        if (!isExcludedPath(compilation.getSourceFile().toUri())) {
+      if (!isExcludedPath(compilation.getSourceFile().toUri())) {
+        if (path.getLeaf().getKind() == Tree.Kind.COMPILATION_UNIT) {
+          // We only get TaskEvents for compilation units if they contain no package declarations
+          // (e.g. package-info.java files).  In this case it's safe to analyze the
+          // CompilationUnitTree immediately.
           transformer.get().apply(path, subContext, descriptionListener);
-        }
-      } else if (finishedCompilation(path.getCompilationUnit())) {
-        // Otherwise this TaskEvent is for a ClassTree, and we can scan the whole
-        // CompilationUnitTree once we've seen all the enclosed classes.
-        if (!isExcludedPath(compilation.getSourceFile().toUri())) {
+        } else if (finishedCompilation(path.getCompilationUnit())) {
+          // Otherwise this TaskEvent is for a ClassTree, and we can scan the whole
+          // CompilationUnitTree once we've seen all the enclosed classes.
           transformer.get().apply(new TreePath(compilation), subContext, descriptionListener);
         }
       }

--- a/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java
@@ -24,6 +24,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
 import com.google.errorprone.scanner.ErrorProneScannerTransformer;
 import com.google.errorprone.scanner.ScannerSupplier;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TaskEvent;
@@ -172,7 +173,7 @@ public class ErrorProneAnalyzer implements TaskListener {
    */
   private boolean isExcludedPath(URI uri) {
     Pattern excludedPattern = errorProneOptions.getExcludedPattern();
-    return (excludedPattern != null) && excludedPattern.matcher(uri.toString()).matches();
+    return (excludedPattern != null) && excludedPattern.matcher(ASTHelpers.getFileNameFromUri(uri)).matches();
   }
 
   /**

--- a/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java
@@ -39,7 +39,6 @@ import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.util.PropagatedException;
-
 import java.net.URI;
 import java.util.HashSet;
 import java.util.Set;

--- a/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java
@@ -38,8 +38,11 @@ import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.util.PropagatedException;
+
+import java.net.URI;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /** A {@link TaskListener} that runs Error Prone over attributed compilation units. */
 @Trusted
@@ -138,11 +141,15 @@ public class ErrorProneAnalyzer implements TaskListener {
         // We only get TaskEvents for compilation units if they contain no package declarations
         // (e.g. package-info.java files).  In this case it's safe to analyze the
         // CompilationUnitTree immediately.
-        transformer.get().apply(path, subContext, descriptionListener);
+        if (!isExcludedPath(compilation.getSourceFile().toUri())) {
+          transformer.get().apply(path, subContext, descriptionListener);
+        }
       } else if (finishedCompilation(path.getCompilationUnit())) {
         // Otherwise this TaskEvent is for a ClassTree, and we can scan the whole
         // CompilationUnitTree once we've seen all the enclosed classes.
-        transformer.get().apply(new TreePath(compilation), subContext, descriptionListener);
+        if (!isExcludedPath(compilation.getSourceFile().toUri())) {
+          transformer.get().apply(new TreePath(compilation), subContext, descriptionListener);
+        }
       }
     } catch (ErrorProneError e) {
       e.logFatalError(log);
@@ -160,7 +167,17 @@ public class ErrorProneAnalyzer implements TaskListener {
     }
   }
 
-  /** Returns true if all declarations inside the given compilation unit have been visited. */
+  /**
+   * Returns true if all declarations inside the given compilation unit have been visited.
+   */
+  private boolean isExcludedPath(URI uri) {
+    Pattern excludedPattern = errorProneOptions.getExcludedPattern();
+    return (excludedPattern != null) && excludedPattern.matcher(uri.toString()).matches();
+  }
+
+  /**
+   * Returns true if all declarations inside the given compilation unit have been visited.
+   */
   private boolean finishedCompilation(CompilationUnitTree tree) {
     OUTER:
     for (Tree decl : tree.getTypeDecls()) {

--- a/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
@@ -440,11 +440,7 @@ public class ErrorProneOptions {
     if (!excludeSubStrings.iterator().hasNext()) {
       return null;
     }
-    Set<String> escapedExcluded = new LinkedHashSet<>();
-    for (String str: excludeSubStrings) {
-      escapedExcluded.add(str.replace(".", "\\."));
-    }
-    String choiceRegexp = Joiner.on("|").join(escapedExcluded);
+    String choiceRegexp = Joiner.on("|").join(excludeSubStrings);
     return Pattern.compile("(?:.*)(?:" + choiceRegexp + ")(?:.*)");
   }
 }

--- a/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
@@ -17,6 +17,7 @@
 package com.google.errorprone;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
@@ -25,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.apply.ImportOrganizer;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
@@ -33,8 +35,10 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Processes command-line options specific to error-prone.
@@ -56,6 +60,7 @@ public class ErrorProneOptions {
   private static final String DISABLE_WARNINGS_IN_GENERATED_CODE_FLAG =
       "-XepDisableWarningsInGeneratedCode";
   private static final String COMPILING_TEST_ONLY_CODE = "-XepCompilingTestOnlyCode";
+  private static final String EXCLUDED_PATHS_PREFIX = "-XepExcludedPaths:";
 
   /** see {@link javax.tools.OptionChecker#isSupportedOption(String)} */
   public static int isSupportedOption(String option) {
@@ -64,6 +69,7 @@ public class ErrorProneOptions {
             || option.startsWith(ErrorProneFlags.PREFIX)
             || option.startsWith(PATCH_OUTPUT_LOCATION)
             || option.startsWith(PATCH_CHECKS_PREFIX)
+            || option.startsWith(EXCLUDED_PATHS_PREFIX)
             || option.equals(IGNORE_UNKNOWN_CHECKS_FLAG)
             || option.equals(DISABLE_WARNINGS_IN_GENERATED_CODE_FLAG)
             || option.equals(ERRORS_AS_WARNINGS_FLAG)
@@ -156,6 +162,7 @@ public class ErrorProneOptions {
   private final boolean isTestOnlyTarget;
   private final ErrorProneFlags flags;
   private final PatchingOptions patchingOptions;
+  private final Pattern excludedPattern;
 
   private ErrorProneOptions(
       ImmutableMap<String, Severity> severityMap,
@@ -167,7 +174,8 @@ public class ErrorProneOptions {
       boolean disableAllChecks,
       boolean isTestOnlyTarget,
       ErrorProneFlags flags,
-      PatchingOptions patchingOptions) {
+      PatchingOptions patchingOptions,
+      Pattern excludedPattern) {
     this.severityMap = severityMap;
     this.remainingArgs = remainingArgs;
     this.ignoreUnknownChecks = ignoreUnknownChecks;
@@ -178,6 +186,7 @@ public class ErrorProneOptions {
     this.isTestOnlyTarget = isTestOnlyTarget;
     this.flags = flags;
     this.patchingOptions = patchingOptions;
+    this.excludedPattern = excludedPattern;
   }
 
   public String[] getRemainingArgs() {
@@ -212,6 +221,10 @@ public class ErrorProneOptions {
     return patchingOptions;
   }
 
+  public Pattern getExcludedPattern() {
+    return excludedPattern;
+  }
+
   private static class Builder {
     private boolean ignoreUnknownChecks = false;
     private boolean disableWarningsInGeneratedCode = false;
@@ -222,6 +235,7 @@ public class ErrorProneOptions {
     private Map<String, Severity> severityMap = new HashMap<>();
     private final ErrorProneFlags.Builder flagsBuilder = ErrorProneFlags.builder();
     private final PatchingOptions.Builder patchingOptionsBuilder = PatchingOptions.builder();
+    private Pattern excludedPattern;
 
     private void parseSeverity(String arg) {
       // Strip prefix
@@ -301,7 +315,12 @@ public class ErrorProneOptions {
           disableAllChecks,
           isTestOnlyTarget,
           flagsBuilder.build(),
-          patchingOptionsBuilder.build());
+          patchingOptionsBuilder.build(),
+          excludedPattern);
+    }
+
+    public void setExcludedPattern(Pattern excludedPattern) {
+      this.excludedPattern = excludedPattern;
     }
   }
 
@@ -391,6 +410,10 @@ public class ErrorProneOptions {
             String remaining = arg.substring(PATCH_IMPORT_ORDER_PREFIX.length());
             ImportOrganizer importOrganizer = ImportOrderParser.getImportOrganizer(remaining);
             builder.patchingOptionsBuilder().importOrganizer(importOrganizer);
+          } else if (arg.startsWith(EXCLUDED_PATHS_PREFIX)) {
+            String remaining = arg.substring(EXCLUDED_PATHS_PREFIX.length());
+            Iterable<String> paths = Splitter.on(',').trimResults().split(remaining);
+            builder.setExcludedPattern(getExcludedPattern(paths));
           } else {
             remainingArgs.add(arg);
           }
@@ -411,5 +434,17 @@ public class ErrorProneOptions {
   public static ErrorProneOptions processArgs(String[] args) {
     Preconditions.checkNotNull(args);
     return processArgs(Arrays.asList(args));
+  }
+
+  private static Pattern getExcludedPattern(Iterable<String> excludeSubStrings) {
+    if (!excludeSubStrings.iterator().hasNext()) {
+      return null;
+    }
+    Set<String> escapedExcluded = new LinkedHashSet<>();
+    for (String str: excludeSubStrings) {
+      escapedExcluded.add(str.replace(".", "\\."));
+    }
+    String choiceRegexp = Joiner.on("|").join(escapedExcluded);
+    return Pattern.compile("(?:.*)(?:" + choiceRegexp + ")(?:.*)");
   }
 }

--- a/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
@@ -411,9 +411,8 @@ public class ErrorProneOptions {
             ImportOrganizer importOrganizer = ImportOrderParser.getImportOrganizer(remaining);
             builder.patchingOptionsBuilder().importOrganizer(importOrganizer);
           } else if (arg.startsWith(EXCLUDED_PATHS_PREFIX)) {
-            String remaining = arg.substring(EXCLUDED_PATHS_PREFIX.length());
-            Iterable<String> paths = Splitter.on(',').trimResults().split(remaining);
-            builder.setExcludedPattern(getExcludedPattern(paths));
+            String pathRegex = arg.substring(EXCLUDED_PATHS_PREFIX.length());
+            builder.setExcludedPattern(Pattern.compile(pathRegex));
           } else {
             remainingArgs.add(arg);
           }
@@ -434,13 +433,5 @@ public class ErrorProneOptions {
   public static ErrorProneOptions processArgs(String[] args) {
     Preconditions.checkNotNull(args);
     return processArgs(Arrays.asList(args));
-  }
-
-  private static Pattern getExcludedPattern(Iterable<String> excludeSubStrings) {
-    if (!excludeSubStrings.iterator().hasNext()) {
-      return null;
-    }
-    String choiceRegexp = Joiner.on("|").join(excludeSubStrings);
-    return Pattern.compile("(?:.*)(?:" + choiceRegexp + ")(?:.*)");
   }
 }

--- a/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.apply.ImportOrganizer;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;

--- a/check_api/src/test/java/com/google/errorprone/ErrorProneOptionsTest.java
+++ b/check_api/src/test/java/com/google/errorprone/ErrorProneOptionsTest.java
@@ -26,6 +26,8 @@ import com.google.errorprone.apply.ImportOrganizer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -162,6 +164,20 @@ public class ErrorProneOptionsTest {
         ErrorProneOptions.processArgs(new String[] {"-XepCompilingTestOnlyCode"});
     assertThat(options.isTestOnlyTarget()).isTrue();
   }
+
+  @Test
+  public void recognizesExcludedPaths() {
+    ErrorProneOptions options =
+            ErrorProneOptions.processArgs(
+                    new String[] {"-XepExcludedPaths:build/generated,other_output"});
+    Pattern excludedPattern = options.getExcludedPattern();
+    assertThat(excludedPattern).isNotNull();
+    assertThat(excludedPattern.matcher("fizz/build/generated/Gen.java").matches()).isTrue();
+    assertThat(excludedPattern.matcher("fizz/bazz/generated/Gen.java").matches()).isFalse();
+    assertThat(excludedPattern.matcher("other_output/Gen.java").matches()).isTrue();
+    assertThat(excludedPattern.matcher("foo/other_output/subdir/Gen.java").matches()).isTrue();
+  }
+
 
   @Test
   public void recognizesPatch() {

--- a/check_api/src/test/java/com/google/errorprone/ErrorProneOptionsTest.java
+++ b/check_api/src/test/java/com/google/errorprone/ErrorProneOptionsTest.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/check_api/src/test/java/com/google/errorprone/ErrorProneOptionsTest.java
+++ b/check_api/src/test/java/com/google/errorprone/ErrorProneOptionsTest.java
@@ -169,13 +169,15 @@ public class ErrorProneOptionsTest {
   public void recognizesExcludedPaths() {
     ErrorProneOptions options =
             ErrorProneOptions.processArgs(
-                    new String[] {"-XepExcludedPaths:build/generated,other_output"});
+                    new String[] {"-XepExcludedPaths:(.*/)?(build/generated|other_output)/.*\\.java"});
     Pattern excludedPattern = options.getExcludedPattern();
     assertThat(excludedPattern).isNotNull();
     assertThat(excludedPattern.matcher("fizz/build/generated/Gen.java").matches()).isTrue();
     assertThat(excludedPattern.matcher("fizz/bazz/generated/Gen.java").matches()).isFalse();
+    assertThat(excludedPattern.matcher("fizz/abuild/generated/Gen.java").matches()).isFalse();
     assertThat(excludedPattern.matcher("other_output/Gen.java").matches()).isTrue();
     assertThat(excludedPattern.matcher("foo/other_output/subdir/Gen.java").matches()).isTrue();
+    assertThat(excludedPattern.matcher("foo/other_output/subdir/Gen.cpp").matches()).isFalse();
   }
 
 

--- a/core/src/test/java/com/google/errorprone/ErrorProneJavaCompilerTest.java
+++ b/core/src/test/java/com/google/errorprone/ErrorProneJavaCompilerTest.java
@@ -398,6 +398,32 @@ public class ErrorProneJavaCompilerTest {
         .contains("AssertionError: Cannot edit synthetic AST nodes");
   }
 
+  @Test
+  public void testWithExcludedPaths() throws Exception {
+    CompilationResult result =
+            doCompile(
+                    Arrays.asList("bugpatterns/testdata/SelfAssignmentPositiveCases1.java"),
+                    Collections.<String>emptyList(),
+                    Collections.<Class<? extends BugChecker>>emptyList());
+    assertThat(result.succeeded).isFalse();
+
+    result =
+            doCompile(
+                    Arrays.asList("bugpatterns/testdata/SelfAssignmentPositiveCases1.java"),
+                    Arrays.asList("-XepExcludedPaths:.*/bugpatterns/.*"),
+                    Collections.<Class<? extends BugChecker>>emptyList());
+    assertThat(result.succeeded).isTrue();
+
+    // ensure regexp must match the full path
+    result =
+            doCompile(
+                    Arrays.asList("bugpatterns/testdata/SelfAssignmentPositiveCases1.java"),
+                    Arrays.asList("-XepExcludedPaths:bugpatterns"),
+                    Collections.<Class<? extends BugChecker>>emptyList());
+    assertThat(result.succeeded).isFalse();
+  }
+
+
   private static class CompilationResult {
     public final boolean succeeded;
     public final DiagnosticTestHelper diagnosticHelper;


### PR DESCRIPTION
This adds an option to suppress some paths entirely from being analyzed by the error prone analyzer. This is particularly useful for generated code or third party code which consumers may not want to analyze.

Fixes #523

The input patterns are treated as regular expressions for path matching. For example:
`-XepExcludedPaths:".*/build/generated/.*\.java"` will exclude all java files inside any `build/generated/` directories