### PR TITLE
Relocate com.google classes in Ant artifact, excluding Error Prone classes

### DIFF
--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -66,6 +66,15 @@
                   <exclude>org.apache.ant:ant-launcher</exclude>
                 </excludes>
               </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.google</pattern>
+                  <shadedPattern>shaded.com.google</shadedPattern>
+                  <excludes>
+                    <exclude>com.google.errorprone.**</exclude>
+                  </excludes>
+                </relocation>
+              </relocations>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>2.1</version>
+          <version>3.1.0</version>
           <configuration>
             <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
           </configuration>


### PR DESCRIPTION
Context: we have Error Prone integrated with Buck, leveraging the `error_prone_ant` shaded jar and Buck's [javac_jar](https://buckbuild.com/concept/buckconfig.html#tools.javac_jar) setting.  One issue with the integration is that if annotation processors use a more recent version of Guava than what EP is using, the version in the shaded jar wins.  This change relocates all `com.google` classes in the EP jar except for the `com.google.errorprone` classes (which need to be accessed by plugin checks).
This change should prevent the most common conflicts with annotation processors and EP plugin checks.