### PR TITLE
Moe Sync

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -47,5 +47,11 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>0.39</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/annotation/src/main/java/com/google/errorprone/BugPatternValidator.java
+++ b/annotation/src/main/java/com/google/errorprone/BugPatternValidator.java
@@ -16,6 +16,7 @@
 
 package com.google.errorprone;
 
+import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableSet;
 import java.lang.annotation.Annotation;
 import java.util.Set;
@@ -30,6 +31,11 @@ public class BugPatternValidator {
   public static void validate(BugPattern pattern) throws ValidationException {
     if (pattern == null) {
       throw new ValidationException("No @BugPattern provided");
+    }
+
+    // name must not contain spaces
+    if (CharMatcher.whitespace().matchesAnyOf(pattern.name())) {
+      throw new ValidationException("Name must not contain whitespace: " + pattern.name());
     }
 
     // linkType must be consistent with link element.

--- a/annotation/src/test/java/com/google/errorprone/BugPatternValidatorTest.java
+++ b/annotation/src/test/java/com/google/errorprone/BugPatternValidatorTest.java
@@ -16,7 +16,9 @@
 
 package com.google.errorprone;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.expectThrows;
 
 import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.LinkType;
@@ -182,5 +184,20 @@ public class BugPatternValidatorTest {
 
     BugPattern annotation = BugPatternTestClass.class.getAnnotation(BugPattern.class);
     assertThrows(ValidationException.class, () -> BugPatternValidator.validate(annotation));
+  }
+
+  @Test
+  public void spacesInNameNotAllowed() {
+    @BugPattern(
+      name = "name with spaces",
+      summary = "Has a name with spaces",
+      severity = SeverityLevel.ERROR
+    )
+    final class BugPatternTestClass {}
+
+    BugPattern annotation = BugPatternTestClass.class.getAnnotation(BugPattern.class);
+    ValidationException e =
+        expectThrows(ValidationException.class, () -> BugPatternValidator.validate(annotation));
+    assertThat(e.getMessage()).contains("Name must not contain whitespace");
   }
 }

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/MethodNameMatcherImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/MethodNameMatcherImpl.java
@@ -53,7 +53,7 @@ public abstract class MethodNameMatcherImpl extends AbstractChainedMatcher<Match
       super(baseMatcher);
       this.name = name;
       checkArgument(
-          !name.contains("(") || !name.contains(")"),
+          !name.contains("(") && !name.contains(")"),
           "method name (%s) cannot contain parentheses; use \"getBytes\" instead of \"getBytes()\"",
           name);
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ConstructorLeaksThis.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ConstructorLeaksThis.java
@@ -29,6 +29,7 @@ import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import javax.lang.model.element.Name;
 
@@ -83,7 +84,11 @@ public class ConstructorLeaksThis extends ConstructorLeakChecker {
 
   private void checkForThis(
       ExpressionTree node, Name identifier, ClassSymbol thisClass, VisitorState state) {
-    if (identifier.contentEquals("this") && thisClass.equals(ASTHelpers.getSymbol(node).owner)) {
+    Symbol sym = ASTHelpers.getSymbol(node);
+    if (sym != null
+        && !sym.isConstructor()
+        && identifier.contentEquals("this")
+        && thisClass.equals(sym.owner)) {
       state.reportMatch(describeMatch(node));
     }
   }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/URLEqualsHashCode.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/URLEqualsHashCode.java
@@ -18,15 +18,26 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.predicates.TypePredicates;
 import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol;
@@ -44,24 +55,52 @@ import java.util.List;
 @BugPattern(
   name = "URLEqualsHashCode",
   summary =
-      "Creation of a Set/HashSet/HashMap of java.net.URL."
-          + " equals() and hashCode() of java.net.URL class make blocking internet connections.",
+      "Avoid hash-based containers of java.net.URL--the containers rely on equals() and hashCode(),"
+          + " which cause java.net.URL to make blocking internet connections.",
   category = JDK,
   severity = WARNING,
   tags = StandardTags.FRAGILE_CODE
 )
-public class URLEqualsHashCode extends BugChecker implements NewClassTreeMatcher {
+public class URLEqualsHashCode extends BugChecker
+    implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
 
   private static final String URL_CLASS = "java.net.URL";
 
-  private static final Matcher<Tree> TYPE_MATCHER =
+  private static final Matcher<ExpressionTree> CONTAINER_MATCHER =
       anyOf(
           new URLTypeArgumentMatcher("java.util.Set", 0),
-          new URLTypeArgumentMatcher("java.util.Map", 0));
+          new URLTypeArgumentMatcher("java.util.Map", 0),
+          // BiMap is a Map, so its first type argument is already being checked
+          new URLTypeArgumentMatcher("com.google.common.collect.BiMap", 1));
+
+  private static final Matcher<ExpressionTree> METHOD_INVOCATION_MATCHER =
+      allOf(
+          anyOf(
+              staticMethod()
+                  .onClassAny(
+                      ImmutableSet.class.getName(),
+                      ImmutableMap.class.getName(),
+                      HashBiMap.class.getName()),
+              instanceMethod()
+                  .onClass(
+                      TypePredicates.isExactTypeAny(
+                          ImmutableList.of(
+                              ImmutableSet.Builder.class.getName(),
+                              ImmutableMap.Builder.class.getName())))
+                  .named("build")),
+          CONTAINER_MATCHER);
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (METHOD_INVOCATION_MATCHER.matches(tree, state)) {
+      return describeMatch(tree);
+    }
+    return Description.NO_MATCH;
+  }
 
   @Override
   public Description matchNewClass(NewClassTree tree, VisitorState state) {
-    if (TYPE_MATCHER.matches(tree, state)) {
+    if (CONTAINER_MATCHER.matches(tree, state)) {
       return describeMatch(tree);
     }
     return Description.NO_MATCH;
@@ -100,3 +139,4 @@ public class URLEqualsHashCode extends BugChecker implements NewClassTreeMatcher
     }
   }
 }
+

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UngroupedOverloads.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UngroupedOverloads.java
@@ -16,16 +16,15 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Multimaps.toMultimap;
 import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Streams;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
@@ -36,16 +35,9 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
-import com.sun.tools.javac.tree.JCTree;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.stream.Stream;
 import javax.lang.model.element.Name;
 
 /** @author hanuszczak@google.com (Łukasz Hanuszczak) */
@@ -62,193 +54,21 @@ import javax.lang.model.element.Name;
 )
 public class UngroupedOverloads extends BugChecker implements ClassTreeMatcher {
 
-  private static final int DEFAULT_METHOD_COUNT_CUTOFF = 100;
+  @AutoValue
+  abstract static class MemberWithIndex {
 
-  private final int methodCountCutoff;
+    abstract int index();
 
-  public UngroupedOverloads() {
-    this(DEFAULT_METHOD_COUNT_CUTOFF);
-  }
+    abstract Tree tree();
 
-  /**
-   * @param methodCountCutoff the limit on the number of methods in the class for which fixes are no
-   *     longer suggested (but correctness is still ensured).
-   */
-  UngroupedOverloads(int methodCountCutoff) {
-    this.methodCountCutoff = methodCountCutoff;
-  }
-
-  @Override
-  public Description matchClass(ClassTree classTree, VisitorState state) {
-    List<? extends Tree> classMembers = new ArrayList<>(classTree.getMembers());
-    MethodFixSuggester suggester = new MethodFixSuggester(classTree, classMembers, state);
-
-    /*
-     * Checking the class members for violations requires only in O(n) time whereas providing
-     * suggested fixes requires O(n^2) time. This is why we have a cut-off limit that depending on
-     * the number of class members selects feasible strategy.
-     */
-    long methodCount = classMembers.stream().filter((tree) -> tree instanceof MethodTree).count();
-    if (methodCount >= methodCountCutoff) {
-      checkMembers(classMembers, suggester);
-    } else {
-      orderMembers(classMembers, suggester);
+    static MemberWithIndex create(int index, Tree tree) {
+      return new AutoValue_UngroupedOverloads_MemberWithIndex(index, tree);
     }
-    return suggester.describeFix();
-  }
-
-  private static void checkMembers(
-      List<? extends Tree> classMembers, MethodFixSuggester suggester) {
-    Map<Name, Integer> previousOccurrences = new LinkedHashMap<>();
-    for (int currentOccurrence = 0; currentOccurrence < classMembers.size(); currentOccurrence++) {
-      Tree memberTree = classMembers.get(currentOccurrence);
-      if (!(memberTree instanceof MethodTree)) {
-        continue;
-      }
-
-      MethodTree methodTree = (MethodTree) memberTree;
-      Name methodName = methodTree.getName();
-
-      /*
-       * If there is a previous occurrence and it is on a position different than the previous one
-       * it must be the case that the methods are not ordered properly (so we report a violation).
-       */
-      Integer previousOccurrence = previousOccurrences.get(methodName);
-      if (previousOccurrence != null && previousOccurrence != currentOccurrence - 1) {
-        suggester.justReport(currentOccurrence);
-      }
-      previousOccurrences.put(methodName, currentOccurrence);
-    }
-  }
-
-  private static void orderMembers(
-      List<? extends Tree> classMembers, MethodFixSuggester suggester) {
-    /*
-     * The ordering algorithm works by bubbling (the same way as in bubble-sort) methods until they
-     * reach correct position. Therefore algorithm has a O(n^2) where n is number of methods within
-     * the class. However, this is just a worst case scenario (and classes usually don't have more
-     * than 1000 members anyway) that could happen only for really, really weird code.
-     *
-     * The problem itself looks like something that could be solved in O(n lg n) time but it would
-     * probably be much more complicated and the constant would be much greater (so for sane code
-     * it would be slower).
-     */
-    Map<OverloadKey, Integer> previousOccurrences = new LinkedHashMap<>();
-    for (int currentOccurrence = 0; currentOccurrence < classMembers.size(); currentOccurrence++) {
-      Tree memberTree = classMembers.get(currentOccurrence);
-      if (!(memberTree instanceof MethodTree)) {
-        continue;
-      }
-
-      OverloadKey methodName = OverloadKey.create((MethodTree) memberTree);
-
-      Integer previousOccurrence = previousOccurrences.get(methodName);
-      if (previousOccurrence != null) {
-        // If the block is actually moved (i.e. the `for` loop below does at least one iteration).
-        if (currentOccurrence - 1 > previousOccurrence) {
-          // We "bubble" the current occurrence until it is placed next to the previous occurrence.
-          for (int i = currentOccurrence - 1; i > previousOccurrence; i--) {
-            Tree splitterTree = classMembers.get(i);
-            if (!(splitterTree instanceof MethodTree)) {
-              continue;
-            }
-            OverloadKey splitterKey = OverloadKey.create((MethodTree) splitterTree);
-
-            // Swapping may invalidate `previousOccurrences` so we need to shift it by one manually.
-            Integer splitterOccurrence = previousOccurrences.get(splitterKey);
-            if (splitterOccurrence != null && splitterOccurrence.equals(i)) {
-              previousOccurrences.put(splitterKey, i + 1);
-            }
-
-            Collections.swap(classMembers, i, i + 1);
-          }
-          suggester.moveBlock(currentOccurrence);
-        }
-        previousOccurrences.put(methodName, previousOccurrence + 1);
-      } else {
-        previousOccurrences.put(methodName, currentOccurrence);
-      }
-    }
-  }
-
-  /**
-   * Returns a more fine-tuned starting position of a {@code current} node in the source code.
-   *
-   * <p>Unfortunately, {@link JCTree#getStartPosition()} doesn't account for comments which usually
-   * are integral part of the code. So, instead we use a heuristic: the AST node actually "starts"
-   * after the first newline after the end position of the previous AST node.
-   *
-   * <p>This assumes the relevant comments are placed either before (i.e. above) the definition or
-   * after the definition on the same line rather than below the definition.
-   *
-   * @param current the node for which we retrieve the position
-   * @param previous a node before the {@code current} one
-   * @return more useful starting position of the {@code current} node
-   */
-  private static int getBroadStartPosition(VisitorState state, Tree current, Tree previous) {
-    int previousEndPosition = getBroadEndPosition(state, previous, current);
-    int currentStartPosition = ((JCTree) current).getStartPosition();
-    return Math.min(previousEndPosition, currentStartPosition);
-  }
-
-  /**
-   * Returns a more fine-tuned ending position of a {@code current} node in the source code.
-   *
-   * <p>See {@link #getBroadStartPosition(VisitorState, Tree, Tree)} for more information.
-   *
-   * @param current the node for which we retrieve the position
-   * @param next a node after the {@code current} one (optional)
-   * @return more useful ending position of the {@code current} node
-   */
-  private static int getBroadEndPosition(VisitorState state, Tree current, @Nullable Tree next) {
-    CharSequence source = state.getSourceCode();
-
-    int currentEndPosition = state.getEndPosition(current);
-    int nextStartPosition;
-    if (next != null) {
-      nextStartPosition = ((JCTree) next).getStartPosition();
-    } else {
-      nextStartPosition = source.length();
-    }
-
-    String newline = System.lineSeparator();
-    int newlinePosition = indexOf(source, newline, currentEndPosition, nextStartPosition);
-    return (newlinePosition < 0) ? currentEndPosition : newlinePosition;
-  }
-
-  /**
-   * Looks for the first occurrence of {@code term} in {@code sequence}.
-   *
-   * <p>This is analogous to the {@link java.lang.String#indexOf(String, int)} but works with any
-   * {@link java.lang.CharSequence} and also supports {@code toIndex} parameter.
-   *
-   * <p>The algorithm has a O(nm) time complexity but it is more than enough for this use case.
-   *
-   * @param sequence the character sequence to perform the search on
-   * @param term the character sequence to search for
-   * @param fromIndex the index from which to start the search (inclusive)
-   * @param toIndex the index to which the search happens (exclusive)
-   * @return the index of the first occurrence of specified substring or -1 if not found
-   */
-  private static int indexOf(CharSequence sequence, CharSequence term, int fromIndex, int toIndex) {
-    int termLength = term.length();
-    for (int index = fromIndex; index + termLength - 1 < toIndex; index++) {
-      int i = 0;
-      for (; i < termLength; i++) {
-        if (sequence.charAt(index + i) != term.charAt(i)) {
-          break;
-        }
-      }
-      if (i == termLength) {
-        return index;
-      }
-    }
-    return -1;
   }
 
   @AutoValue
   abstract static class OverloadKey {
-    abstract String name();
+    abstract Name name();
 
     // TODO(cushon): re-enable this, but don't warn about interspersed static/non-static overloads
     // Include static-ness when grouping overloads. Static and non-static methods are still
@@ -257,231 +77,68 @@ public class UngroupedOverloads extends BugChecker implements ClassTreeMatcher {
 
     public static OverloadKey create(MethodTree methodTree) {
       MethodSymbol sym = ASTHelpers.getSymbol(methodTree);
-      return new AutoValue_UngroupedOverloads_OverloadKey(sym.getSimpleName().toString());
+      return new AutoValue_UngroupedOverloads_OverloadKey(sym.getSimpleName());
     }
   }
 
-  private interface OverloadViolation {
-    Name getMethodName();
-
-    void buildFix(SuggestedFix.Builder fix, VisitorState state, MethodTree target);
+  @Override
+  public Description matchClass(ClassTree classTree, VisitorState state) {
+    // collect all member methods and their indices in the list of members, grouped by name
+    LinkedHashMultimap<OverloadKey, MemberWithIndex> methods =
+        Streams.zip(
+                Stream.iterate(0, i -> i + 1),
+                classTree.getMembers().stream(),
+                MemberWithIndex::create)
+            .filter(m -> m.tree() instanceof MethodTree)
+            .collect(
+                toMultimap(
+                    m -> OverloadKey.create((MethodTree) m.tree()),
+                    x -> x,
+                    LinkedHashMultimap::create));
+    methods.asMap().forEach((key, overloads) -> checkOverloads(state, key.name(), overloads));
+    return NO_MATCH;
   }
 
-  private static class JustReport implements OverloadViolation {
-    private final MethodTree methodTree;
-
-    public JustReport(MethodTree methodTree) {
-      this.methodTree = methodTree;
+  private void checkOverloads(
+      VisitorState state, Name name, Collection<MemberWithIndex> overloads) {
+    if (overloads.size() <= 1) {
+      return;
     }
-
-    @Override
-    public Name getMethodName() {
-      return methodTree.getName();
+    // check if the indices of the overloads in the member list are sequential
+    MemberWithIndex first = overloads.iterator().next();
+    boolean grouped =
+        Streams.zip(
+                Stream.iterate(first.index(), i -> i + 1),
+                overloads.stream().map(m -> m.index()),
+                (a, b) -> Objects.equals(a, b))
+            .allMatch(x -> x);
+    if (grouped) {
+      return;
     }
-
-    @Override
-    public void buildFix(SuggestedFix.Builder fix, VisitorState state, MethodTree target) {
-      // Do nothing, this is just for reporting violations.
+    if (overloads.stream().anyMatch(m -> isSuppressed(m.tree()))) {
+      return;
     }
-  }
-
-  private static class MoveBlock implements OverloadViolation {
-    private final Name methodName;
-    private final int startPosition;
-    private final int endPosition;
-
-    public MoveBlock(Name methodName, int startPosition, int endPosition) {
-      this.methodName = methodName;
-      this.startPosition = startPosition;
-      this.endPosition = endPosition;
-    }
-
-    @Override
-    public Name getMethodName() {
-      return methodName;
-    }
-
-    @Override
-    public void buildFix(SuggestedFix.Builder fix, VisitorState state, MethodTree target) {
-      String methodSource = getMethodSource(state.getSourceCode());
-      fix.replace(startPosition, endPosition, "");
-      fix.postfixWith(target, methodSource);
-    }
-
-    public String getMethodSource(CharSequence sourceCode) {
-      return sourceCode.subSequence(startPosition, endPosition).toString();
-    }
-  }
-
-  private class MethodFixSuggester {
-
-    private final ClassTree classTree;
-    private final ImmutableList<? extends Tree> classMembers; // Initial, unchanged members.
-    private final VisitorState state;
-    private final List<OverloadViolation> violations;
-    private final ImmutableSet<String> suppressed;
-
-    public MethodFixSuggester(
-        ClassTree classTree, List<? extends Tree> classMembers, VisitorState state) {
-      this.classTree = classTree;
-      this.classMembers = ImmutableList.copyOf(classMembers);
-      this.state = state;
-      this.violations = new ArrayList<>();
-      this.suppressed =
-          classMembers
-              .stream()
-              .filter(MethodTree.class::isInstance)
-              .map(MethodTree.class::cast)
-              .filter(m -> isSuppressed(m))
-              .map(m -> m.getName().toString())
-              .collect(toImmutableSet());
-    }
-
-    private void addViolation(OverloadViolation violation) {
-      if (!suppressed.contains(violation.getMethodName().toString())) {
-        violations.add(violation);
-      }
-    }
-
-    public void justReport(int currentOccurrence) {
-      addViolation(new JustReport((MethodTree) classMembers.get(currentOccurrence)));
-    }
-
-    public void moveBlock(int currentOccurrence) {
-      MethodTree currentTree = (MethodTree) classMembers.get(currentOccurrence);
-      Name currentName = currentTree.getName();
-
-      Tree previousTree = classMembers.get(currentOccurrence - 1);
-      Tree nextTree;
-      if (currentOccurrence + 1 < classMembers.size()) {
-        nextTree = classMembers.get(currentOccurrence + 1);
-      } else {
-        nextTree = null;
-      }
-
-      int startPosition = getBroadStartPosition(state, currentTree, previousTree);
-      int endPosition = getBroadEndPosition(state, currentTree, nextTree);
-      addViolation(new MoveBlock(currentName, startPosition, endPosition));
-    }
-
-    public Description describeFix() {
-      if (violations.isEmpty()) {
-        return Description.NO_MATCH;
-      } else {
-        return buildAdaptedDescription().addFix(buildFix()).build();
-      }
-    }
-
-    private SuggestedFix buildFix() {
-      ImmutableMap<Name, MethodTree> lastGroupedOccurrences = getLastGroupedOccurrences();
-
-      SuggestedFix.Builder fix = SuggestedFix.builder();
-      for (OverloadViolation violation : violations) {
-        Name methodName = violation.getMethodName();
-        violation.buildFix(fix, state, lastGroupedOccurrences.get(methodName));
-      }
-      return fix.build();
-    }
-
-    private Description.Builder buildAdaptedDescription() {
-      ImmutableSet<Name> methodNames =
-          violations.stream().map(OverloadViolation::getMethodName).collect(toImmutableSet());
-
-      if (methodNames.size() == 1) {
-        return buildMethodDescription(methodNames.iterator().next());
-      } else {
-        return buildClassDescription(methodNames);
-      }
-    }
-
-    private Description.Builder buildMethodDescription(Name methodName) {
-      MethodTree methodTree = getFirstOccurrences().get(methodName);
-      return buildDescription(methodTree).setMessage(getMethodFixMessage(methodTree));
-    }
-
-    private Description.Builder buildClassDescription(Collection<Name> methodNames) {
-      return buildDescription(classTree).setMessage(getClassFixMessage(methodNames));
-    }
-
-    /**
-     * Returns a mapping from a method name to the first (topmost) AST node matching this name.
-     *
-     * <p>For a class with methods {@code A}, {@code B} and {@code C} in the following order the
-     * marked nodes are considered to be "first occurrences":
-     *
-     * <pre>
-     * AABBBABCCAB
-     * ^ ^    ^
-     * </pre>
-     */
-    private ImmutableMap<Name, MethodTree> getFirstOccurrences() {
-      Map<Name, MethodTree> firstOccurrences = new LinkedHashMap<>();
-      for (Tree memberTree : classMembers) {
-        if (!(memberTree instanceof MethodTree)) {
-          continue;
-        }
-        MethodTree methodTree = (MethodTree) memberTree;
-        Name methodName = methodTree.getName();
-
-        firstOccurrences.computeIfAbsent(methodName, __ -> methodTree);
-      }
-      return ImmutableMap.copyOf(firstOccurrences);
-    }
-
-    /**
-     * Returns a mapping from a method name to the last grouped AST node matching this name.
-     *
-     * <p>For a class with methods {@code A}, {@code B} and {@code C} in the following order the
-     * marked nodes are considered to be "last grouped occurrences":
-     *
-     * <pre>
-     * AABBBABCCAB
-     *  ^  ^   ^
-     * </pre>
-     */
-    private ImmutableMap<Name, MethodTree> getLastGroupedOccurrences() {
-      Map<Name, Integer> lastGroupedOccurrences = new LinkedHashMap<>();
-      for (int i = 0; i < classMembers.size(); i++) {
-        Tree memberTree = classMembers.get(i);
-        if (!(memberTree instanceof MethodTree)) {
-          continue;
-        }
-        MethodTree methodTree = (MethodTree) memberTree;
-        Name methodName = methodTree.getName();
-
-        Integer lastGroupedOccurrence = lastGroupedOccurrences.get(methodName);
-        if (lastGroupedOccurrence == null || lastGroupedOccurrence + 1 == i) {
-          lastGroupedOccurrences.put(methodName, i);
-        }
-      }
-      return transformMap(lastGroupedOccurrences, (index) -> (MethodTree) classMembers.get(index));
-    }
-  }
-
-  /**
-   * Transforms each value in the given {@code input} map using the {@code mapper} function.
-   *
-   * @return a new map with transformed values
-   */
-  private static <K, V1, V2> ImmutableMap<K, V2> transformMap(
-      Map<K, V1> input, Function<? super V1, ? extends V2> mapper) {
-    return input
-        .entrySet()
+    // build a fix that deletes all but the first overload, and adds them back immediately after
+    // the first overload
+    SuggestedFix.Builder fixBuilder = SuggestedFix.builder();
+    StringBuilder sb = new StringBuilder("\n");
+    overloads
         .stream()
-        .collect(toImmutableMap(Map.Entry::getKey, entry -> mapper.apply(entry.getValue())));
-  }
-
-  private static String getMethodFixMessage(MethodTree methodTree) {
-    return String.format("Overloads of '%s' are not grouped together", methodTree.getName());
-  }
-
-  private static String getClassFixMessage(Collection<Name> methodNames) {
-    String methods =
-        methodNames
-            .stream()
-            .map(methodName -> String.format("\"%s\"", methodName.toString()))
-            .sorted()
-            .collect(Collectors.joining(", "));
-    return String.format("Overloaded methods (%s) of this class are not grouped together", methods);
+        .filter(o -> o != first)
+        .forEach(
+            o -> {
+              sb.append(state.getSourceForNode(o.tree())).append('\n');
+              fixBuilder.delete(o.tree());
+            });
+    fixBuilder.postfixWith(first.tree(), sb.toString());
+    SuggestedFix fix = fixBuilder.build();
+    String message = String.format("Overloads of '%s' are not grouped together.", name);
+    // emit findings for each overload
+    overloads
+        .stream()
+        .forEach(
+            o ->
+                state.reportMatch(
+                    buildDescription(o.tree()).addFix(fix).setMessage(message).build()));
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MethodCanBeStaticTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MethodCanBeStaticTest.java
@@ -16,6 +16,7 @@
 
 package com.google.errorprone.bugpatterns;
 
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -267,6 +268,32 @@ public class MethodCanBeStaticTest {
             "  private void readObjectNoData() throws ObjectStreamException {}",
             "  private Object readResolve() { return null; }",
             "  private Object writeReplace() { return null; }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void methodReference() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(new MethodCanBeStatic(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "import java.util.function.ToIntBiFunction;",
+            "class Test {",
+            "  private int add(int x, int y) {",
+            "    return x + y;",
+            "  }",
+            "  ToIntBiFunction<Integer, Integer> f = this::add;",
+            "  ToIntBiFunction<Integer, Integer> g = (x, y) -> this.add(x, y);",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "import java.util.function.ToIntBiFunction;",
+            "class Test {",
+            "  private static int add(int x, int y) {",
+            "    return x + y;",
+            "  }",
+            "  ToIntBiFunction<Integer, Integer> f = Test::add;",
+            "  ToIntBiFunction<Integer, Integer> g = (x, y) -> Test.add(x, y);",
             "}")
         .doTest();
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UngroupedOverloadsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UngroupedOverloadsTest.java
@@ -16,13 +16,8 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
-import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
-
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
-import com.google.errorprone.BugPattern;
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,84 +27,35 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class UngroupedOverloadsTest {
 
-  /**
-   * Specialized version of the {@link UngroupedOverloads} bug checker for testing with a low cutoff
-   * limit set.
-   *
-   * <p>This class needs to be public because of the limitation of {@link CompilationTestHelper}.
-   */
-  @BugPattern(
-    name = "UngroupedOverloadsLowCutoff",
-    summary = "A specialized version of the ungrouped overloads checker with a low cutoff limit",
-    category = JDK,
-    severity = SUGGESTION
-  )
-  public static final class UngroupedOverloadsLowCutoff extends UngroupedOverloads {
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(UngroupedOverloads.class, getClass());
 
-    public UngroupedOverloadsLowCutoff() {
-      super(5);
-    }
-  }
-
-  private CompilationTestHelper compilationHelper;
-  private CompilationTestHelper cutoffCompilationHelper;
-
-  private BugCheckerRefactoringTestHelper refactoringHelper;
-  private BugCheckerRefactoringTestHelper cutoffRefactoringHelper;
-
-  @Before
-  public void createCompilationHelpers() {
-    compilationHelper = createCompilationHelper(UngroupedOverloads.class);
-    cutoffCompilationHelper = createCompilationHelper(UngroupedOverloadsLowCutoff.class);
-  }
-
-  private CompilationTestHelper createCompilationHelper(Class<? extends BugChecker> bugChecker) {
-    return CompilationTestHelper.newInstance(bugChecker, getClass());
-  }
-
-  @Before
-  public void createRefactoringHelper() {
-    refactoringHelper = createRefactoringHelper(new UngroupedOverloads());
-    cutoffRefactoringHelper = createRefactoringHelper(new UngroupedOverloadsLowCutoff());
-  }
-
-  private BugCheckerRefactoringTestHelper createRefactoringHelper(BugChecker bugChecker) {
-    return BugCheckerRefactoringTestHelper.newInstance(bugChecker, getClass());
-  }
+  private final BugCheckerRefactoringTestHelper refactoringHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new UngroupedOverloads(), getClass());
 
   @Test
   public void ungroupedOverloadsPositiveCasesSingle() throws Exception {
-    final String path = "UngroupedOverloadsPositiveCasesSingle.java";
-    compilationHelper.addSourceFile(path).doTest();
-    cutoffCompilationHelper.addSourceFile(path).doTest();
+    compilationHelper.addSourceFile("UngroupedOverloadsPositiveCasesSingle.java").doTest();
   }
 
   @Test
   public void ungroupedOverloadsPositiveCasesMultiple() throws Exception {
-    final String path = "UngroupedOverloadsPositiveCasesMultiple.java";
-    compilationHelper.addSourceFile(path).doTest();
-    cutoffCompilationHelper.addSourceFile(path).doTest();
+    compilationHelper.addSourceFile("UngroupedOverloadsPositiveCasesMultiple.java").doTest();
   }
 
   @Test
   public void ungroupedOverloadsPositiveCasesInterleaved() throws Exception {
-    final String path = "UngroupedOverloadsPositiveCasesInterleaved.java";
-    compilationHelper.addSourceFile(path).doTest();
-    cutoffCompilationHelper.addSourceFile(path).doTest();
+    compilationHelper.addSourceFile("UngroupedOverloadsPositiveCasesInterleaved.java").doTest();
   }
 
   @Test
   public void ungroupedOverloadsPositiveCasesCovering() throws Exception {
-    final String path = "UngroupedOverloadsPositiveCasesCovering.java";
-    compilationHelper.addSourceFile(path).doTest();
-    cutoffCompilationHelper.addSourceFile(path).doTest();
+    compilationHelper.addSourceFile("UngroupedOverloadsPositiveCasesCovering.java").doTest();
   }
 
   @Test
   public void ungroupedOverloadsNegativeCases() throws Exception {
-    final String path = "UngroupedOverloadsNegativeCases.java";
-    compilationHelper.addSourceFile(path).doTest();
-    cutoffCompilationHelper.addSourceFile(path).doTest();
+    compilationHelper.addSourceFile("UngroupedOverloadsNegativeCases.java").doTest();
   }
 
   @Test
@@ -139,7 +85,7 @@ public final class UngroupedOverloadsTest {
   @Test
   public void ungroupedOverloadsRefactoringBelowCutoffLimit() throws Exception {
     // Here we have 4 methods so refactoring should be applied.
-    cutoffRefactoringHelper
+    refactoringHelper
         .addInputLines(
             "in/BelowLimit.java",
             "class BelowLimit {",
@@ -160,9 +106,8 @@ public final class UngroupedOverloadsTest {
   }
 
   @Test
-  public void ungroupedOverloadsRefactoringAboveCutoffLimit() throws Exception {
-    // Here we have 5 methods so refactoring should NOT be applied.
-    cutoffRefactoringHelper
+  public void ungroupedOverloadsRefactoring_fiveMethods() throws Exception {
+    refactoringHelper
         .addInputLines(
             "in/AboveLimit.java",
             "class AboveLimit {",
@@ -177,8 +122,8 @@ public final class UngroupedOverloadsTest {
             "class AboveLimit {",
             "  AboveLimit() {}",
             "  void foo() {}",
-            "  void bar() {}",
             "  void foo(int x) {}",
+            "  void bar() {}",
             "  void baz() {}",
             "}")
         .doTest();
@@ -201,7 +146,7 @@ public final class UngroupedOverloadsTest {
 
   @Test
   public void staticAndNonStaticInterspersed() throws Exception {
-    cutoffCompilationHelper
+    compilationHelper
         .addSourceLines(
             "Test.java",
             "class Test {",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ConstructorLeaksThisNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ConstructorLeaksThisNegativeCases.java
@@ -97,4 +97,13 @@ public class ConstructorLeaksThisNegativeCases {
     @SuppressWarnings("ConstructorLeaksThis")
     final FixtureController that = new FixtureController(this);
   }
+
+  static final class WithTwoConstructors {
+    public WithTwoConstructors() {
+      // 'this' references another constructor, not an object
+      this(0);
+    }
+
+    public WithTwoConstructors(int i) {}
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/URLEqualsHashCodePositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/URLEqualsHashCodePositiveCases.java
@@ -16,6 +16,9 @@
 
 package com.google.errorprone.bugpatterns.testdata;
 
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableSet;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -81,5 +84,29 @@ public class URLEqualsHashCodePositiveCases {
 
     // BUG: Diagnostic contains: java.net.URL
     Map urlMap = new ExtendedMap();
+  }
+
+  public void hashBiMapOfURL() {
+    // BUG: Diagnostic contains: java.net.URL
+    BiMap<URL, String> urlBiMap = HashBiMap.create();
+
+    // BUG: Diagnostic contains: java.net.URL
+    BiMap<String, URL> toUrlBiMap = HashBiMap.create();
+  }
+
+  public void hashBiMapOfCompleteURL() {
+    // BUG: Diagnostic contains: java.net.URL
+    HashBiMap<java.net.URL, String> urlBiMap = HashBiMap.create();
+
+    // BUG: Diagnostic contains: java.net.URL
+    HashBiMap<String, java.net.URL> toUrlBiMap = HashBiMap.create();
+  }
+
+  public void immutableSetOfURL() {
+    // BUG: Diagnostic contains: java.net.URL
+    ImmutableSet<URL> urlSet = ImmutableSet.of();
+
+    // BUG: Diagnostic contains: java.net.URL
+    ImmutableSet<URL> urlSet2 = ImmutableSet.<URL>builder().build();
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UngroupedOverloadsPositiveCasesCovering.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UngroupedOverloadsPositiveCasesCovering.java
@@ -17,14 +17,14 @@
 package com.google.errorprone.bugpatterns.testdata;
 
 /** @author hanuszczak@google.com (Łukasz Hanuszczak) */
-// BUG: Diagnostic contains: Overloaded methods ("bar", "foo", "quux") of this class are not grouped
-// together
 public class UngroupedOverloadsPositiveCasesCovering {
 
+  // BUG: Diagnostic contains: Overloads of 'foo' are not grouped together
   public void foo(int x) {
     System.out.println(x);
   }
 
+  // BUG: Diagnostic contains: Overloads of 'bar' are not grouped together
   public void bar() {
     foo();
   }
@@ -33,10 +33,12 @@ public class UngroupedOverloadsPositiveCasesCovering {
     bar();
   }
 
+  // BUG: Diagnostic contains: Overloads of 'bar' are not grouped together
   public void bar(int x) {
     foo(x);
   }
 
+  // BUG: Diagnostic contains: Overloads of 'quux' are not grouped together
   private void quux() {
     norf();
   }
@@ -45,10 +47,12 @@ public class UngroupedOverloadsPositiveCasesCovering {
     quux();
   }
 
+  // BUG: Diagnostic contains: Overloads of 'quux' are not grouped together
   public void quux(int x) {
     bar(x);
   }
 
+  // BUG: Diagnostic contains: Overloads of 'foo' are not grouped together
   public void foo() {
     foo(42);
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UngroupedOverloadsPositiveCasesInterleaved.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UngroupedOverloadsPositiveCasesInterleaved.java
@@ -17,12 +17,11 @@
 package com.google.errorprone.bugpatterns.testdata;
 
 /** @author hanuszczak@google.com (Łukasz Hanuszczak) */
-// BUG: Diagnostic contains: Overloaded methods ("bar", "baz") of this class are not grouped
-// together
 public class UngroupedOverloadsPositiveCasesInterleaved {
 
   private int foo;
 
+  // BUG: Diagnostic contains: Overloads of 'bar' are not grouped together
   public void bar(int x, String z, int y) {
     System.out.println(String.format("z: %s, x: %d, y: %d", z, x, y));
   }
@@ -31,20 +30,24 @@ public class UngroupedOverloadsPositiveCasesInterleaved {
     this.foo = foo;
   }
 
+  // BUG: Diagnostic contains: Overloads of 'bar' are not grouped together
   public void bar(int x) {
     bar(foo, x);
   }
 
+  // BUG: Diagnostic contains: Overloads of 'baz' are not grouped together
   public void baz(String x) {
     baz(x, FOO);
   }
 
+  // BUG: Diagnostic contains: Overloads of 'bar' are not grouped together
   public void bar(int x, int y) {
     bar(y, FOO, x);
   }
 
   public static final String FOO = "foo";
 
+  // BUG: Diagnostic contains: Overloads of 'baz' are not grouped together
   public void baz(String x, String y) {
     bar(foo, x + y, foo);
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UngroupedOverloadsPositiveCasesMultiple.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UngroupedOverloadsPositiveCasesMultiple.java
@@ -17,12 +17,11 @@
 package com.google.errorprone.bugpatterns.testdata;
 
 /** @author hanuszczak@google.com (Łukasz Hanuszczak) */
-// BUG: Diagnostic contains: Overloaded methods ("bar", "norf", "quux") of this class are not
-// grouped together
 public class UngroupedOverloadsPositiveCasesMultiple {
 
   private int foo;
 
+  // BUG: Diagnostic contains: Overloads of 'bar' are not grouped together
   public void bar(int x, String z, int y) {
     System.out.println(String.format("z: %s, x: %d, y: %d", z, x, y));
   }
@@ -31,6 +30,7 @@ public class UngroupedOverloadsPositiveCasesMultiple {
     this.foo = foo;
   }
 
+  // BUG: Diagnostic contains: Overloads of 'bar' are not grouped together
   public void bar(int x) {
     bar(foo, x);
   }
@@ -39,36 +39,43 @@ public class UngroupedOverloadsPositiveCasesMultiple {
     bar(42, x, 42);
   }
 
+  // BUG: Diagnostic contains: Overloads of 'bar' are not grouped together
   public void bar(int x, int y) {
     bar(y, FOO, x);
   }
 
   public static final String FOO = "foo";
 
+  // BUG: Diagnostic contains: Overloads of 'bar' are not grouped together
   public void bar(int x, int y, int z) {
     bar(x, String.valueOf(y), z);
   }
 
+  // BUG: Diagnostic contains: Overloads of 'quux' are not grouped together
   public int quux() {
     return quux(quux);
   }
 
   public int quux = 42;
 
+  // BUG: Diagnostic contains: Overloads of 'quux' are not grouped together
   public int quux(int x) {
     return x + quux;
   }
 
   private static class Quux {}
 
+  // BUG: Diagnostic contains: Overloads of 'quux' are not grouped together
   public int quux(int x, int y) {
     return quux(x + y);
   }
 
+  // BUG: Diagnostic contains: Overloads of 'norf' are not grouped together
   public int norf(int x) {
     return quux(x, x);
   }
 
+  // BUG: Diagnostic contains: Overloads of 'norf' are not grouped together
   public int norf(int x, int y) {
     return norf(x + y);
   }
@@ -77,6 +84,7 @@ public class UngroupedOverloadsPositiveCasesMultiple {
     System.out.println("foo");
   }
 
+  // BUG: Diagnostic contains: Overloads of 'norf' are not grouped together
   public void norf(int x, int y, int w) {
     norf(x + w, y + w);
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UngroupedOverloadsPositiveCasesSingle.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UngroupedOverloadsPositiveCasesSingle.java
@@ -28,6 +28,7 @@ public class UngroupedOverloadsPositiveCasesSingle {
     foo(42);
   }
 
+  // BUG: Diagnostic contains: Overloads of 'foo' are not grouped together
   public void foo(int x) {
     foo(x, x);
   }
@@ -40,6 +41,7 @@ public class UngroupedOverloadsPositiveCasesSingle {
     foo(x);
   }
 
+  // BUG: Diagnostic contains: Overloads of 'foo' are not grouped together
   public void foo(int x, int y) {
     System.out.println(x + y);
   }

--- a/core/src/test/java/com/google/errorprone/matchers/MatchersTest.java
+++ b/core/src/test/java/com/google/errorprone/matchers/MatchersTest.java
@@ -64,6 +64,16 @@ public class MatchersTest {
       fail("Expected an IAE to be throw but wasn't");
     } catch (IllegalArgumentException expected) {
     }
+    try {
+      Matchers.instanceMethod().onExactClass("java.lang.String").named("getBytes)");
+      fail("Expected an IAE to be throw but wasn't");
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      Matchers.instanceMethod().onExactClass("java.lang.String").named("getBytes(");
+      fail("Expected an IAE to be throw but wasn't");
+    } catch (IllegalArgumentException expected) {
+    }
   }
 
   @Test

--- a/core/src/test/java/com/google/errorprone/scanner/ScannerSupplierTest.java
+++ b/core/src/test/java/com/google/errorprone/scanner/ScannerSupplierTest.java
@@ -21,11 +21,15 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.scanner.BuiltInCheckerSuppliers.getSuppliers;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.expectThrows;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.jimfs.Jimfs;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.Subject;
 import com.google.errorprone.BugCheckerInfo;
@@ -48,9 +52,23 @@ import com.google.errorprone.bugpatterns.PreconditionsCheckNotNull;
 import com.google.errorprone.bugpatterns.RestrictedApiChecker;
 import com.google.errorprone.bugpatterns.StaticQualifiedUsingExpression;
 import com.google.errorprone.bugpatterns.StringEquality;
+import com.sun.source.util.JavacTask;
+import com.sun.tools.javac.api.JavacTool;
+import com.sun.tools.javac.file.JavacFileManager;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
+import javax.tools.JavaFileObject.Kind;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardLocation;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -96,16 +114,126 @@ public class ScannerSupplierTest {
             PreconditionsCheckNotNull.class);
   }
 
+  // Allow different instances of classes to be merged, provided they have the same name.
+  // This allows e.g. seeing the same check built in to Error Prone and loaded on the
+  // processorpath.
   @Test
-  public void plusDoesntAllowDuplicateChecks() {
-    ScannerSupplier ss1 =
-        ScannerSupplier.fromBugCheckerClasses(
-            ArrayEquals.class, StaticQualifiedUsingExpression.class);
-    ScannerSupplier ss2 = ScannerSupplier.fromBugCheckerClasses(ArrayEquals.class);
+  public void plusAllowsDuplicateClassLoading() throws Exception {
+    FileSystem fileSystem = Jimfs.newFileSystem();
 
-    IllegalArgumentException expected =
+    Class<? extends BugChecker> class1 =
+        compileAndLoadChecker(
+            fileSystem,
+            "com.google.errorprone.bugpatterns.TestChecker",
+            "package com.google.errorprone.bugpatterns;",
+            "import com.google.errorprone.BugPattern;",
+            "@BugPattern(name = \"TestChecker\", summary = \"\","
+                + " severity = BugPattern.SeverityLevel.WARNING)",
+            "public class TestChecker extends BugChecker {}");
+
+    Class<? extends BugChecker> class2 =
+        compileAndLoadChecker(
+            fileSystem,
+            "com.google.errorprone.bugpatterns.TestChecker",
+            "package com.google.errorprone.bugpatterns;",
+            "import com.google.errorprone.BugPattern;",
+            "@BugPattern(name = \"TestChecker\", summary = \"\","
+                + " severity = BugPattern.SeverityLevel.WARNING)",
+            "public class TestChecker extends BugChecker {}");
+
+    ScannerSupplier ss1 = ScannerSupplier.fromBugCheckerClasses(class1);
+    ScannerSupplier ss2 = ScannerSupplier.fromBugCheckerClasses(class2);
+
+    assertThat(class1).isNotEqualTo(class2);
+    ScannerSupplier ss = ss1.plus(ss2);
+    assertThat(ss.getAllChecks()).hasSize(1);
+    assertThat(Iterables.getOnlyElement(ss.getAllChecks().values()).checkerClass())
+        .isEqualTo(class1);
+  }
+
+  /** Another check with the canonical name ArrayEquals, for testing. */
+  @BugPattern(name = "ArrayEquals", summary = "", severity = ERROR)
+  public static class OtherArrayEquals extends BugChecker {}
+
+  @Test
+  public void plusDisallowsDuplicates() throws Exception {
+    ScannerSupplier ss1 = ScannerSupplier.fromBugCheckerClasses(ArrayEquals.class);
+    ScannerSupplier ss2 = ScannerSupplier.fromBugCheckerClasses(OtherArrayEquals.class);
+
+    IllegalArgumentException thrown =
         expectThrows(IllegalArgumentException.class, () -> ss1.plus(ss2));
-    assertThat(expected.getMessage()).contains("ArrayEquals");
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains(
+            "different implementations of 'ArrayEquals':"
+                + " com.google.errorprone.scanner.ScannerSupplierTest$OtherArrayEquals,"
+                + " com.google.errorprone.bugpatterns.ArrayEquals");
+  }
+
+  @Test
+  public void plusDisallowsDifferentSeverities() throws Exception {
+    FileSystem fileSystem = Jimfs.newFileSystem();
+
+    Class<? extends BugChecker> class1 =
+        compileAndLoadChecker(
+            fileSystem,
+            "com.google.errorprone.bugpatterns.TestChecker",
+            "package com.google.errorprone.bugpatterns;",
+            "import com.google.errorprone.BugPattern;",
+            "@BugPattern(name = \"TestChecker\", summary = \"\","
+                + " severity = BugPattern.SeverityLevel.ERROR)",
+            "public class TestChecker extends BugChecker {}");
+
+    Class<? extends BugChecker> class2 =
+        compileAndLoadChecker(
+            fileSystem,
+            "com.google.errorprone.bugpatterns.TestChecker",
+            "package com.google.errorprone.bugpatterns;",
+            "import com.google.errorprone.BugPattern;",
+            "@BugPattern(name = \"TestChecker\", summary = \"\","
+                + " severity = BugPattern.SeverityLevel.WARNING)",
+            "public class TestChecker extends BugChecker {}");
+
+    ScannerSupplier ss1 = ScannerSupplier.fromBugCheckerClasses(class1);
+    ScannerSupplier ss2 = ScannerSupplier.fromBugCheckerClasses(class2);
+
+    IllegalArgumentException thrown =
+        expectThrows(IllegalArgumentException.class, () -> ss1.plus(ss2));
+
+    assertThat(class1).isNotEqualTo(class2);
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("different severities for 'TestChecker': WARNING, ERROR");
+  }
+
+  static Class<? extends BugChecker> compileAndLoadChecker(
+      FileSystem fileSystem, String name, String... lines)
+      throws IOException, ClassNotFoundException {
+    JavacTool javacTool = JavacTool.create();
+    JavacFileManager fileManager =
+        javacTool.getStandardFileManager(null, Locale.getDefault(), UTF_8);
+    Path tmp = fileSystem.getPath("tmp");
+    Files.createDirectories(tmp);
+    Path output = Files.createTempDirectory(tmp, "output");
+    fileManager.setLocationFromPaths(StandardLocation.CLASS_OUTPUT, ImmutableList.of(output));
+    JavacTask task =
+        javacTool.getTask(
+            null,
+            fileManager,
+            null,
+            Collections.emptyList(),
+            null,
+            Collections.singletonList(
+                new SimpleJavaFileObject(
+                    URI.create(name.replace('.', '/') + ".java"), Kind.SOURCE) {
+                  @Override
+                  public CharSequence getCharContent(boolean b) throws IOException {
+                    return Joiner.on('\n').join(lines);
+                  }
+                }));
+    assertThat(task.call()).isTrue();
+    return Class.forName(name, true, new URLClassLoader(new URL[] {output.toUri().toURL()}))
+        .asSubclass(BugChecker.class);
   }
 
   @Test

--- a/docs/bugpattern/DateFormatConstant.md
+++ b/docs/bugpattern/DateFormatConstant.md
@@ -1,4 +1,4 @@
-[`DateFormat`][] is not thread-safe. The documentation recommendeds creating
+[`DateFormat`][] is not thread-safe. The documentation recommends creating
 separate format instances for each thread. If multiple threads access a format
 concurrently, it must be synchronized externally.
 

--- a/examples/gradle/build.gradle
+++ b/examples/gradle/build.gradle
@@ -1,11 +1,14 @@
 // See https://github.com/tbroyer/gradle-errorprone-plugin
 plugins {
   id 'java'
-  id 'net.ltgt.errorprone' version '0.0.11'
+  id 'net.ltgt.errorprone' version '0.0.13'
 }
 repositories {
   mavenCentral()
+  maven {
+    url "https://oss.sonatype.org/content/repositories/snapshots/"
+  }
 }
 dependencies {
-  errorprone 'com.google.errorprone:error_prone_core:2.2.0'
+  errorprone 'com.google.errorprone:error_prone_core:2.2.1-SNAPSHOT'
 }

--- a/examples/plugin/gradle/build.gradle
+++ b/examples/plugin/gradle/build.gradle
@@ -1,15 +1,8 @@
 // See https://github.com/tbroyer/gradle-errorprone-plugin
 // See https://github.com/tbroyer/gradle-apt-plugin
-buildscript {
-  repositories {
-    maven {
-      url "https://plugins.gradle.org/m2/"
-    }
-  }
-  dependencies {
-    classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.8"
-    classpath "net.ltgt.gradle:gradle-apt-plugin:0.6"
-  }
+plugins {
+  id 'net.ltgt.errorprone' version '0.0.13' apply false
+  id 'net.ltgt.apt' version '0.14' apply false
 }
 
 subprojects {
@@ -24,7 +17,7 @@ subprojects {
   apply plugin: 'net.ltgt.errorprone'
   apply plugin: 'net.ltgt.apt'
 
-  configurations.errorprone {
-    resolutionStrategy.force 'com.google.errorprone:error_prone_core:2.2.1-SNAPSHOT'
+  dependencies {
+    errorprone 'com.google.errorprone:error_prone_core:2.2.1-SNAPSHOT'
   }
 }

--- a/examples/plugin/gradle/hello/build.gradle
+++ b/examples/plugin/gradle/hello/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  apt project(':sample_plugin')
+  annotationProcessor project(':sample_plugin')
 }

--- a/examples/plugin/gradle/sample_plugin/build.gradle
+++ b/examples/plugin/gradle/sample_plugin/build.gradle
@@ -2,6 +2,6 @@ dependencies {
   compileOnly 'com.google.errorprone:error_prone_core:2.2.1-SNAPSHOT'
   compileOnly 'com.google.errorprone:error_prone_annotation:2.2.1-SNAPSHOT'
 
-  compileOnly 'com.google.auto.service:auto-service:1.0-rc2'
-  apt         'com.google.auto.service:auto-service:1.0-rc2'
+  compileOnly         'com.google.auto.service:auto-service:1.0-rc4'
+  annotationProcessor 'com.google.auto.service:auto-service:1.0-rc4'
 }

--- a/test_helpers/pom.xml
+++ b/test_helpers/pom.xml
@@ -139,7 +139,7 @@
       <!-- Apache 2.0 -->
       <groupId>com.google.jimfs</groupId>
       <artifactId>jimfs</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
     </dependency>
     <dependency>
       <!-- Apache 2.0 -->


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't batch UngroupedOverload findings

Instead, emit one find (and fix) for each method. This makes the findings more
useful if they are only shown on changed lines, since we don't know which method
was added by the change.

RELNOTES: N/A

0657c99775d02b42f8e5c32e6cff30fef2022fe7

-------

<p> Also accept ErrorProne @GuardedBy

88906c96b1745902ae85e5312000f49108c40d77

-------

<p> Disallow BugPattern names that includes spaces.

RELNOTES: Disallow Error Prone BugPattern names that includes spaces.

9b5899cd8f1cd4ed0a6f22df0171fb0fd3695a01

-------

<p> Fix qualified method access in MethodCanBeStatic

RELNOTES: N/A

cd5eab07aa6063907d9db0e0684d085814f739ce

-------

<p> Handle duplicates when merging ScannerSuppliers

Loading different implementations of a check is still disallowed, but we can now
tolerate e.g. loading the same check both as a built-in and as a plugin.

RELNOTES: N/A

1d65cf6592affe310132e971e1fab3764c2286eb

-------

<p> Prevent `ConstructorLeaksThis` false positive on constructor
reference

Fixes #789

RELNOTES: Fixed false positive in ConstructorLeaksThis

7fe83a2dd733d1cbc6a7abe6ce3f5046cad4b3a1

-------

<p> Recognize more `URLEqualsHashCode` violations

- Flag maps created using common factory methods.

Fixes #921

RELNOTES: N/A

062e0bc63e72e10b0eeba1f4846f19b837ce9b1b

-------

<p> Update Gradle examples

* use latest version of net.ltgt.apt plugin
 and its new annotationProcessor configuration
 (will be built into Gradle 4.6, no plugin needed)
* use errorprone snapshot version in examples/gradle
* use Gradle plugins DSL in examples/plugin/gradle
* use new way (as of net.ltgt.errorprone 0.0.9, which
 is already a bit old) of declaring errorprone
 dependency in examples/plugin/gradle
* update auto-service to latest version

Fixes #931

RELNOTES: N/A

4e538e092726e224f5015b7f50b0a659ac1d3d94

-------

<p> Fix small precondition bug in ErrorProne method matcher.

RELNOTES: none

b8aa4e51d5388e9802916749038ed4c688d3ab35

-------

<p> Fix minor typo in DateFormatConstant

fc0ff5f3f961b240a791dedb89b3013034da0279