### PR TITLE
Update Gradle example to latest version

### DIFF
--- a/examples/gradle/build.gradle
+++ b/examples/gradle/build.gradle
@@ -1,21 +1,11 @@
 // See https://github.com/tbroyer/gradle-errorprone-plugin
-buildscript {
-  repositories {
-    maven {
-      url "https://plugins.gradle.org/m2/"
-    }
-  }
-  dependencies {
-    classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.8'
-  }
+plugins {
+  id 'java'
+  id 'net.ltgt.errorprone' version '0.0.11'
 }
-
-apply plugin: 'java'
-apply plugin: 'net.ltgt.errorprone'
-
 repositories {
   mavenCentral()
 }
-configurations.errorprone {
-  resolutionStrategy.force 'com.google.errorprone:error_prone_core:2.1.1'
+dependencies {
+  errorprone 'com.google.errorprone:error_prone_core:2.1.1'
 }


### PR DESCRIPTION
Use new Gradle plugins DSL, and new way to define errorprone version;
makes the build script much simpler and easier to understand.