### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/matchers/method/MethodNameMatcherImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/MethodNameMatcherImpl.java
@@ -16,6 +16,8 @@
 
 package com.google.errorprone.matchers.method;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.base.Optional;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.method.MethodMatchers.MethodNameMatcher;
@@ -50,6 +52,10 @@ public abstract class MethodNameMatcherImpl extends AbstractChainedMatcher<Match
     Exact(AbstractSimpleMatcher<MatchState> baseMatcher, String name) {
       super(baseMatcher);
       this.name = name;
+      checkArgument(
+          !name.contains("(") || !name.contains(")"),
+          "method name (%s) cannot contain parentheses; use \"getBytes\" instead of \"getBytes()\"",
+          name);
     }
 
     @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ThreadSafety.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ThreadSafety.java
@@ -290,8 +290,7 @@ public final class ThreadSafety {
                     a ->
                         ((ClassSymbol) a.getAnnotationType().asElement())
                             .flatName()
-                            .toString()
-                            .equals(suppressAnnotation.getName()))) {
+                            .contentEquals(suppressAnnotation.getName()))) {
           continue;
         }
         Violation info = isThreadSafeType(!immutableTypeParameter, containerTypeParameters, tyarg);
@@ -491,12 +490,7 @@ public final class ThreadSafety {
         && symbol
             .getAnnotationMirrors()
             .stream()
-            .anyMatch(
-                t ->
-                    t.type
-                        .tsym
-                        .getQualifiedName()
-                        .contentEquals(typeParameterAnnotation.getName()));
+            .anyMatch(t -> t.type.tsym.flatName().contentEquals(typeParameterAnnotation.getName()));
   }
 
   /**

--- a/core/src/test/java/com/google/errorprone/matchers/MatchersTest.java
+++ b/core/src/test/java/com/google/errorprone/matchers/MatchersTest.java
@@ -25,6 +25,7 @@ import static com.google.errorprone.matchers.Matchers.isSubtypeOf;
 import static com.google.errorprone.matchers.Matchers.isVoidType;
 import static com.google.errorprone.matchers.Matchers.methodReturns;
 import static com.google.errorprone.suppliers.Suppliers.typeFromString;
+import static org.junit.Assert.fail;
 
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.CompilationTestHelper;
@@ -54,6 +55,15 @@ public class MatchersTest {
   @Before
   public void setUp() {
     compilationHelper = CompilationTestHelper.newInstance(InLoopChecker.class, getClass());
+  }
+
+  @Test
+  public void methodNameWithParenthesisThrows() {
+    try {
+      Matchers.instanceMethod().onExactClass("java.lang.String").named("getBytes()");
+      fail("Expected an IAE to be throw but wasn't");
+    } catch (IllegalArgumentException expected) {
+    }
   }
 
   @Test


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Throw an IAE if the method name contains ( or ).

32d6853c35d0f9c8be59332d4a5a8de38a9aac31

-------

<p> Use flatName() so that nested classes work
RELNOTES: Fix for ThreadSafety checker, non-user-visible

fa4984def30380ca32dd222fc3dd72f0f2c4d8e6