### PR TITLE
Tolerate missing symbols in `URLEqualsHashCode`

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/URLEqualsHashCode.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/URLEqualsHashCode.java
@@ -30,6 +30,7 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.CompletionFailure;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import java.util.List;
@@ -83,7 +84,12 @@ public class URLEqualsHashCode extends BugChecker implements NewClassTreeMatcher
         return false;
       }
       Type type = ASTHelpers.getType(tree);
-      if (!ASTHelpers.isSubtype(type, sym.type, state)) {
+      try {
+        if (!ASTHelpers.isSubtype(type, sym.type, state)) {
+          return false;
+        }
+      } catch (CompletionFailure e) {
+        // Some symbols necessary for the subtype check are not on the classpath; bail out
         return false;
       }
       Types types = state.getTypes();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/URLEqualsHashCodeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/URLEqualsHashCodeTest.java
@@ -16,9 +16,19 @@
 
 package com.google.errorprone.bugpatterns;
 
+import com.google.common.io.ByteStreams;
 import com.google.errorprone.CompilationTestHelper;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -29,6 +39,8 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class URLEqualsHashCodeTest {
+  @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+
   CompilationTestHelper compilationHelper;
 
   @Before
@@ -44,5 +56,37 @@ public class URLEqualsHashCodeTest {
   @Test
   public void testNegativeCase() throws Exception {
     compilationHelper.addSourceFile("URLEqualsHashCodeNegativeCases.java").doTest();
+  }
+
+  public static class Super {}
+
+  public static class Sub extends Super {}
+
+  @Test
+  public void incompleteClasspath() throws Exception {
+    File libJar = tempFolder.newFile("lib.jar");
+    try (FileOutputStream fis = new FileOutputStream(libJar);
+        JarOutputStream jos = new JarOutputStream(fis)) {
+      addClassToJar(jos, getClass());
+      addClassToJar(jos, Sub.class);
+      // Note that `Sub` references `Super`, but the latter is missing from the classpath.
+    }
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import " + Sub.class.getCanonicalName() + ";",
+            "class Test {",
+            "  private Sub s = new Sub();",
+            "}")
+        .setArgs(Arrays.asList("-cp", libJar.toString()))
+        .doTest();
+  }
+
+  private static void addClassToJar(JarOutputStream jos, Class<?> clazz) throws IOException {
+    String entryPath = clazz.getName().replace('.', '/') + ".class";
+    try (InputStream is = clazz.getClassLoader().getResourceAsStream(entryPath)) {
+      jos.putNextEntry(new JarEntry(entryPath));
+      ByteStreams.copy(is, jos);
+    }
   }
 }


### PR DESCRIPTION
Fixes #542.