### PR TITLE
Update Gradle examples

### DIFF
--- a/examples/gradle/build.gradle
+++ b/examples/gradle/build.gradle
@@ -1,11 +1,14 @@
 // See https://github.com/tbroyer/gradle-errorprone-plugin
 plugins {
   id 'java'
-  id 'net.ltgt.errorprone' version '0.0.11'
+  id 'net.ltgt.errorprone' version '0.0.13'
 }
 repositories {
   mavenCentral()
+  maven {
+    url "https://oss.sonatype.org/content/repositories/snapshots/"
+  }
 }
 dependencies {
-  errorprone 'com.google.errorprone:error_prone_core:2.2.0'
+  errorprone 'com.google.errorprone:error_prone_core:2.2.1-SNAPSHOT'
 }

--- a/examples/plugin/gradle/build.gradle
+++ b/examples/plugin/gradle/build.gradle
@@ -1,15 +1,8 @@
 // See https://github.com/tbroyer/gradle-errorprone-plugin
 // See https://github.com/tbroyer/gradle-apt-plugin
-buildscript {
-  repositories {
-    maven {
-      url "https://plugins.gradle.org/m2/"
-    }
-  }
-  dependencies {
-    classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.8"
-    classpath "net.ltgt.gradle:gradle-apt-plugin:0.6"
-  }
+plugins {
+  id 'net.ltgt.errorprone' version '0.0.13' apply false
+  id 'net.ltgt.apt' version '0.14' apply false
 }
 
 subprojects {
@@ -24,7 +17,7 @@ subprojects {
   apply plugin: 'net.ltgt.errorprone'
   apply plugin: 'net.ltgt.apt'
 
-  configurations.errorprone {
-    resolutionStrategy.force 'com.google.errorprone:error_prone_core:2.2.1-SNAPSHOT'
+  dependencies {
+    errorprone 'com.google.errorprone:error_prone_core:2.2.1-SNAPSHOT'
   }
 }

--- a/examples/plugin/gradle/hello/build.gradle
+++ b/examples/plugin/gradle/hello/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  apt project(':sample_plugin')
+  annotationProcessor project(':sample_plugin')
 }

--- a/examples/plugin/gradle/sample_plugin/build.gradle
+++ b/examples/plugin/gradle/sample_plugin/build.gradle
@@ -2,6 +2,6 @@ dependencies {
   compileOnly 'com.google.errorprone:error_prone_core:2.2.1-SNAPSHOT'
   compileOnly 'com.google.errorprone:error_prone_annotation:2.2.1-SNAPSHOT'
 
-  compileOnly 'com.google.auto.service:auto-service:1.0-rc2'
-  apt         'com.google.auto.service:auto-service:1.0-rc2'
+  compileOnly         'com.google.auto.service:auto-service:1.0-rc4'
+  annotationProcessor 'com.google.auto.service:auto-service:1.0-rc4'
 }


### PR DESCRIPTION
* use latest version of net.ltgt.apt plugin and its new annotationProcessor configuration (will be built into Gradle 4.6, no plugin needed)
* use errorprone snapshot version in examples/gradle
* use Gradle plugins DSL in examples/plugin/gradle
* use new way (as of net.ltgt.errorprone 0.0.9, which is already a bit old) of declaring errorprone dependency in examples/plugin/gradle
* update auto-service to latest version
* update net.ltgt.errorprone to latest version (0.0.13)