### PR TITLE
Add option to ignore missing @Override annotations in interfaces

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingOverride.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingOverride.java
@@ -48,12 +48,12 @@ import javax.lang.model.element.Modifier;
 public class MissingOverride extends BugChecker implements MethodTreeMatcher {
 
   /**
-   * if true, don't warn on missing @Override annotations inside interfaces
+   * if true, don't warn on missing {@code @Override} annotations inside interfaces
    */
   private final boolean ignoreInterfaceOverrides;
 
   public MissingOverride() {
-    this.ignoreInterfaceOverrides = false;
+    this(ErrorProneFlags.empty());
   }
 
   public MissingOverride(ErrorProneFlags flags) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingOverride.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingOverride.java
@@ -22,6 +22,7 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
+import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -45,6 +46,20 @@ import javax.lang.model.element.Modifier;
   providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION
 )
 public class MissingOverride extends BugChecker implements MethodTreeMatcher {
+
+  /**
+   * if true, don't warn on missing @Override annotations inside interfaces
+   */
+  private final boolean ignoreInterfaceOverrides;
+
+  public MissingOverride() {
+    this.ignoreInterfaceOverrides = false;
+  }
+
+  public MissingOverride(ErrorProneFlags flags) {
+    this.ignoreInterfaceOverrides = flags.getBoolean("MissingOverride:IgnoreInterfaceOverrides")
+        .orElse(false);
+  }
 
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {
@@ -84,6 +99,10 @@ public class MissingOverride extends BugChecker implements MethodTreeMatcher {
    */
   private MethodSymbol getFirstOverride(Symbol sym, Types types) {
     ClassSymbol owner = sym.enclClass();
+    if (ignoreInterfaceOverrides && owner.isInterface()) {
+      // pretend the method does not override anything
+      return null;
+    }
     for (Type s : types.closure(owner.type)) {
       if (s == owner.type) {
         continue;

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MissingOverrideTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MissingOverrideTest.java
@@ -16,6 +16,7 @@
 
 package com.google.errorprone.bugpatterns;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.Before;
 import org.junit.Test;
@@ -89,4 +90,32 @@ public class MissingOverrideTest {
             "Test.java", "public class Test extends Super {", "  public void f() {}", "}")
         .doTest();
   }
+
+  @Test
+  public void interfaceOverride() throws Exception {
+    compilationHelper
+        .addSourceLines("Super.java", "interface Super {", "  void f();", "}")
+        .addSourceLines(
+            "Test.java",
+            "public interface Test extends Super {",
+            "  // BUG: Diagnostic contains: f implements method in Super; expected @Override",
+            "  void f();",
+            "}")
+        .doTest();
+  }
+
+  // this doesn't work!  need new APIs in CompilationTestHelper
+//  @Test
+//  public void ignoreInterfaceOverride() throws Exception {
+//    compilationHelper
+//        .setArgs(ImmutableList.of("-XepOpt:MissingOverride:IgnoreInterfaceOverrides=true"));
+//    compilationHelper
+//        .addSourceLines("Super.java", "interface Super {", "  void f();", "}")
+//        .addSourceLines(
+//            "Test.java",
+//            "public interface Test extends Super {",
+//            "  void f();",
+//            "}")
+//        .doTest();
+//  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MissingOverrideTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MissingOverrideTest.java
@@ -104,18 +104,16 @@ public class MissingOverrideTest {
         .doTest();
   }
 
-  // this doesn't work!  need new APIs in CompilationTestHelper
-//  @Test
-//  public void ignoreInterfaceOverride() throws Exception {
-//    compilationHelper
-//        .setArgs(ImmutableList.of("-XepOpt:MissingOverride:IgnoreInterfaceOverrides=true"));
-//    compilationHelper
-//        .addSourceLines("Super.java", "interface Super {", "  void f();", "}")
-//        .addSourceLines(
-//            "Test.java",
-//            "public interface Test extends Super {",
-//            "  void f();",
-//            "}")
-//        .doTest();
-//  }
+  @Test
+  public void ignoreInterfaceOverride() throws Exception {
+    compilationHelper
+        .setArgs(ImmutableList.of("-XepOpt:MissingOverride:IgnoreInterfaceOverrides=true"))
+        .addSourceLines("Super.java", "interface Super {", "  void f();", "}")
+        .addSourceLines(
+            "Test.java",
+            "public interface Test extends Super {",
+            "  void f();",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
In the [mobile RIB architecture](https://github.com/uber/RIBs), we often have cases where Dagger Component-related interfaces form an inheritance chain, such that a method gets added to a Component super-interface that was already present in the Component sub-interface.  In such a case, the EP MissingOverride check forces an `@Override` annotation to be added to the sub-interface.  Forcing this change goes against some of the modularity in the RIB architecture (@AttwellBrian can explain more).  Further, in this case the annotation does not really add safety, as (I think) Dagger code gen will complain if there is some ambiguity in the set of methods exposed by the component sub-interface.

In general, it's not clear whether forcing `@Override` annotations in interfaces is as much of a win as it is for classes.  (Kotlin forces it on interfaces, but Swift only requires it on classes, not sub-protocols.)  This PR adds an option to the MissingOverride check to disable checking for `@Override` annotations in interfaces.