### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedBySymbolResolver.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedBySymbolResolver.java
@@ -162,6 +162,14 @@ public class GuardedBySymbolResolver implements GuardedByBinder.Resolver {
         return sym;
       }
     }
+    if (classSymbol.owner != null
+        && classSymbol != classSymbol.owner
+        && classSymbol.owner instanceof Symbol.ClassSymbol) {
+      T sym = getMember(type, kind, classSymbol.owner, name);
+      if (sym != null && sym.isStatic()) {
+        return sym;
+      }
+    }
     return null;
   }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByCheckerTest.java
@@ -1592,7 +1592,7 @@ public class GuardedByCheckerTest {
   // Ensure sure outer instance handling doesn't accidentally include enclosing classes of
   // static member classes.
   @Test
-  public void testInnerClass_staticOuterClassLock() throws Exception {
+  public void testStaticMemberClass_enclosingInstanceLock() throws Exception {
     compilationHelper
         .addSourceLines(
             "threadsafety/Test.java",
@@ -1602,6 +1602,29 @@ public class GuardedByCheckerTest {
             "  final Object mu = new Object();",
             "  private static final class Baz {",
             "    // BUG: Diagnostic contains: could not resolve guard",
+            "    @GuardedBy(\"mu\") int x;",
+            "  }",
+            "  public void m(Baz b) {",
+            "    synchronized (mu) {",
+            "      b.x++;",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  // Ensure sure outer instance handling doesn't accidentally include enclosing classes of
+  // static member classes.
+  @Test
+  public void testStaticMemberClass_staticOuterClassLock() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "threadsafety/Test.java",
+            "package threadsafety;",
+            "import javax.annotation.concurrent.GuardedBy;",
+            "public class Test {",
+            "  static final Object mu = new Object();",
+            "  private static final class Baz {",
             "    @GuardedBy(\"mu\") int x;",
             "  }",
             "  public void m(Baz b) {",


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Allow references to static locks in enclosing classes

The only case we want to disallow is static member classes accessing locks in
enclosing classes.

RELNOTES: N/A

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=184911398

115387d0330f894ce4b99e87678edcc319ef5aa2