### PR TITLE
Disable caching in URLConnection when loading plugin checkers

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/ErrorPronePlugins.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorPronePlugins.java
@@ -18,10 +18,19 @@ package com.google.errorprone;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.scanner.ScannerSupplier;
 import com.sun.tools.javac.util.Context;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Collections;
+import java.util.List;
 import java.util.ServiceLoader;
+
 import javax.tools.JavaFileManager;
 import javax.tools.StandardLocation;
 
@@ -45,11 +54,50 @@ public class ErrorPronePlugins {
       return scannerSupplier;
     }
     ClassLoader loader = fileManager.getClassLoader(StandardLocation.ANNOTATION_PROCESSOR_PATH);
-    Iterable<BugChecker> extraBugCheckers = ServiceLoader.load(BugChecker.class, loader);
-    if (Iterables.isEmpty(extraBugCheckers)) {
-      return scannerSupplier;
+
+    List<Class<? extends BugChecker>> bugCheckerClasses;
+    // Synchronize to prevent races
+    synchronized(ErrorPronePlugins.class) {
+      // disable URL caching to avoid stale state bugs when run within a daemon-building process
+      boolean oldURLCaching = setUrlCaching(false);
+      Iterable<BugChecker> extraBugCheckers = ServiceLoader.load(BugChecker.class, loader);
+      bugCheckerClasses = Lists.newArrayList(Iterables.transform(extraBugCheckers, GET_CLASS));
+      // restore the old URL caching setting
+      setUrlCaching(oldURLCaching);
     }
-    return scannerSupplier.plus(
-        ScannerSupplier.fromBugCheckerClasses(Iterables.transform(extraBugCheckers, GET_CLASS)));
+    if (bugCheckerClasses.isEmpty()) {
+      return scannerSupplier;
+    } else {
+      return scannerSupplier.plus(ScannerSupplier.fromBugCheckerClasses(bugCheckerClasses));
+    }
+  }
+
+  /**
+   * A dummy {@link URLConnection} object used for disabling the global setting to use caches
+   */
+  private static URLConnection DUMMY_CONNECTION = null;
+
+  static {
+    try {
+      DUMMY_CONNECTION = new URLConnection(new URL("file:///")) {
+        @Override
+        public void connect() throws IOException {
+
+        }
+      };
+    } catch (MalformedURLException e) {
+      // this should never fail
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Update the global caching setting for {@link URLConnection}.  We need this hackish implementation since
+   * for some reason, the global caching setting can only be controlled via an instance method.
+   */
+  private static boolean setUrlCaching(boolean enable) {
+    boolean prevEnabled = DUMMY_CONNECTION.getDefaultUseCaches();
+    DUMMY_CONNECTION.setDefaultUseCaches(enable);
+    return prevEnabled;
   }
 }


### PR DESCRIPTION
Fixes #588 

We were seeing bizarre issues when running builds with a daemon process and making changes to Error Prone checkers (see #588 for more details).  We eventually diagnosed the problem as due to caching of jar files loaded by `ServiceLoader`, which is enabled by default in `URLConnection`.  This change disables that caching only while checker plugins are being loaded.  The code required to disable this caching is a bit hackish, as `URLConnection` only exposes the global setting via an instance method.  (This issue is [fixed more cleanly](http://hg.openjdk.java.net/jdk9/dev/jdk/file/f2612af45b7a/src/java.base/share/classes/java/util/ServiceLoader.java#l1059) inside `ServiceLoader` in JDK 9.)

The change also imposes some synchronization, as we may be running builds from multiple threads.  The synchronization is not airtight (other unrelated code could in principle be modifying the `URLConnection` setting), but it's better than nothing.