### PR TITLE
Use valueOf method instead of constructor since valueOf is likely to …

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/LambdaFunctionalInterfacePositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/LambdaFunctionalInterfacePositiveCases.java
@@ -165,7 +165,7 @@ public class LambdaFunctionalInterfacePositiveCases {
 
     // BUG: Diagnostic contains: [LambdaFunctionalInterface]
     private <T> int sumAll(Function<T, Integer> sizeConv) {
-      return sizeConv.apply((T) new Integer(3));
+      return sizeConv.apply((T) Integer.valueOf(3));
     }
 
     public int getSumAll() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/NullablePrimitiveNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/NullablePrimitiveNegativeCases.java
@@ -26,6 +26,6 @@ public class NullablePrimitiveNegativeCases {
 
   @Nullable
   public Integer method() {
-    return new Integer(0);
+    return Integer.valueOf(0);
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/NumericEqualityPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/NumericEqualityPositiveCases.java
@@ -27,7 +27,7 @@ public class NumericEqualityPositiveCases {
 
     // BUG: Diagnostic contains: !Objects.equals(x, y)
     retVal = (x != y);
-    final Integer constValue = new Integer(1000);
+    final Integer constValue = Integer.valueOf(1000);
 
     // BUG: Diagnostic contains: Objects.equals(x, constValue)
     retVal = (x == constValue);
@@ -46,7 +46,7 @@ public class NumericEqualityPositiveCases {
 
     // BUG: Diagnostic contains: !Objects.equals(x, y)
     retVal = (x != y);
-    final Long constValue = new Long(1000L);
+    final Long constValue = Long.valueOf(1000L);
 
     // BUG: Diagnostic contains: Objects.equals(x, constValue)
     retVal = (x == constValue);
@@ -65,7 +65,7 @@ public class NumericEqualityPositiveCases {
 
     // BUG: Diagnostic contains: !Objects.equals(x, y)
     retVal = (x != y);
-    final Number constValue = new Long(1000L);
+    final Number constValue = Long.valueOf(1000L);
 
     // BUG: Diagnostic contains: Objects.equals(x, constValue)
     retVal = (x == constValue);

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/StaticQualifiedUsingExpressionPositiveCase1.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/StaticQualifiedUsingExpressionPositiveCase1.java
@@ -77,7 +77,7 @@ public class StaticQualifiedUsingExpressionPositiveCase1 {
 
   public void test2() {
     int i;
-    Integer integer = new Integer(1);
+    Integer integer = Integer.valueOf(1);
     // BUG: Diagnostic contains: variable MAX_VALUE
     // i = Integer.MAX_VALUE
     i = integer.MAX_VALUE;


### PR DESCRIPTION
…yield significantly better space and time performance by caching frequently requested values.