### PR TITLE
Support other file encodings than UTF-8

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/BaseErrorProneCompiler.java
+++ b/check_api/src/main/java/com/google/errorprone/BaseErrorProneCompiler.java
@@ -18,7 +18,6 @@ package com.google.errorprone;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.MaskedClassLoader.MaskedFileManager;
 import com.google.errorprone.scanner.ScannerSupplier;
@@ -30,6 +29,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.processing.Processor;
@@ -100,7 +100,7 @@ public class BaseErrorProneCompiler {
         }
       }
     }
-    return Charsets.UTF_8;
+    return StandardCharsets.UTF_8;
  }
 
   public Result run(String[] argv) {

--- a/check_api/src/main/java/com/google/errorprone/BaseErrorProneCompiler.java
+++ b/check_api/src/main/java/com/google/errorprone/BaseErrorProneCompiler.java
@@ -17,6 +17,7 @@
 package com.google.errorprone;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.MaskedClassLoader.MaskedFileManager;
@@ -29,7 +30,6 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.processing.Processor;
@@ -100,7 +100,7 @@ public class BaseErrorProneCompiler {
         }
       }
     }
-    return StandardCharsets.UTF_8;
+    return UTF_8;
  }
 
   public Result run(String[] argv) {

--- a/check_api/src/main/java/com/google/errorprone/BaseErrorProneCompiler.java
+++ b/check_api/src/main/java/com/google/errorprone/BaseErrorProneCompiler.java
@@ -18,6 +18,7 @@ package com.google.errorprone;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.MaskedClassLoader.MaskedFileManager;
 import com.google.errorprone.scanner.ScannerSupplier;
@@ -87,6 +88,20 @@ public class BaseErrorProneCompiler {
       return this;
     }
   }
+  
+  private static Charset getCharsetFromArgs(String[] argv)
+  {
+    for (int i = 0; i < argv.length; i++) {
+      if ("-encoding".equals(argv[i])) {
+        if (i < argv.length - 1) {
+          return Charset.forName(argv[i + 1]);
+        } else {
+          throw new RuntimeException("missing encoding");
+        }
+      }
+    }
+    return Charsets.UTF_8;
+ }
 
   public Result run(String[] argv) {
     try {
@@ -104,7 +119,7 @@ public class BaseErrorProneCompiler {
         javacOpts.add(arg);
       }
     }
-    StandardJavaFileManager fileManager = new MaskedFileManager();
+    StandardJavaFileManager fileManager = new MaskedFileManager(getCharsetFromArgs(argv));
     return run(
         javacOpts.toArray(new String[0]),
         fileManager,

--- a/check_api/src/main/java/com/google/errorprone/MaskedClassLoader.java
+++ b/check_api/src/main/java/com/google/errorprone/MaskedClassLoader.java
@@ -23,6 +23,8 @@ import com.sun.tools.javac.file.JavacFileManager;
 import com.sun.tools.javac.util.Context;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.Charset;
+
 import javax.tools.JavaFileManager;
 
 /**
@@ -35,13 +37,13 @@ public class MaskedClassLoader extends ClassLoader {
    * An alternative to {@link JavacFileManager#preRegister(Context)} that installs a {@link
    * MaskedClassLoader}.
    */
-  public static void preRegisterFileManager(Context context) {
+  public static void preRegisterFileManager(Context context, Charset charset) {
     context.put(
         JavaFileManager.class,
         new Context.Factory<JavaFileManager>() {
           @Override
           public JavaFileManager make(Context c) {
-            return new MaskedFileManager(c);
+            return new MaskedFileManager(c, charset);
           }
         });
   }
@@ -63,12 +65,12 @@ public class MaskedClassLoader extends ClassLoader {
   @Trusted
   static class MaskedFileManager extends JavacFileManager {
 
-    public MaskedFileManager(Context context) {
-      super(context, /* register= */ true, UTF_8);
+    public MaskedFileManager(Context context, Charset charset) {
+      super(context, /* register= */ true, charset);
     }
 
-    public MaskedFileManager() {
-      this(new Context());
+    public MaskedFileManager(Charset charset) {
+      this(new Context(), charset);
     }
 
     @Override

--- a/check_api/src/main/java/com/google/errorprone/MaskedClassLoader.java
+++ b/check_api/src/main/java/com/google/errorprone/MaskedClassLoader.java
@@ -16,8 +16,6 @@
 
 package com.google.errorprone;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.sun.tools.javac.api.ClientCodeWrapper.Trusted;
 import com.sun.tools.javac.file.JavacFileManager;
 import com.sun.tools.javac.util.Context;


### PR DESCRIPTION
The source file encoding _UTF-8_ is hard coded into [MaskedClassLoader.java](https://github.com/google/error-prone/blob/71f27667eb723c18e574f905e0fe3a64786a2c3c/check_api/src/main/java/com/google/errorprone/MaskedClassLoader.java#L67). 
This makes it impossible to use error-prone for otherwise encoded sources.
This MR leaves the default to _UTF-8_ and only changes it if the parameter "-encoding" is given on the command line.

This problem ist reported in #873  and mentioned in https://groups.google.com/d/msg/error-prone-discuss/075NR0aTzm4/LsHe6t7BBgAJ.