### PR TITLE
Document how plugin checkers can accept configuration flags

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -95,3 +95,13 @@ for Android projects.
 For a complete example using the `net.ltgt.apt` plugin, see:
 [examples/plugin/gradle](https://github.com/google/error-prone/tree/master/examples/plugin/gradle).
 
+## Command-Line Arguments
+
+Plugin checkers can accept additional configuration flags by defining
+a single-argument constructor taking an `ErrorProneFlags` object (see
+the [flags docs](http://errorprone.info/docs/flags)).  However, note
+that plugin checkers must also define a zero-argument constructor, as
+they are loaded by a `ServiceLoader`.  The actual checker instance
+used by Error Prone will be constructed using the `ErrorProneFlags`
+constructor.
+


### PR DESCRIPTION
In particular, document the fact that in addition to the
constructor taking an ErrorProneFlags object, plugin checkers
must also define a zero-argument constructor, in order to be
loaded by the ServiceLoader.