### PR TITLE
attempt to fix formatting issue with JdkObsolete docs

### DIFF
--- a/docs/bugpattern/JdkObsolete.md
+++ b/docs/bugpattern/JdkObsolete.md
@@ -57,11 +57,4 @@ An ancient precursor to `Iterator`.
 
 Replaced by `NavigableSet` and `NavigableMap` in Java 6.
 
-[^1]: People generally choose `LinkedList` because they want fast insertion and
-  removal.  However, `LinkedList` has slow traversal, and typically you need to
-  traverse the list to find the place to insert/remove.  It turns out that
-  the cost of traversing to a location in a `LinkedList` is approximately 4x
-  the cost of copying an element in an `ArrayList`.  Thus, `LinkedList`'s
-  traversal cost dominates and results in poorer performance.
-
-  More info: https://stuartmarks.wordpress.com/2015/12/18/some-java-list-benchmarks/
+[^1]: People generally choose `LinkedList` because they want fast insertion and removal.  However, `LinkedList` has slow traversal, and typically you need to traverse the list to find the place to insert/remove.  It turns out that the cost of traversing to a location in a `LinkedList` is approximately 4x the cost of copying an element in an `ArrayList`.  Thus, `LinkedList`'s traversal cost dominates and results in poorer performance.  More info: https://stuartmarks.wordpress.com/2015/12/18/some-java-list-benchmarks/


### PR DESCRIPTION
The footnote on the [JdkObsolete doc](http://errorprone.info/bugpattern/JdkObsolete) is formatted incorrectly.  This is an attempt to fix that by removing newlines.  Not sure if it worked; don't know how to test locally.  Is there any way to test this?