### PR TITLE
Remove redundant calls to `String.format()`

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassNewInstance.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassNewInstance.java
@@ -78,7 +78,7 @@ public class ClassNewInstance extends BugChecker implements MethodInvocationTree
     fix.replace(
         state.getEndPosition(ASTHelpers.getReceiver(tree)),
         state.getEndPosition(tree),
-        String.format(".getDeclaredConstructor().newInstance()"));
+        ".getDeclaredConstructor().newInstance()");
     boolean fixedExceptions = fixExceptions(state, fix);
     if (!fixedExceptions) {
       fixThrows(state, fix);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableAnalysis.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableAnalysis.java
@@ -369,7 +369,7 @@ public class ImmutableAnalysis {
 
     @Override
     public Violation visitArrayType(ArrayType t, Void s) {
-      return Violation.of(String.format("arrays are mutable"));
+      return Violation.of("arrays are mutable");
     }
 
     @Override


### PR DESCRIPTION
I found these redundant calls to `String.format()` using IntelliJ IDEA's "Inspect Code" feature. Hopefully the changes are rather self-explanatory, but if not then I'd be happy to explain them in detail.

Overall, I submit this PR in the hope that the error-prone team will find it worth merging. :)