### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/AssertionFailureIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AssertionFailureIgnored.java
@@ -16,6 +16,7 @@
 
 package com.google.errorprone.bugpatterns;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
@@ -34,17 +35,24 @@ import com.google.errorprone.fixes.Fix;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.google.errorprone.predicates.TypePredicates;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.ThrowTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
+import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.UnionClassType;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCCatch;
 import com.sun.tools.javac.tree.JCTree.JCExpressionStatement;
 import com.sun.tools.javac.tree.JCTree.JCTry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -67,6 +75,9 @@ public class AssertionFailureIgnored extends BugChecker implements MethodInvocat
           .onClassAny("org.junit.Assert", "junit.framework.Assert", "junit.framework.TestCase")
           .withNameMatching(Pattern.compile("fail|assert.*"));
 
+  private static final Matcher<ExpressionTree> NEW_THROWABLE =
+      MethodMatchers.constructor().forClass(TypePredicates.isDescendantOf("java.lang.Throwable"));
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (!ASSERTION.matches(tree, state)) {
@@ -76,7 +87,38 @@ public class AssertionFailureIgnored extends BugChecker implements MethodInvocat
     if (tryStatement == null) {
       return NO_MATCH;
     }
-    if (!catchesType(tryStatement, state.getSymtab().assertionErrorType, state)) {
+    Optional<JCCatch> maybeCatchTree =
+        catchesType(tryStatement, state.getSymtab().assertionErrorType, state);
+    if (!maybeCatchTree.isPresent()) {
+      return NO_MATCH;
+    }
+    JCCatch catchTree = maybeCatchTree.get();
+    VarSymbol parameter = ASTHelpers.getSymbol(catchTree.getParameter());
+    boolean rethrows =
+        firstNonNull(
+            new TreeScanner<Boolean, Void>() {
+              @Override
+              public Boolean visitThrow(ThrowTree tree, Void unused) {
+                if (Objects.equals(parameter, ASTHelpers.getSymbol(tree.getExpression()))) {
+                  return true;
+                }
+                if (NEW_THROWABLE.matches(tree.getExpression(), state)
+                    && ((NewClassTree) tree.getExpression())
+                        .getArguments()
+                        .stream()
+                        .anyMatch(arg -> Objects.equals(parameter, ASTHelpers.getSymbol(arg)))) {
+                  return true;
+                }
+                return super.visitThrow(tree, null);
+              }
+
+              @Override
+              public Boolean reduce(Boolean a, Boolean b) {
+                return firstNonNull(a, false) || firstNonNull(b, false);
+              }
+            }.scan(catchTree.getBlock(), null),
+            false);
+    if (rethrows) {
       return NO_MATCH;
     }
     Description.Builder description = buildDescription(tree);
@@ -152,18 +194,20 @@ public class AssertionFailureIgnored extends BugChecker implements MethodInvocat
     return Optional.of(fix.build());
   }
 
-  private static boolean catchesType(
+  private static Optional<JCCatch> catchesType(
       JCTry tryStatement, Type assertionErrorType, VisitorState state) {
     return tryStatement
         .getCatches()
         .stream()
-        .map(catchTree -> ASTHelpers.getType(catchTree.getParameter()))
-        .flatMap(
-            type ->
-                type.isUnion()
-                    ? Streams.stream(((UnionClassType) type).getAlternativeTypes())
-                    : Stream.of(type))
-        .anyMatch(caught -> isSubtype(assertionErrorType, caught, state));
+        .filter(
+            catchTree -> {
+              Type type = ASTHelpers.getType(catchTree.getParameter());
+              return (type.isUnion()
+                      ? Streams.stream(((UnionClassType) type).getAlternativeTypes())
+                      : Stream.of(type))
+                  .anyMatch(caught -> isSubtype(assertionErrorType, caught, state));
+            })
+        .findFirst();
   }
 
   private static JCTry enclosingTry(VisitorState state) {
@@ -183,3 +227,4 @@ public class AssertionFailureIgnored extends BugChecker implements MethodInvocat
     return null;
   }
 }
+

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringValidation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringValidation.java
@@ -21,6 +21,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ConditionalExpressionTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Type;
@@ -51,6 +52,7 @@ import java.util.MissingFormatArgumentException;
 import java.util.MissingFormatWidthException;
 import java.util.UnknownFormatConversionException;
 import java.util.UnknownFormatFlagsException;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.lang.model.type.TypeKind;
 
@@ -72,14 +74,28 @@ public class FormatStringValidation {
     }
   }
 
