### PR TITLE
Replace explicit types with diamond operator

### DIFF
--- a/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
+++ b/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
@@ -33,7 +33,7 @@ import org.apache.tools.ant.util.LoaderUtils;
 public class ErrorProneExternalCompilerAdapter extends DefaultCompilerAdapter {
   private Path classpath;
   private String memoryStackSize;
-  private List<Argument> jvmArgs = new ArrayList<Argument>();
+  private List<Argument> jvmArgs = new ArrayList<>();
 
   public void setClasspath(Path classpath) {
     this.classpath = classpath;

--- a/check_api/src/main/java/com/google/errorprone/dataflow/LocalStore.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/LocalStore.java
@@ -80,7 +80,7 @@ public final class LocalStore<V extends AbstractValue<V>>
   }
 
   public Builder<V> toBuilder() {
-    return new Builder<V>(this);
+    return new Builder<>(this);
   }
 
   /**
@@ -108,7 +108,7 @@ public final class LocalStore<V extends AbstractValue<V>>
     }
 
     public LocalStore<V> build() {
-      return new LocalStore<V>(contents);
+      return new LocalStore<>(contents);
     }
   }
 

--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -583,7 +583,7 @@ public class SuggestedFixes {
 
   private static String newArgument(String existingParameters, Collection<String> initializers) {
     return newArgument(
-        new ImmutableList.Builder<String>().add(existingParameters).addAll(initializers).build());
+        ImmutableList.<String>builder().add(existingParameters).addAll(initializers).build());
   }
 
   private static String newArgument(Collection<String> initializers) {

--- a/check_api/src/main/java/com/google/errorprone/util/FindIdentifiers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/FindIdentifiers.java
@@ -153,7 +153,7 @@ public final class FindIdentifiers {
           com.sun.tools.javac.util.List<Type> superTypes = state.getTypes().closure(classType).tail;
           for (Type type : superTypes) {
             Scope scope = type.tsym.members();
-            ImmutableList.Builder<VarSymbol> varsList = new ImmutableList.Builder<VarSymbol>();
+            ImmutableList.Builder<VarSymbol> varsList = new ImmutableList.Builder<>();
             for (Symbol var : scope.getSymbols(VarSymbol.class::isInstance)) {
               varsList.add((VarSymbol) var);
             }

--- a/check_api/src/main/java/com/google/errorprone/util/FindIdentifiers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/FindIdentifiers.java
@@ -153,7 +153,7 @@ public final class FindIdentifiers {
           com.sun.tools.javac.util.List<Type> superTypes = state.getTypes().closure(classType).tail;
           for (Type type : superTypes) {
             Scope scope = type.tsym.members();
-            ImmutableList.Builder<VarSymbol> varsList = new ImmutableList.Builder<>();
+            ImmutableList.Builder<VarSymbol> varsList = ImmutableList.builder();
             for (Symbol var : scope.getSymbols(VarSymbol.class::isInstance)) {
               varsList.add((VarSymbol) var);
             }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ForOverrideChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ForOverrideChecker.java
@@ -191,7 +191,7 @@ public class ForOverrideChecker extends BugChecker
           "getOverriddenMethods may not be called on a static method");
     }
 
-    List<MethodSymbol> list = new LinkedList<MethodSymbol>();
+    List<MethodSymbol> list = new LinkedList<>();
     list.add(method);
 
     // Iterate over supertypes of the type that owns this method, collecting a list of all method

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatString.java
@@ -65,7 +65,7 @@ public class FormatString extends BugChecker implements MethodInvocationTreeMatc
     if (!FORMAT_METHOD.matches(tree, state)) {
       return Description.NO_MATCH;
     }
-    Deque<ExpressionTree> args = new ArrayDeque<ExpressionTree>(tree.getArguments());
+    Deque<ExpressionTree> args = new ArrayDeque<>(tree.getArguments());
     // skip the first argument of printf(Locale,String,Object...)
     if (ASTHelpers.isSameType(
         ASTHelpers.getType(args.peekFirst()),

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringValidation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringValidation.java
@@ -76,7 +76,7 @@ public class FormatStringValidation {
   public static ValidationResult validate(
       Collection<? extends ExpressionTree> arguments, final VisitorState state) {
 
-    Deque<ExpressionTree> args = new ArrayDeque<ExpressionTree>(arguments);
+    Deque<ExpressionTree> args = new ArrayDeque<>(arguments);
 
     String formatString = ASTHelpers.constValue(args.removeFirst(), String.class);
     if (formatString == null) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/AutoFactoryAtInject.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/AutoFactoryAtInject.java
@@ -72,7 +72,7 @@ public class AutoFactoryAtInject extends BugChecker implements AnnotationTreeMat
 
     ClassTree classTree = findEnclosingNode(state.getPath(), ClassTree.class);
     ImmutableList<Tree> potentiallyAnnotatedTrees =
-        new ImmutableList.Builder<Tree>().add(classTree).addAll(getConstructors(classTree)).build();
+        ImmutableList.<Tree>builder().add(classTree).addAll(getConstructors(classTree)).build();
     for (Tree potentiallyAnnotatedTree : potentiallyAnnotatedTrees) {
       if (HAS_AUTO_FACTORY_ANNOTATION.matches(potentiallyAnnotatedTree, state)
           && (potentiallyAnnotatedTree.getKind().equals(CLASS)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/EmptySetMultibindingContributions.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/EmptySetMultibindingContributions.java
@@ -237,7 +237,7 @@ public final class EmptySetMultibindingContributions extends BugChecker
 
   private String createReplacementClassModifiers(
       VisitorState state, JCModifiers enclosingClassModifiers) {
-    ImmutableList.Builder<String> classModifierStringsBuilder = new ImmutableList.Builder<String>();
+    ImmutableList.Builder<String> classModifierStringsBuilder = new ImmutableList.Builder<>();
 
     for (JCAnnotation annotation : enclosingClassModifiers.annotations) {
       classModifierStringsBuilder.add(state.getSourceForNode(annotation));

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/EmptySetMultibindingContributions.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/EmptySetMultibindingContributions.java
@@ -212,7 +212,7 @@ public final class EmptySetMultibindingContributions extends BugChecker
 
   private String createReplacementMethodModifiers(VisitorState state, JCModifiers modifiers) {
     ImmutableList.Builder<String> modifierStringsBuilder =
-        new ImmutableList.Builder<String>().add("@Multibinds");
+        ImmutableList.<String>builder().add("@Multibinds");
 
     for (JCAnnotation annotation : modifiers.annotations) {
       Name annotationQualifiedName = ASTHelpers.getSymbol(annotation).getQualifiedName();
@@ -237,7 +237,7 @@ public final class EmptySetMultibindingContributions extends BugChecker
 
   private String createReplacementClassModifiers(
       VisitorState state, JCModifiers enclosingClassModifiers) {
-    ImmutableList.Builder<String> classModifierStringsBuilder = new ImmutableList.Builder<>();
+    ImmutableList.Builder<String> classModifierStringsBuilder = ImmutableList.builder();
 
     for (JCAnnotation annotation : enclosingClassModifiers.annotations) {
       classModifierStringsBuilder.add(state.getSourceForNode(annotation));

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/UseBinds.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/UseBinds.java
@@ -161,7 +161,7 @@ public class UseBinds extends BugChecker implements MethodTreeMatcher {
 
     JCModifiers modifiers = ((JCMethodDecl) method).getModifiers();
     ImmutableList.Builder<String> modifierStringsBuilder =
-        new ImmutableList.Builder<String>().add("@Binds");
+        ImmutableList.<String>builder().add("@Binds");
 
     for (JCAnnotation annotation : modifiers.annotations) {
       Name annotationQualifiedName = getSymbol(annotation).getQualifiedName();

--- a/core/src/main/java/com/google/errorprone/refaster/Bindings.java
+++ b/core/src/main/java/com/google/errorprone/refaster/Bindings.java
@@ -98,7 +98,7 @@ public class Bindings extends ForwardingMap<Bindings.Key<?>, Object> {
   }
 
   private Bindings() {
-    this(new HashMap<Key<?>, Object>());
+    this(new HashMap<>());
   }
 
   Bindings(Bindings bindings) {

--- a/core/src/main/java/com/google/errorprone/refaster/PlaceholderUnificationVisitor.java
+++ b/core/src/main/java/com/google/errorprone/refaster/PlaceholderUnificationVisitor.java
@@ -127,7 +127,7 @@ abstract class PlaceholderUnificationVisitor
   abstract static class State<R> {
     static <R> State<R> create(
         List<UVariableDecl> seenParameters, Unifier unifier, @Nullable R result) {
-      return new AutoValue_PlaceholderUnificationVisitor_State<R>(seenParameters, unifier, result);
+      return new AutoValue_PlaceholderUnificationVisitor_State<>(seenParameters, unifier, result);
     }
 
     public abstract List<UVariableDecl> seenParameters();

--- a/core/src/main/java/com/google/errorprone/refaster/UClassDecl.java
+++ b/core/src/main/java/com/google/errorprone/refaster/UClassDecl.java
@@ -87,7 +87,7 @@ abstract class UClassDecl extends USimpleStatement implements ClassTree {
               @Override
               public Choice<UnifierWithRemainingMembers> apply(Integer i) {
                 ImmutableList<UMethodDecl> remainingMembers =
-                    new ImmutableList.Builder<UMethodDecl>()
+                    ImmutableList.<UMethodDecl>builder()
                         .addAll(currentMembers.subList(0, i))
                         .addAll(currentMembers.subList(i + 1, currentMembers.size()))
                         .build();

--- a/test_helpers/src/main/java/com/google/errorprone/DiagnosticTestHelper.java
+++ b/test_helpers/src/main/java/com/google/errorprone/DiagnosticTestHelper.java
@@ -69,7 +69,7 @@ public class DiagnosticTestHelper {
   }
 
   public final ClearableDiagnosticCollector<JavaFileObject> collector =
-      new ClearableDiagnosticCollector<JavaFileObject>();
+      new ClearableDiagnosticCollector<>();
 
   public static Matcher<Diagnostic<? extends JavaFileObject>> suggestsRemovalOfLine(
       URI fileURI, int line) {
@@ -381,7 +381,7 @@ public class DiagnosticTestHelper {
     if (bugMarkerIndex < 0) {
       throw new IllegalArgumentException("Line must contain bug marker prefix");
     }
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     String restOfLine = line.substring(bugMarkerIndex + matchString.length()).trim();
     result.add(restOfLine);
     line = reader.readLine().trim();


### PR DESCRIPTION
The redundant types in this PR were found and replaced with Java 7's diamond syntax using IntelliJ IDEA's "Inspect Code" feature. Hopefully the changes are self-explanatory, but if not then I'd be happy to explain them in detail.

I'm submitting this PR because firstly I enjoy reducing the number of meaningful warnings that my copy of IntelliJ produces, and because secondly I also enjoy improving the brevity of code whilst (arguably) maintaining its readability, and thus I hope that the error-prone team will find this PR worth merging.