### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/CatchAndPrintStackTrace.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CatchAndPrintStackTrace.java
@@ -43,9 +43,7 @@ public class CatchAndPrintStackTrace extends BugChecker implements CatchTreeMatc
 
   private static final Matcher<StatementTree> MATCHER =
       expressionStatement(
-          instanceMethod()
-              .onDescendantOf("java.lang.Throwable")
-              .withSignature("printStackTrace()"));
+          instanceMethod().onDescendantOf("java.lang.Throwable").named("printStackTrace"));
 
   @Override
   public Description matchCatch(CatchTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InputStreamSlowMultibyteRead.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InputStreamSlowMultibyteRead.java
@@ -111,12 +111,15 @@ public class InputStreamSlowMultibyteRead extends BugChecker implements ClassTre
   private Description maybeMatchReadByte(MethodTree readByteMethod, VisitorState state) {
     // Methods that return a constant expression are likely to be 'dummy streams', for which
     // the multibyte read is OK.
-    List<? extends StatementTree> statements = readByteMethod.getBody().getStatements();
-    if (statements.size() == 1) {
-      Tree tree = statements.get(0);
-      if (tree.getKind() == Kind.RETURN
-          && ASTHelpers.constValue(((ReturnTree) tree).getExpression()) != null) {
-        return Description.NO_MATCH;
+
+    if (readByteMethod.getBody() != null) { // Null-check for native/abstract overrides of read()
+      List<? extends StatementTree> statements = readByteMethod.getBody().getStatements();
+      if (statements.size() == 1) {
+        Tree tree = statements.get(0);
+        if (tree.getKind() == Kind.RETURN
+            && ASTHelpers.constValue(((ReturnTree) tree).getExpression()) != null) {
+          return Description.NO_MATCH;
+        }
       }
     }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/CatchAndPrintStackTraceTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/CatchAndPrintStackTraceTest.java
@@ -41,6 +41,12 @@ public class CatchAndPrintStackTraceTest {
             "      // BUG: Diagnostic contains:",
             "      t.printStackTrace();",
             "    }",
+            "    try {",
+            "      System.err.println();",
+            "    } catch (Throwable t) {",
+            "      // BUG: Diagnostic contains:",
+            "      t.printStackTrace(System.err);",
+            "    }",
             "  }",
             "}")
         .doTest();
@@ -61,11 +67,6 @@ public class CatchAndPrintStackTraceTest {
             "    } catch (Throwable t) {",
             "      t.printStackTrace();",
             "      t.printStackTrace();",
-            "    }",
-            "    try {",
-            "      System.err.println();",
-            "    } catch (Throwable t) {",
-            "      t.printStackTrace(System.err);",
             "    }",
             "  }",
             "}")

--- a/core/src/test/java/com/google/errorprone/bugpatterns/InputStreamSlowMultibyteReadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/InputStreamSlowMultibyteReadTest.java
@@ -47,7 +47,7 @@ public class InputStreamSlowMultibyteReadTest {
   }
 
   @Test
-  public void basic() throws Exception {
+  public void basic() {
     compilationHelper
         .addSourceLines(
             "TestClass.java",
@@ -55,6 +55,30 @@ public class InputStreamSlowMultibyteReadTest {
             "  byte[] buf = new byte[42];",
             "  // BUG: Diagnostic contains:",
             "  public int read() { return buf[0]; }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void abstractOverride() {
+    compilationHelper
+        .addSourceLines(
+            "TestClass.java",
+            "abstract class TestClass extends java.io.InputStream {",
+            "  // BUG: Diagnostic contains:",
+            "  public abstract int read();",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nativeOverride() {
+    compilationHelper
+        .addSourceLines(
+            "TestClass.java",
+            "abstract class TestClass extends java.io.InputStream {",
+            "  // BUG: Diagnostic contains:",
+            "  public native int read();",
             "}")
         .doTest();
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/StreamResourceLeakTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/StreamResourceLeakTest.java
@@ -204,6 +204,29 @@ public class StreamResourceLeakTest {
   }
 
   @Test
+  public void returnFromMustBeClosedMethodWithChaining() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.errorprone.annotations.MustBeClosed;",
+            "import java.io.IOException;",
+            "import java.nio.file.Files;",
+            "import java.nio.file.Path;",
+            "import java.util.stream.Stream;",
+            "class Test {",
+            "  @MustBeClosed",
+            "  Stream<String> f(Path p) throws IOException {",
+            "    return Files.list(p).map(Path::toString); // OK due to @MustBeClosed",
+            "  }",
+            "  Stream<String> g(Path p) throws IOException {",
+            "    // BUG: Diagnostic contains: should be closed",
+            "    return Files.list(p).map(Path::toString);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void moreRefactorings() throws IOException {
     BugCheckerRefactoringTestHelper.newInstance(new StreamResourceLeak(), getClass())
         .addInputLines(

--- a/docs/bugpattern/CatchAndPrintStackTrace.md
+++ b/docs/bugpattern/CatchAndPrintStackTrace.md
@@ -25,9 +25,3 @@ try {
   e.printStackTrace();
 }
 ```
-
-If you truly intend to print a stack trace to stderr, do so explicitly:
-
-```java
-e.printStackTrace(System.err);
-```


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Handling printStackTrace() and printStackTrace(System.err) consistently

RELNOTES: N/A

0549cd2885417d3396f61f366b90afc876e30e77

-------

<p> Don't crash if InputStream#read() is overridden by an abstract or native
method.

Fixes #954

RELNOTES: n/a

8c33782fbff87da9f78668e122505b1ea32a8414

-------

<p> Confirm that StreamResourceLeak handles @MustBeClosed and chained calls

RELNOTES: N/A

fa6166400be9b4c453b46b0e241f4b1eb7f60700