+  static Stream<String> constValues(Tree tree) {
+    if (tree instanceof ConditionalExpressionTree) {
+      ConditionalExpressionTree cond = (ConditionalExpressionTree) tree;
+      String t = ASTHelpers.constValue(cond.getTrueExpression(), String.class);
+      String f = ASTHelpers.constValue(cond.getFalseExpression(), String.class);
+      if (t == null || f == null) {
+        return null;
+      }
+      return Stream.of(t, f);
+    }
+    String r = ASTHelpers.constValue(tree, String.class);
+    return r != null ? Stream.of(r) : null;
+  }
+
   @Nullable
   public static ValidationResult validate(
       Collection<? extends ExpressionTree> arguments, final VisitorState state) {
 
     Deque<ExpressionTree> args = new ArrayDeque<>(arguments);
 
-    String formatString = ASTHelpers.constValue(args.removeFirst(), String.class);
-    if (formatString == null) {
+    Stream<String> formatStrings = constValues(args.removeFirst());
+    if (formatStrings == null) {
       return null;
     }
 
@@ -109,7 +125,11 @@ public class FormatStringValidation {
               }
             });
 
-    return validate(formatString, instances);
+    return formatStrings
+        .map(formatString -> validate(formatString, instances))
+        .filter(x -> x != null)
+        .findFirst()
+        .orElse(null);
   }
 
   /**

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/StrictFormatStringValidation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/StrictFormatStringValidation.java
@@ -39,6 +39,7 @@ import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import java.util.List;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.lang.model.element.ElementKind;
 
@@ -60,11 +61,11 @@ public class StrictFormatStringValidation {
       return null;
     }
 
-    String formatStringValue = ASTHelpers.constValue(formatStringTree, String.class);
+    Stream<String> formatStringValues = FormatStringValidation.constValues(formatStringTree);
 
     // If formatString has a constant value, then it couldn't have been an @FormatString parameter,
     // so don't bother with annotations and just check if the parameters match the format string.
-    if (formatStringValue != null) {
+    if (formatStringValues != null) {
       return FormatStringValidation.validate(
           ImmutableList.<ExpressionTree>builder().add(formatStringTree).addAll(args).build(),
           state);

--- a/core/src/test/java/com/google/errorprone/bugpatterns/AssertionFailureIgnoredTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/AssertionFailureIgnoredTest.java
@@ -55,6 +55,19 @@ public class AssertionFailureIgnoredTest {
             "      Assert.fail();",
             "    } catch (NoSuchFieldException | NoSuchMethodException | AssertionError t) {",
             "    }",
+            "    AssertionError e = null;",
+            "    try {",
+            "      // BUG: Diagnostic contains:",
+            "      Assert.fail();",
+            "    } catch (AssertionError t) {",
+            "      throw e;",
+            "    }",
+            "    try {",
+            "      // BUG: Diagnostic contains:",
+            "      Assert.fail();",
+            "    } catch (AssertionError t) {",
+            "      throw new AssertionError(e);",
+            "    }",
             "  }",
             "}")
         .doTest();
@@ -87,6 +100,16 @@ public class AssertionFailureIgnoredTest {
             "    try {",
             "    } catch (Throwable t) {",
             "      Assert.fail();",
+            "    }",
+            "    try {",
+            "      Assert.fail();",
+            "    } catch (AssertionError t) {",
+            "      throw t;",
+            "    }",
+            "    try {",
+            "      Assert.fail();",
+            "    } catch (AssertionError t) {",
+            "      throw new AssertionError(t);",
             "    }",
             "  }",
             "}")
@@ -232,3 +255,4 @@ public class AssertionFailureIgnoredTest {
         .doTest();
   }
 }
+

--- a/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringTest.java
@@ -114,6 +114,20 @@ public class FormatStringTest {
   }
 
   @Test
+  public void testConditionalExpression() throws Exception {
+    testFormat(
+        "missing argument for format specifier '%s'", "String.format(true ? \"\" : \"%s\");");
+    testFormat(
+        "missing argument for format specifier '%s'", "String.format(true ? \"%s\" : \"\");");
+    testFormat(
+        "extra format arguments: used 1, provided 2",
+        "String.format(true ? \"%s\" : \"%s\", 1, 2);");
+    testFormat(
+        "extra format arguments: used 1, provided 2",
+        "String.format(true ? \"%s\" : \"%s\", 1, 2);");
+  }
+
+  @Test
   public void missingArguments() throws Exception {
     compilationHelper
         .addSourceLines(
@@ -155,7 +169,7 @@ public class FormatStringTest {
         .addSourceLines(
             "Test.java",
             "class Test {",
-            "  void f() {",
+            "  void f(boolean b) {",
             "    String.format(\"%d\", 42);",
             "    String.format(\"%d\", 42L);",
             "    String.format(\"%f\", 42.0f);",
@@ -165,6 +179,7 @@ public class FormatStringTest {
             "    String.format(\"%s\", (Object) null);",
             "    String.format(\"%s\", new Object());",
             "    String.format(\"%c\", 'c');",
+            "    String.format(b ? \"%s\" : \"%d\", 42);",
             "  }",
             "}")
         .doTest();


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add support for conditional expressions to format string validation

to enable checking e.g. `format(flag ? "one %s" : "two %s", 42)`.

RELNOTES: N/A

6b23fb3c7203b3fe5cf27babebe0a93c0bfcdcf3

-------

<p> Handle rethrown exceptions in AssertionFailureIgnored

RELNOTES: N/A

e6044000c4d66936baac061ccaf9e18a4740d160