### PR TITLE
Enable plugin checkers to suggest fixes for generated patches

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
+++ b/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
@@ -210,11 +210,11 @@ public class BaseErrorProneJavaCompiler implements JavaCompiler {
             .customRefactorer()
             .or(
                 () -> {
-                  ScannerSupplier toUse = scannerSupplier;
+                  ScannerSupplier toUse = ErrorPronePlugins.loadPlugins(scannerSupplier, context);
                   Set<String> namedCheckers = epOptions.patchingOptions().namedCheckers();
                   if (!namedCheckers.isEmpty()) {
                     toUse =
-                        scannerSupplier.filter(bci -> namedCheckers.contains(bci.canonicalName()));
+                        toUse.filter(bci -> namedCheckers.contains(bci.canonicalName()));
                   }
                   return ErrorProneScannerTransformer.create(toUse.applyOverrides(epOptions).get());
                 })


### PR DESCRIPTION
Before, when `-XepPatchChecks` was used, a plugin checker could not be included as one of the named checks.