### PR TITLE
Allow long non-file arguments to be spilled

### DIFF
--- a/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
+++ b/ant/src/main/java/com/google/errorprone/ErrorProneExternalCompilerAdapter.java
@@ -98,10 +98,14 @@ public class ErrorProneExternalCompilerAdapter extends DefaultCompilerAdapter {
       }
 
       cmd.createArgument().setValue(ErrorProneCompiler.class.getName());
+      // This is the first argument that may be spilled to a file.
+      // The ant API describes it as the first argument which is a
+      // file, but in fact only uses it for spilling.  Putting the
+      // break here allows long classpath arguments to be handled.
+      int firstSpillableArgument = cmd.size();
       setupModernJavacCommandlineSwitches(cmd);
-      int firstFile = cmd.size();
       logAndAddFilesToCompile(cmd);
-      return executeExternalCompile(cmd.getCommandline(), firstFile, true) == 0;
+      return executeExternalCompile(cmd.getCommandline(), firstSpillableArgument, true) == 0;
     } else {
       attributes.log(
           "You must set fork=\"yes\" to use the external Error Prone compiler", Project.MSG_ERR);


### PR DESCRIPTION
Allow long non-file arguments (e.g. -classpath) to go to a file.  This
prevents E2BIG when the classpath argument is too long.

This can't easily be fixed in upstream ant because:
(a) it would require an API change, and
(b) there is no way for ant to know which arguments are safe to spill
as that depends on the semantics of the external compiler.