### PR TITLE
Remove redundant calls to `String.toString()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .idea/dataSources.ids
 .idea/codeStyleSettings.xml
 .idea/compiler.xml
+.idea/encodings.xml
 .idea/modules.xml
 .idea/uiDesigner.xml
 .idea/libraries

--- a/core/src/main/java/com/google/errorprone/bugpatterns/HashtableContains.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/HashtableContains.java
@@ -108,7 +108,7 @@ public class HashtableContains extends BugChecker implements MethodInvocationTre
   }
 
   private Fix replaceMethodName(MethodInvocationTree tree, VisitorState state, String newName) {
-    String source = state.getSourceForNode((JCTree) tree.getMethodSelect()).toString();
+    String source = state.getSourceForNode((JCTree) tree.getMethodSelect());
     int idx = source.lastIndexOf("contains");
     String replacement =
         source.substring(0, idx) + newName + source.substring(idx + "contains".length());

--- a/docgen/src/main/java/com/google/errorprone/BugPatternFileGenerator.java
+++ b/docgen/src/main/java/com/google/errorprone/BugPatternFileGenerator.java
@@ -204,7 +204,7 @@ class BugPatternFileGenerator implements LineProcessor<List<BugPatternInstance>>
                 .put("title", pattern.name)
                 .put("summary", pattern.summary)
                 .put("layout", "bugpattern")
-                .put("category", pattern.category.toString())
+                .put("category", pattern.category)
                 .put("severity", pattern.severity.toString())
                 .build();
         DumperOptions options = new DumperOptions();


### PR DESCRIPTION
I found these redundant calls to `String.toString()` using IntelliJ IDEA's "Inspect Code" feature. Like #635, I hope that the `toString()` changes are self-explanatory, but if not then I'd be happy to explain them in detail.

What's probably not so self-explanatory is the new addition to .gitignore. I added the entry `.idea/encodings.xml` because it was generated by my copy of IntelliJ IDEA at some point after I first imported error-prone into the IDE, and it's not clear to me that it's worth keeping in version control, as it only contains the following text on my machine:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project version="4">
  <component name="Encoding">
    <file url="file://$PROJECT_DIR$" charset="UTF-8" />
    <file url="file://$PROJECT_DIR$/annotation" charset="UTF-8" />
    <file url="file://$PROJECT_DIR$/annotations" charset="UTF-8" />
    <file url="file://$PROJECT_DIR$/ant" charset="UTF-8" />
    <file url="file://$PROJECT_DIR$/check_api" charset="UTF-8" />
    <file url="file://$PROJECT_DIR$/core" charset="UTF-8" />
    <file url="file://$PROJECT_DIR$/docgen" charset="UTF-8" />
    <file url="file://$PROJECT_DIR$/docgen_processor" charset="UTF-8" />
    <file url="file://$PROJECT_DIR$/refaster" charset="UTF-8" />
    <file url="file://$PROJECT_DIR$/test_helpers" charset="UTF-8" />
  </component>
</project>
```

Overall, I submit this PR in the hope that the error-prone team will find it worth merging.