### PR TITLE
Add String.split check, and make all existing code pass it

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@
 # some cases, their employer may be the copyright holder.  To see the full list
 # of contributors, see the revision history in source control.
 Google Inc.
+Two Sigma Open Source

--- a/ant/src/main/java/com/google/errorprone/ErrorProneAntCompilerAdapter.java
+++ b/ant/src/main/java/com/google/errorprone/ErrorProneAntCompilerAdapter.java
@@ -47,7 +47,7 @@ public class ErrorProneAntCompilerAdapter extends DefaultCompilerAdapter {
     if (originalLoader instanceof URLClassLoader) {
       urls = ((URLClassLoader) originalLoader).getURLs();
     } else if (originalLoader instanceof AntClassLoader) {
-      String[] pieces = ((AntClassLoader) originalLoader).getClasspath().split(":");
+      String[] pieces = ((AntClassLoader) originalLoader).getClasspath().split(":", -1);
       urls = new URL[pieces.length];
       for (int i = 0; i < pieces.length; ++i) {
         try {

--- a/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
@@ -238,7 +238,7 @@ public class ErrorProneOptions {
       // Strip prefix
       String remaining = arg.substring(SEVERITY_PREFIX.length());
       // Split on ':'
-      String[] parts = remaining.split(":");
+      String[] parts = remaining.split(":", -1);
       if (parts.length > 2 || parts[0].isEmpty()) {
         throw new InvalidCommandLineOptionException("invalid flag: " + arg);
       }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StringSplit.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StringSplit.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 The Error Prone Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.errorprone.BugPattern.Category.JDK;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.List;
+
+/** @author dturner@twosigma.com (David Turner) */
+@BugPattern(
+  name = "StringSplit",
+  category = JDK,
+  summary = "String.split should never take only a single argument; it has surprising behavior",
+  severity = WARNING
+)
+public class StringSplit extends BugChecker implements MethodInvocationTreeMatcher {
+  private static final Matcher<ExpressionTree> MATCHER =
+      instanceMethod().onDescendantOf("java.lang.String").withSignature("split(java.lang.String)");
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (!MATCHER.matches(tree, state)) {
+      return NO_MATCH;
+    }
+    List<? extends ExpressionTree> arguments = tree.getArguments();
+    return describeMatch(
+	tree, SuggestedFix.builder().postfixWith(getOnlyElement(arguments), ", -1").build());
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/NamedParameterComment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/NamedParameterComment.java
@@ -114,7 +114,8 @@ public final class NamedParameterComment {
         // that its a match. Therefore we also check to make sure that the comment is not really
         // long and that it doesn't contain acsii-art style markup.
         String commentText = Comments.getTextFromComment(comment);
-        boolean textMatches = Arrays.asList(commentText.split("[^a-zA-Z0-9_]+")).contains(formal);
+        boolean textMatches =
+            Arrays.asList(commentText.split("[^a-zA-Z0-9_]+", -1)).contains(formal);
         boolean tooLong = commentText.length() > formal.length() + 5 && commentText.length() > 50;
         boolean tooMuchMarkup = CharMatcher.anyOf("-*!@<>").countIn(commentText) > 5;
         return textMatches && !tooLong && !tooMuchMarkup;

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -191,6 +191,7 @@ import com.google.errorprone.bugpatterns.StreamResourceLeak;
 import com.google.errorprone.bugpatterns.StreamToString;
 import com.google.errorprone.bugpatterns.StringBuilderInitWithChar;
 import com.google.errorprone.bugpatterns.StringEquality;
+import com.google.errorprone.bugpatterns.StringSplit;
 import com.google.errorprone.bugpatterns.SuppressWarningsDeprecated;
 import com.google.errorprone.bugpatterns.SwitchDefault;
 import com.google.errorprone.bugpatterns.TestExceptionChecker;
@@ -586,6 +587,7 @@ public class BuiltInCheckerSuppliers {
           StaticQualifiedUsingExpression.class,
           StaticOrDefaultInterfaceMethod.class,
           StringEquality.class,
+          StringSplit.class,
           SwitchDefault.class,
           TestExceptionChecker.class,
           ThrowsUncheckedException.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/StringSplitTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/StringSplitTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 The Error Prone Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link StringSplit} bug pattern.
+ *
+ * @author dturner@twosigma.com (David Turner)
+ */
+@RunWith(JUnit4.class)
+public class StringSplitTest {
+  CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setUp() {
+    compilationHelper = CompilationTestHelper.newInstance(StringSplit.class, getClass());
+  }
+
+  @Test
+  public void testPositiveCase() throws Exception {
+    compilationHelper.addSourceFile("StringSplitPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void testNegativeCase() throws Exception {
+    compilationHelper.addSourceFile("StringSplitNegativeCases.java").doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/StringSplitNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/StringSplitNegativeCases.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 The Error Prone Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+/**
+ * Negative test cases for StringSplit check.
+ *
+ * @author dturner@twosigma.com (David Turner)
+ */
+public class StringSplitNegativeCases {
+  public void StringSplitTwoArgs() {
+    String foo = "a:b";
+    foo.split(":", 1);
+  }
+
+  public void StringSplitTwoArgsOneNegative() {
+    String foo = "a:b";
+    foo.split(":", -1);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/StringSplitPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/StringSplitPositiveCases.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 The Error Prone Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+/**
+ * Positive test cases for StringSplit check.
+ *
+ * @author dturner@twosigma.com (David Turner)
+ */
+public class StringSplitPositiveCases {
+
+  public void StringSplitOneArg() {
+    String foo = "a:b";
+    // BUG: Diagnostic contains: String.split
+    foo.split(":");
+  }
+}


### PR DESCRIPTION
Fixes #867.  I decided not to do work to suggest the Guava Splitter.  That could always be added later, and String.split is just fine in its two-argument form.