### PR TITLE
Add FieldCanBeStatic checker

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeStatic.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeStatic.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
+import static com.google.errorprone.fixes.SuggestedFixes.addModifiers;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.Matchers.isPrimitiveType;
+import static com.google.errorprone.util.ASTHelpers.getType;
+import static com.google.errorprone.util.ASTHelpers.isSubtype;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
+
+/** @author andrew@gaul.org (Andrew Gaul) */
+@BugPattern(
+  name = "FieldCanBeStatic",
+  summary = "A final field initialized at compile-time with an instance of an immutable type can be static.",
+  severity = SUGGESTION,
+  providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION
+)
+public class FieldCanBeStatic extends BugChecker implements VariableTreeMatcher {
+
+  @Override
+  public Description matchVariable(VariableTree tree, VisitorState state) {
+    VarSymbol sym = ASTHelpers.getSymbol(tree);
+    if (sym == null || sym.getKind() != ElementKind.FIELD) {
+      return NO_MATCH;
+    }
+    if (!sym.getModifiers().contains(Modifier.FINAL)) {
+      return NO_MATCH;
+    }
+    if (sym.isStatic()) {
+      return NO_MATCH;
+    }
+    Tree targetType = tree.getType();
+    if (!isPrimitiveType().matches(targetType, state) &&
+        !isSubtype(getType(tree), state.getTypeFromString("java.lang.String"), state)) {
+      return NO_MATCH;
+    }
+    ExpressionTree tagExpr = tree.getInitializer();
+    if (tagExpr == null) {
+      return NO_MATCH;
+    }
+    if (tagExpr.getKind() != Kind.BOOLEAN_LITERAL &&
+        tagExpr.getKind() != Kind.CHAR_LITERAL &&
+        tagExpr.getKind() != Kind.DOUBLE_LITERAL &&
+        tagExpr.getKind() != Kind.FLOAT_LITERAL &&
+        tagExpr.getKind() != Kind.INT_LITERAL &&
+        tagExpr.getKind() != Kind.LONG_LITERAL &&
+        tagExpr.getKind() != Kind.NULL_LITERAL &&
+        tagExpr.getKind() != Kind.STRING_LITERAL) {
+      return NO_MATCH;
+    }
+    return describeMatch(tree.getModifiers(), addModifiers(tree, state, Modifier.STATIC));
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -106,6 +106,7 @@ import com.google.errorprone.bugpatterns.ExtendingJUnitAssert;
 import com.google.errorprone.bugpatterns.FallThrough;
 import com.google.errorprone.bugpatterns.FieldCanBeFinal;
 import com.google.errorprone.bugpatterns.FieldCanBeLocal;
+import com.google.errorprone.bugpatterns.FieldCanBeStatic;
 import com.google.errorprone.bugpatterns.Finally;
 import com.google.errorprone.bugpatterns.FloatCast;
 import com.google.errorprone.bugpatterns.FloatingPointAssertionWithinEpsilon;
@@ -793,6 +794,7 @@ public class BuiltInCheckerSuppliers {
           ExpectedExceptionRefactoring.class,
           FieldCanBeFinal.class,
           FieldCanBeLocal.class,
+          FieldCanBeStatic.class,
           FieldMissingNullable.class,
           FunctionalInterfaceClash.class,
           FuzzyEqualsShouldNotBeUsedInEqualsMethod.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/FieldCanBeStaticTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/FieldCanBeStaticTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** {@link FieldCanBeStatic}Test */
+@RunWith(JUnit4.class)
+public class FieldCanBeStaticTest {
+  @Test
+  public void positive() throws IOException {
+    CompilationTestHelper.newInstance(FieldCanBeStatic.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  // BUG: Diagnostic contains:",
+            "  private final int primitive = 3;",
+            "  // BUG: Diagnostic contains:",
+            "  private final String string = \"string\";",
+            "  // BUG: Diagnostic contains:",
+            "  private final String nullString = null;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative() throws IOException {
+    CompilationTestHelper.newInstance(FieldCanBeStatic.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  private static final String staticFinalInitializer;",
+            "  static {",
+            "    staticFinalInitializer = \"string\";",
+            "  }",
+            "  private static final String staticFinal = \"string\";",
+            "  private int nonFinal = 3;",
+            "  private static int staticNontFinal = 4;",
+            "  private final Object finalMutable = new Object();",
+            "  private final int nonLiteral = new java.util.Random().nextInt();",
+            "  private final Person pojo = new Person(\"Bob\", 42);",
+            "  private static class Person {",
+            "    final String name;",
+            "    final int age;",
+            "    Person(String name, int age) {",
+            "      this.name = name;",
+            "      this.age = age;",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/docs/bugpattern/FieldCanBeStatic.md
+++ b/docs/bugpattern/FieldCanBeStatic.md
@@ -1,0 +1,19 @@
+`final` fields initialized with a literal can elide a per-instance reference by
+adding the `static` keyword.  Since the field is `final` it is unmodifiable and
+since its initializer is a literal the value is immutable and thus sharing a
+per-class field is safe.  This also allows a simpler constant load bytecode
+instead of a field lookup.
+
+That is, prefer this:
+
+```java{.good}
+static final String string = "string";
+static final int number = 42;
+```
+
+Not this:
+
+```java{.bad}
+final String string = "string";
+final int number = 42;
+```


### PR DESCRIPTION
This finds final fields which are initialized with a literal.  Adding
static reduces memory overhead from per-instance to per-class and
allows initialization at compile-time instead of run-time.