### PR TITLE
Fix Markdown of links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,23 +29,27 @@ its type int is not compatible with its collection's type argument Short
 
 Our documentation is at [errorprone.info](http://errorprone.info).
 
-Error Prone works with [Bazel](http://bazel.io), [Maven]
-(http://maven.apache.org), [Ant](http://ant.apache.org), and [Gradle]
-(http://gradle.org). See our [installation instructions]
-(http://errorprone.info/docs/installation) for details.
+Error Prone works with [Bazel](http://bazel.io),
+[Maven](http://maven.apache.org), [Ant](http://ant.apache.org), and
+[Gradle](http://gradle.org). See our [installation instructions][installation]
+for details.
+
+[installation]: http://errorprone.info/docs/installation
 
 ## Developing Error Prone
 
-Developing and building Error Prone is documented on the [wiki]
-(https://github.com/google/error-prone/wiki/For-Developers).
+Developing and building Error Prone is documented on the
+[wiki](https://github.com/google/error-prone/wiki/For-Developers).
 
 ## Links
 
 -   Mailing lists
-    -   [General discussion]
-        (https://groups.google.com/forum/#!forum/error-prone-discuss)
-    -   [Announcements]
-        (https://groups.google.com/forum/#!forum/error-prone-announce)
+    -   [General discussion][error-prone-discuss]
+    -   [Announcements][error-prone-announce]
 -   [Javadoc](http://errorprone.info/api/latest/)
--   Pre-release snapshots are available from [Sonatype's snapshot repository]
-    (https://oss.sonatype.org/content/repositories/snapshots/com/google/errorprone/).
+-   Pre-release snapshots are available from [Sonatype's snapshot
+    repository][snapshots].
+
+[error-prone-discuss]: https://groups.google.com/forum/#!forum/error-prone-discuss
+[error-prone-announce]: https://groups.google.com/forum/#!forum/error-prone-announce
+[snapshots]: https://oss.sonatype.org/content/repositories/snapshots/com/google/errorprone/


### PR DESCRIPTION
```
The []() and [][] styles of linking can't be separated by spaces/newline
on GitHub. I kept the []()-style for short URLs, but for long URLs that
caused line-wrapping issues I swapped to the [][] to make the text more
readable.
```