### PR TITLE
Fix ThreadLocalUsage documentation formatting.

### DIFF
--- a/docs/bugpattern/ThreadLocalUsage.md
+++ b/docs/bugpattern/ThreadLocalUsage.md
@@ -1,6 +1,6 @@
 `ThreadLocal`s should be stored in `static` variables to avoid memory leaks. If
-a `ThreadLocal` is stored in an instance (non-static) variable, there will be `M
-* N` instances of the `ThreadLocal` value where `M` is the number of threads,
+a `ThreadLocal` is stored in an instance (non-static) variable, there will be <code>M
+\* N</code> instances of the `ThreadLocal` value where `M` is the number of threads,
 and `N` is the number of instances of the containing class. Each instance may
 remain live as long the thread that stored it stays live.
 


### PR DESCRIPTION
<img width="948" alt="screen shot 2018-01-11 at 1 40 17 pm" src="https://user-images.githubusercontent.com/4032667/34848841-27d4f7ba-f6d5-11e7-8682-ec5668439e70.png">
