### PR TITLE
Add a regression test for #792

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/ParameterNameTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ParameterNameTest.java
@@ -102,4 +102,27 @@ public class ParameterNameTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void issue792() {
+    testHelper
+        .addSourceLines(
+            "a/Foo.java",
+            "package a;",
+            "class Bar {",
+            "}",
+            "public class Foo {",
+            "  public void setInteger(Integer i) {",
+            "  }",
+            "  public void callSetInteger() {",
+            "    setInteger(0);",
+            " }",
+            "}")
+        .addSourceLines(
+            "a/Baz.java",
+            "package a;",
+            "public class Baz extends Foo {",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
Adds a regression test to cover the case where one java file contains
two class declarations, and another class in a separate file extends the
public class in the first file.

This test would fail at v2.1.2, but was patched in 73e24807d.