### PR TITLE
Add license info to all pom.xml files

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -27,6 +27,13 @@
   <name>@BugPattern annotation</name>
   <artifactId>error_prone_annotation</artifactId>
 
+  <licenses>
+    <license>
+      <name>Apache 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
   <dependencies>
     <dependency>
       <!-- Apache 2.0 -->

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -36,6 +36,13 @@
     </dependency>
   </dependencies>
 
+  <licenses>
+    <license>
+      <name>Apache 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
   <build>
     <plugins>
       <plugin>

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -25,6 +25,14 @@
 
   <name>Ant build support</name>
   <artifactId>error_prone_ant</artifactId>
+
+  <licenses>
+    <license>
+      <name>Apache 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+  
   <dependencies>
     <dependency>
       <groupId>org.apache.ant</groupId>

--- a/check_api/pom.xml
+++ b/check_api/pom.xml
@@ -37,6 +37,13 @@
   <name>error-prone check api</name>
   <artifactId>error_prone_check_api</artifactId>
 
+  <licenses>
+    <license>
+      <name>Apache 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
   <dependencies>
     <!-- If you add a dependency, please also add a comment with the license
          as the existing examples do. -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,6 +37,13 @@
   <name>error-prone library</name>
   <artifactId>error_prone_core</artifactId>
 
+  <licenses>
+    <license>
+      <name>Apache 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
   <dependencies>
     <!-- If you add a dependency, please also add a comment with the license
          as the existing examples do.

--- a/docgen/pom.xml
+++ b/docgen/pom.xml
@@ -27,6 +27,13 @@
   <name>Documention tool for generating Error Prone bugpattern documentation</name>
   <artifactId>error_prone_docgen</artifactId>
 
+  <licenses>
+    <license>
+      <name>Apache 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
   <build>
     <resources>
       <resource>

--- a/docgen_processor/pom.xml
+++ b/docgen_processor/pom.xml
@@ -27,6 +27,13 @@
   <name>JSR-269 annotation processor for @BugPattern annotation</name>
   <artifactId>error_prone_docgen_processor</artifactId>
 
+  <licenses>
+    <license>
+      <name>Apache 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
   <dependencies>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/refaster/pom.xml
+++ b/refaster/pom.xml
@@ -25,6 +25,14 @@
 
     <artifactId>error_prone_refaster</artifactId>
     <name>Refaster rule compiler</name>
+
+    <licenses>
+      <license>
+        <name>Apache 2.0</name>
+        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      </license>
+    </licenses>
+  
     <dependencies>
         <dependency>
             <!-- Apache 2.0 -->

--- a/test_helpers/pom.xml
+++ b/test_helpers/pom.xml
@@ -37,6 +37,13 @@
   <name>error-prone test helpers</name>
   <artifactId>error_prone_test_helpers</artifactId>
 
+  <licenses>
+    <license>
+      <name>Apache 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
   <dependencies>
     <!-- If you add a dependency, please also add a comment with the license
          as the existing examples do. -->


### PR DESCRIPTION
This enables tools like the Gradle License Plugin
(https://github.com/jaredsburrows/gradle-license-plugin) to work
correctly.