### PR TITLE
Add Date equality checker

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/DateEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DateEquals.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2012 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.argument;
+import static com.google.errorprone.matchers.Matchers.instanceMethod;
+import static com.google.errorprone.matchers.Matchers.staticMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.Fix;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.predicates.TypePredicates;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
+
+/** @author thomas.schwery@sai-erp.net (Thomas Schwery) */
+@BugPattern(
+  name = "DateEquals",
+  summary = "Equals used to compare dates",
+  explanation =
+      "Date comparison using equals can cause equality mismatch when comparing java.util.Date"
+              + "with its descendants, even though both objects represents the same date."
+              + "It is thus preferable to use the instance compareTo to check for"
+              + "period equality.",
+  severity = SUGGESTION,
+  providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION
+)
+public class DateEquals extends BugChecker implements MethodInvocationTreeMatcher {
+  /** Matches when the equals instance method is used to compare two Date objects. */
+  private static final Matcher<MethodInvocationTree> instanceEqualsMatcher =
+      Matchers.allOf(
+          instanceMethod().onClass(TypePredicates.isDescendantOf("java.util.Date")).named("equals"),
+          argument(0, Matchers.<ExpressionTree>isSubtypeOf("java.util.Date")));
+
+  /**
+   * Matches when the Guava com.google.common.base.Objects#equal or the JDK7
+   * java.util.Objects#equals method is used to compare two Date objects.
+   */
+  private static final Matcher<MethodInvocationTree> staticEqualsMatcher =
+      allOf(
+          anyOf(
+              staticMethod().onClass("com.google.common.base.Objects").named("equal"),
+              staticMethod().onClass("java.util.Objects").named("equals")),
+          argument(0, Matchers.<ExpressionTree>isSubtypeOf("java.util.Date")),
+          argument(1, Matchers.<ExpressionTree>isSubtypeOf("java.util.Date")));
+
+  /**
+   * Suggests replacing with compareTo.
+   */
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree t, VisitorState state) {
+    String arg1;
+    String arg2;
+    if (instanceEqualsMatcher.matches(t, state)) {
+      arg1 = ((JCFieldAccess) t.getMethodSelect()).getExpression().toString();
+      arg2 = t.getArguments().get(0).toString();
+    } else if (staticEqualsMatcher.matches(t, state)) {
+      arg1 = t.getArguments().get(0).toString();
+      arg2 = t.getArguments().get(1).toString();
+    } else {
+      return NO_MATCH;
+    }
+
+    Fix fix =
+        SuggestedFix.builder()
+            .replace(t, "" + arg1 + ".compareTo(" + arg2 + ") == 0")
+            .build();
+    return describeMatch(t, fix);
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -53,6 +53,7 @@ import com.google.errorprone.bugpatterns.ConstantField;
 import com.google.errorprone.bugpatterns.ConstantOverflow;
 import com.google.errorprone.bugpatterns.ConstructorInvokesOverridable;
 import com.google.errorprone.bugpatterns.ConstructorLeaksThis;
+import com.google.errorprone.bugpatterns.DateEquals;
 import com.google.errorprone.bugpatterns.DeadException;
 import com.google.errorprone.bugpatterns.DeadThread;
 import com.google.errorprone.bugpatterns.DefaultCharset;
@@ -508,6 +509,7 @@ public class BuiltInCheckerSuppliers {
           ConstantField.class,
           ConstructorInvokesOverridable.class,
           ConstructorLeaksThis.class,
+          DateEquals.class,
           DepAnn.class,
           DivZero.class,
           EmptyIfStatement.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/DateEqualsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/DateEqualsTest.java
@@ -1,0 +1,153 @@
+package com.google.errorprone.bugpatterns;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.errorprone.CompilationTestHelper;
+
+@RunWith(value = JUnit4.class)
+public class DateEqualsTest {
+
+    private CompilationTestHelper compilationHelper;
+
+    @Before
+    public void setUp() {
+        compilationHelper = CompilationTestHelper.newInstance(DateEquals.class, getClass());
+    }
+
+    @Test
+    public void compareDates() {
+        compilationHelper
+                .addSourceLines(
+                        "NormalDate.java",
+                        "import java.util.Date;",
+                        "public class NormalDate {",
+                        "  public void normal() {",
+                        "    Date date = new Date();",
+                        "    Date date1 = new Date();",
+                        "    date.compareTo(date1);",
+                        "  }",
+                        "}").doTest();
+    }
+
+    @Test
+    public void compareTimestamp() {
+        compilationHelper
+                .addSourceLines(
+                        "TimestampDate.java",
+                        "import java.util.Date;",
+                        "import java.sql.Timestamp;",
+                        "public class TimestampDate {",
+                        "  public void normal() {",
+                        "    Date date = new Date();",
+                        "    Date date1 = new Timestamp(date.getTime());",
+                        "    date.compareTo(date1);",
+                        "  }",
+                        "}").doTest();
+    }
+
+    @Test
+    public void instanceEqualUsed() {
+        compilationHelper
+                .addSourceLines(
+                        "DateEquals.java",
+                        "import java.util.Date;",
+                        "public class DateEquals {",
+                        "  public void normal() {",
+                        "    Date date = new Date();",
+                        "    Date date1 = new Date();",
+                        "    // BUG: Diagnostic contains: Equals used to compare dates",
+                        "    date.equals(date1);",
+                        "  }",
+                        "}").doTest();
+    }
+
+    @Test
+    public void objectsEqualUsed() {
+        compilationHelper
+                .addSourceLines(
+                        "DateObjectsEquals.java",
+                        "import java.util.Date;",
+                        "import java.util.Objects;",
+                        "public class DateObjectsEquals {",
+                        "  public void normal() {",
+                        "    Date date = new Date();",
+                        "    Date date1 = new Date();",
+                        "    // BUG: Diagnostic contains: Equals used to compare dates",
+                        "    Objects.equals(date, date1);",
+                        "  }",
+                        "}").doTest();
+    }
+
+    @Test
+    public void timestampInstanceEquals() {
+        compilationHelper
+                .addSourceLines(
+                        "TimeStampEquals.java",
+                        "import java.util.Date;",
+                        "import java.sql.Timestamp;",
+                        "public class TimeStampEquals {",
+                        "  public void normal() {",
+                        "    Date date = new Date();",
+                        "    Date date1 = new Timestamp(date.getTime());",
+                        "    // BUG: Diagnostic contains: Equals used to compare dates",
+                        "    date.equals(date1);",
+                        "  }",
+                        "}").doTest();
+    }
+
+    @Test
+    public void timestampInstanceEqualsReverse() {
+        compilationHelper
+                .addSourceLines(
+                        "TimeStampEquals.java",
+                        "import java.util.Date;",
+                        "import java.sql.Timestamp;",
+                        "public class TimeStampEquals {",
+                        "  public void normal() {",
+                        "    Date date = new Date();",
+                        "    Date date1 = new Timestamp(date.getTime());",
+                        "    // BUG: Diagnostic contains: Equals used to compare dates",
+                        "    date1.equals(date);",
+                        "  }",
+                        "}").doTest();
+    }
+
+    @Test
+    public void timestampObjectEquals() {
+        compilationHelper
+                .addSourceLines(
+                        "TimeStampEquals.java",
+                        "import java.util.Date;",
+                        "import java.sql.Timestamp;",
+                        "import java.util.Objects;",
+                        "public class TimeStampEquals {",
+                        "  public void normal() {",
+                        "    Date date = new Date();",
+                        "    Date date1 = new Timestamp(date.getTime());",
+                        "    // BUG: Diagnostic contains: Equals used to compare dates",
+                        "    Objects.equals(date, date1);",
+                        "  }",
+                        "}").doTest();
+    }
+
+    @Test
+    public void timestampObjectEqualsReverse() {
+        compilationHelper
+                .addSourceLines(
+                        "TimeStampEquals.java",
+                        "import java.util.Date;",
+                        "import java.sql.Timestamp;",
+                        "import java.util.Objects;",
+                        "public class TimeStampEquals {",
+                        "  public void normal() {",
+                        "    Date date = new Date();",
+                        "    Date date1 = new Timestamp(date.getTime());",
+                        "    // BUG: Diagnostic contains: Equals used to compare dates",
+                        "    Objects.equals(date1, date);",
+                        "  }",
+                        "}").doTest();
+    }
+}


### PR DESCRIPTION
This check verifies that two dates are not compared using the instance `equals` or `Objects.equals` because of problems when one of the instances are descendants of Date, such as `sql.Timestamp`. In such cases, the comparison can return false every time. The `compareTo` method has no such problems.

This check is added as disabled and with a level of suggestion because code bases that don't use dates from `sql.Timestamp` (for example from entities) are not really impacted by this behavior.