### PR TITLE
Add alternate name for `MethodCanBeStatic` check

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/MethodCanBeStatic.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MethodCanBeStatic.java
@@ -36,6 +36,7 @@ import javax.lang.model.element.Modifier;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
   name = "MethodCanBeStatic",
+  altNames = "static-method",
   summary = "A private method that does not reference the enclosing instance can be static",
   category = JDK,
   severity = SUGGESTION

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MethodCanBeStaticTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MethodCanBeStaticTest.java
@@ -108,6 +108,34 @@ public class MethodCanBeStaticTest {
   }
 
   @Test
+  public void negativeSuppressed() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  @SuppressWarnings(\"MethodCanBeStatic\")",
+            "  private String f() {",
+            "    return \"\";",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negativeSuppressedAlt() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  @SuppressWarnings(\"static-method\")",
+            "  private String f() {",
+            "    return \"\";",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void negativeOverride() {
     testHelper
         .addSourceLines(


### PR DESCRIPTION
Alternative name for `MethodCanBeStatic` is `static-method`, as used in Eclipse compiler:
http://help.eclipse.org/neon/index.jsp?topic=%2Forg.eclipse.jdt.doc.user%2Ftasks%2Ftask-suppress_warnings.htm