### PR TITLE
Update maven-project-info-reports-plugin version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.7</version>
+        <version>2.9</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
The previous version we were using was printing a stack trace on
invokedynamic bytecodes.  This filled up the logs and caused our
Travis build to fail.