### PR TITLE
Optimize string concatenations within `StringBuilder.append()` calls

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFix.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFix.java
@@ -68,8 +68,13 @@ public class SuggestedFix implements Fix {
     StringBuilder result = new StringBuilder("replace ");
     for (Replacement replacement : getReplacements(compilationUnit.endPositions)) {
       result
-          .append("position " + replacement.startPosition() + ":" + replacement.endPosition())
-          .append(" with \"" + replacement.replaceWith() + "\" ");
+          .append("position ")
+          .append(replacement.startPosition())
+          .append(":")
+          .append(replacement.endPosition())
+          .append(" with \"")
+          .append(replacement.replaceWith())
+          .append("\" ");
     }
     return result.toString();
   }

--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFix.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFix.java
@@ -67,14 +67,10 @@ public class SuggestedFix implements Fix {
   public String toString(JCCompilationUnit compilationUnit) {
     StringBuilder result = new StringBuilder("replace ");
     for (Replacement replacement : getReplacements(compilationUnit.endPositions)) {
-      result
-          .append("position ")
-          .append(replacement.startPosition())
-          .append(":")
-          .append(replacement.endPosition())
-          .append(" with \"")
-          .append(replacement.replaceWith())
-          .append("\" ");
+      result.append(
+          String.format(
+              "position %d:%d with \"%s\"",
+              replacement.startPosition(), replacement.endPosition(), replacement.replaceWith()));
     }
     return result.toString();
   }

--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFix.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFix.java
@@ -69,7 +69,7 @@ public class SuggestedFix implements Fix {
     for (Replacement replacement : getReplacements(compilationUnit.endPositions)) {
       result.append(
           String.format(
-              "position %d:%d with \"%s\"",
+              "position %d:%d with \"%s\" ",
               replacement.startPosition(), replacement.endPosition(), replacement.replaceWith()));
     }
     return result.toString();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AbstractSuppressWarningsMatcher.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AbstractSuppressWarningsMatcher.java
@@ -18,6 +18,7 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.errorprone.bugpatterns.BugChecker.AnnotationTreeMatcher;
 
+import com.google.common.base.Joiner;
 import com.google.errorprone.fixes.Fix;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.sun.source.tree.AnnotationTree;
@@ -70,13 +71,8 @@ abstract class AbstractSuppressWarningsMatcher extends BugChecker implements Ann
     } else if (values.size() == 1) {
       return SuggestedFix.replace(annotationTree, "@SuppressWarnings(\"" + values.get(0) + "\")");
     } else {
-      StringBuilder sb = new StringBuilder("@SuppressWarnings({\"" + values.get(0) + "\"");
-      for (int i = 1; i < values.size(); i++) {
-        sb.append(", ");
-        sb.append('"').append(values.get(i)).append('"');
-      }
-      sb.append("})");
-      return SuggestedFix.replace(annotationTree, sb.toString());
+      return SuggestedFix.replace(
+          annotationTree, "@SuppressWarnings({\"" + Joiner.on("\", \"").join(values) + "})");
     }
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AbstractSuppressWarningsMatcher.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AbstractSuppressWarningsMatcher.java
@@ -73,7 +73,7 @@ abstract class AbstractSuppressWarningsMatcher extends BugChecker implements Ann
       StringBuilder sb = new StringBuilder("@SuppressWarnings({\"" + values.get(0) + "\"");
       for (int i = 1; i < values.size(); i++) {
         sb.append(", ");
-        sb.append("\"" + values.get(i) + "\"");
+        sb.append('"').append(values.get(i)).append('"');
       }
       sb.append("})");
       return SuggestedFix.replace(annotationTree, sb.toString());

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AbstractSuppressWarningsMatcher.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AbstractSuppressWarningsMatcher.java
@@ -72,7 +72,7 @@ abstract class AbstractSuppressWarningsMatcher extends BugChecker implements Ann
       return SuggestedFix.replace(annotationTree, "@SuppressWarnings(\"" + values.get(0) + "\")");
     } else {
       return SuggestedFix.replace(
-          annotationTree, "@SuppressWarnings({\"" + Joiner.on("\", \"").join(values) + "})");
+          annotationTree, "@SuppressWarnings({\"" + Joiner.on("\", \"").join(values) + "\"})");
     }
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullPrimitive.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullPrimitive.java
@@ -157,10 +157,10 @@ public class PreconditionsCheckNotNullPrimitive extends BugChecker
 
     // Was the original call to Preconditions.checkNotNull a static import or not?
     if (methodInvocationTree.getMethodSelect().getKind() == Kind.IDENTIFIER) {
-      replacement.append(replacementMethod + "(");
+      replacement.append(replacementMethod).append("(");
       fix.addStaticImport("com.google.common.base.Preconditions." + replacementMethod);
     } else {
-      replacement.append("Preconditions." + replacementMethod + "(");
+      replacement.append("Preconditions.").append(replacementMethod).append("(");
     }
 
     Joiner.on(", ").appendTo(replacement, methodInvocationTree.getArguments());

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullPrimitive.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullPrimitive.java
@@ -157,11 +157,11 @@ public class PreconditionsCheckNotNullPrimitive extends BugChecker
 
     // Was the original call to Preconditions.checkNotNull a static import or not?
     if (methodInvocationTree.getMethodSelect().getKind() == Kind.IDENTIFIER) {
-      replacement.append(replacementMethod).append("(");
       fix.addStaticImport("com.google.common.base.Preconditions." + replacementMethod);
     } else {
-      replacement.append("Preconditions.").append(replacementMethod).append("(");
+      replacement.append("Preconditions.");
     }
+    replacement.append(replacementMethod).append('(');
 
     Joiner.on(", ").appendTo(replacement, methodInvocationTree.getArguments());
 


### PR DESCRIPTION
The change in this PR was made using IntelliJ IDEA's "Inspect Code" feature. The reason for this change is explained in the commit message, which I've pasted below.

```text
Concatenating strings as an argument to `StringBuilder.append()` causes
a new, temporary StringBuilder to be created just for that argument on
modern JVMs, which is a little wasteful. This commit replaces those
concatenations with separate calls to `StringBuilder.append()` so as to
make sure that only one StringBuilder is created, rather than
(1 + concat-args) StringBuilders.
```

Overall, I submit this PR in the hope that the error-prone team will find it worth merging.