### PR TITLE
Support more kinds of fail() in CheckReturnValue

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/CheckReturnValueTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/CheckReturnValueTest.java
@@ -378,6 +378,10 @@ public class CheckReturnValueTest {
             "      foo.f();",
             "      junit.framework.TestCase.fail();",
             "    } catch (Exception expected) {}",
+            "    try {",
+            "      foo.f();",
+            "      throw new AssertionError();",
+            "    } catch (Exception expected) {}",
             "  }",
             "}")
         .doTest();
@@ -432,6 +436,10 @@ public class CheckReturnValueTest {
             "    try {",
             "      foo.f();",
             "      junit.framework.TestCase.fail(\"message\");",
+            "    } catch (Exception expected) {}",
+            "    try {",
+            "      foo.f();",
+            "      throw new AssertionError(\"message\");",
             "    } catch (Exception expected) {}",
             "  }",
             "}")
@@ -528,6 +536,9 @@ public class CheckReturnValueTest {
             "    // BUG: Diagnostic contains: Ignored return value",
             "    foo.f();",
             "    junit.framework.TestCase.fail();",
+            "    // BUG: Diagnostic contains: Ignored return value",
+            "    foo.f();",
+            "    throw new AssertionError();",
             "  }",
             "}")
         .doTest();

--- a/docs/bugpattern/CheckReturnValue.md
+++ b/docs/bugpattern/CheckReturnValue.md
@@ -44,6 +44,14 @@ try {
 }
 ```
 
+4.  code that is using `assertThrows`; e.g.:
+
+```java
+assertThrows(
+    NullPointerException.class,
+    () -> user.setName(null));
+```
+
 This is because such tests meant to check if a method is invoked and/or throws
 the correct exception type, rather than consuming the return value.
 


### PR DESCRIPTION
Fixes #804

By the way, I noticed a couple of other patterns in the codebase for detecting `fail()` statements in addition to the one used by `CheckReturnValue`:

https://github.com/google/error-prone/blob/9af93b6548b57011a5320e8d0fee61bc693e8c18/core/src/main/java/com/google/errorprone/bugpatterns/AbstractExpectedExceptionChecker.java#L79-L81

https://github.com/google/error-prone/blob/74b237d6c07be0108be1743d4b1d2ad83f7e37a1/core/src/main/java/com/google/errorprone/bugpatterns/MissingFail.java#L177-L186

Maybe they are slightly different because they have different requirements -- I didn't investigate.   I thought I'd point this out in case the pattern is being duplicated by accident.