### PR TITLE
clear out Checker Framework cache after compilation to avoid leak

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
+++ b/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
@@ -31,9 +31,6 @@ import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.JavacMessages;
 import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.util.Log.WriterKind;
-
-import org.checkerframework.javacutil.AnnotationUtils;
-
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
@@ -51,6 +48,7 @@ import javax.tools.JavaCompiler;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
+import org.checkerframework.javacutil.AnnotationUtils;
 
 /** An Error Prone compiler that implements {@link javax.tools.JavaCompiler}. */
 public class BaseErrorProneJavaCompiler implements JavaCompiler {


### PR DESCRIPTION
This is a workaround for typetools/checker-framework#1482, which can affect any build process that runs javac in memory as part of a daemon.  Change is pretty simple; after compilation, we clear out the caches to avoid the leak.  This is not an ideal fix for concurrent builds (since there is just one global cache), but that would require some deeper changes to the CF.