### PR TITLE
#633 - add non-regression unit test

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/NamedParameterCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/NamedParameterCheckerTest.java
@@ -17,6 +17,7 @@
 package com.google.errorprone.bugpatterns.argumentselectiondefects;
 
 import com.google.errorprone.CompilationTestHelper;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -185,5 +186,21 @@ public class NamedParameterCheckerTest {
             "  }",
             "}")
         .doTest();
+  }
+
+  @Test
+  public void namedParametersChecker_nonreg_issue633() {
+      compilationHelper
+      .addSourceLines(
+          "Test.java",
+          "abstract class Test {",
+          "  abstract void target(String san);",
+          "  void test() {",
+          "    target(",
+          "        // https://connect.microsoft.com/IE/feedback/details/814744/the-ie-doesnt-trust-a-san-certificate-when-connecting-to-ip-address",
+          "        \"dns:localhost,ip:127.0.0.1,dns:127.0.0.1,ip:::1,uri:https://127.0.0.1:8112,uri:https://::1:8112\");",
+          "  }",
+          "}")
+      .doTest();
   }
 }


### PR DESCRIPTION
I'm not sure how to fix this as the bug comes from the use of line comments inside a method call, but I'am afraid this will clash with your test framework doing special treatments with required line comments starting with "// BUG".

I hope it will help you to fix #633.