### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ModifyingCollectionWithItself.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ModifyingCollectionWithItself.java
@@ -18,6 +18,8 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.bugpatterns.ReplacementVariableFinder.fixesByReplacingExpressionWithLocallyDeclaredField;
+import static com.google.errorprone.bugpatterns.ReplacementVariableFinder.fixesByReplacingExpressionWithMethodParameter;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
@@ -27,13 +29,8 @@ import static com.google.errorprone.matchers.Matchers.variableType;
 import static com.sun.source.tree.Tree.Kind.IDENTIFIER;
 import static com.sun.source.tree.Tree.Kind.MEMBER_SELECT;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
@@ -42,19 +39,14 @@ import com.google.errorprone.fixes.Fix;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.names.LevenshteinEditDistance;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionStatementTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
-import com.sun.tools.javac.tree.JCTree.JCClassDecl;
-import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
-import com.sun.tools.javac.tree.JCTree.JCIdent;
-import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
-import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 import javax.lang.model.element.ElementKind;
 
 /** @author scottjohnson@google.com (Scott Johnson) */
@@ -142,7 +134,9 @@ public class ModifyingCollectionWithItself extends BugChecker
     if (receiver.getKind() == MEMBER_SELECT) {
       // Only inspect method parameters, unlikely to want to this.a.addAll(b), where b is another
       // field.
-      fixes = fixesFromMethodParameters(state, argument);
+      fixes =
+          fixesByReplacingExpressionWithMethodParameter(
+              argument, isCollectionVariable(state), state);
     } else {
       // a.addAll(...)
       Preconditions.checkState(receiver.getKind() == IDENTIFIER, "receiver.getKind is identifier");
@@ -150,8 +144,10 @@ public class ModifyingCollectionWithItself extends BugChecker
       boolean lhsIsField = ASTHelpers.getSymbol(receiver).getKind() == ElementKind.FIELD;
       fixes =
           lhsIsField
-              ? fixesFromMethodParameters(state, argument)
-              : fixesFromFields(state, receiver);
+              ? fixesByReplacingExpressionWithMethodParameter(
+                  argument, isCollectionVariable(state), state)
+              : fixesByReplacingExpressionWithLocallyDeclaredField(
+                  receiver, isCollectionVariable(state), state);
     }
 
     if (fixes.isEmpty()) {
@@ -160,99 +156,11 @@ public class ModifyingCollectionWithItself extends BugChecker
     return fixes;
   }
 
-  private List<Fix> fixesFromFields(VisitorState state, final ExpressionTree receiver) {
-    FluentIterable<JCVariableDecl> collectionFields =
-        FluentIterable.from(
-                ASTHelpers.findEnclosingNode(state.getPath(), JCClassDecl.class).getMembers())
-            .filter(JCVariableDecl.class)
-            .filter(isCollectionVariable(state));
-
-    Multimap<Integer, JCVariableDecl> potentialReplacements =
-        partitionByEditDistance(simpleNameOfIdentifierOrMemberAccess(receiver), collectionFields);
-
-    return buildValidReplacements(
-        potentialReplacements,
-        new Function<JCVariableDecl, Fix>() {
-          @Override
-          public Fix apply(JCVariableDecl var) {
-            return SuggestedFix.replace(receiver, "this." + var.sym.toString());
-          }
-        });
+  private static Predicate<JCVariableDecl> isCollectionVariable(final VisitorState state) {
+    return var -> variableType(isSubtypeOf("java.util.Collection")).matches(var, state);
   }
 
-  private List<Fix> buildValidReplacements(
-      Multimap<Integer, JCVariableDecl> potentialReplacements,
-      Function<JCVariableDecl, Fix> replacementFunction) {
-    if (potentialReplacements.isEmpty()) {
-      return ImmutableList.of();
-    }
-
-    // Take all of the potential edit-distance replacements with the same minimum distance,
-    // then suggest them as individual fixes.
-    return FluentIterable.from(
-            potentialReplacements.get(Collections.min(potentialReplacements.keySet())))
-        .transform(replacementFunction)
-        .toList();
-  }
-
-  private Predicate<JCVariableDecl> isCollectionVariable(final VisitorState state) {
-    return new Predicate<JCVariableDecl>() {
-      @Override
-      public boolean apply(JCVariableDecl var) {
-        return variableType(isSubtypeOf("java.util.Collection")).matches(var, state);
-      }
-    };
-  }
-
-  private List<Fix> fixesFromMethodParameters(VisitorState state, final ExpressionTree argument) {
-    // find a method parameter of the same type and similar name and suggest it
-    // as the new argument
-
-    Preconditions.checkState(
-        argument.getKind() == IDENTIFIER || argument.getKind() == MEMBER_SELECT);
-
-    FluentIterable<JCVariableDecl> collectionParams =
-        FluentIterable.from(
-                ASTHelpers.findEnclosingNode(state.getPath(), JCMethodDecl.class).getParameters())
-            .filter(isCollectionVariable(state));
-
-    Multimap<Integer, JCVariableDecl> potentialReplacements =
-        partitionByEditDistance(simpleNameOfIdentifierOrMemberAccess(argument), collectionParams);
-
-    return buildValidReplacements(
-        potentialReplacements,
-        new Function<JCVariableDecl, Fix>() {
-          @Override
-          public Fix apply(JCVariableDecl var) {
-            return SuggestedFix.replace(argument, var.sym.toString());
-          }
-        });
-  }
-
-  private Multimap<Integer, JCVariableDecl> partitionByEditDistance(
-      final String baseName, Iterable<JCVariableDecl> candidates) {
-    return Multimaps.index(
-        candidates,
-        new Function<JCVariableDecl, Integer>() {
-          @Override
-          public Integer apply(JCVariableDecl jcVariableDecl) {
-            return LevenshteinEditDistance.getEditDistance(
-                baseName, jcVariableDecl.name.toString());
-          }
-        });
-  }
-
-  private String simpleNameOfIdentifierOrMemberAccess(ExpressionTree tree) {
-    String name = null;
-    if (tree.getKind() == IDENTIFIER) {
-      name = ((JCIdent) tree).name.toString();
-    } else if (tree.getKind() == MEMBER_SELECT) {
-      name = ((JCFieldAccess) tree).name.toString();
-    }
-    return name;
-  }
-
-  private List<Fix> literalReplacement(
+  private static ImmutableList<Fix> literalReplacement(
       MethodInvocationTree methodInvocationTree, VisitorState state, ExpressionTree lhs) {
 
     Tree parent = state.getPath().getParentPath().getLeaf();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ReplacementVariableFinder.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ReplacementVariableFinder.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.sun.source.tree.Tree.Kind.IDENTIFIER;
+import static com.sun.source.tree.Tree.Kind.MEMBER_SELECT;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.fixes.Fix;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.names.LevenshteinEditDistance;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.tools.javac.tree.JCTree.JCClassDecl;
+import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
+import com.sun.tools.javac.tree.JCTree.JCIdent;
+import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
+import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
+import java.util.Collections;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+/** Utility methods to find replacement variables with similar names. */
+public final class ReplacementVariableFinder {
+  private ReplacementVariableFinder() {}
+
+  /**
+   * Suggest replacing {@code input} with a qualified reference to a locally declared field with a
+   * similar or the same name as the {@code input} expression.
+   *
+   * @param input a MEMBER_SELECT or IDENTIFIER expression which should be replaced.
+   * @param validFieldPredicate Predicate used to decide which locally declared fields are
+   *     appropriate candidates for replacement (e.g.: is the appropriate type)
+   */
+  public static ImmutableList<Fix> fixesByReplacingExpressionWithLocallyDeclaredField(
+      ExpressionTree input, Predicate<JCVariableDecl> validFieldPredicate, VisitorState state) {
+    Preconditions.checkState(input.getKind() == IDENTIFIER || input.getKind() == MEMBER_SELECT);
+
+    ImmutableMultimap<Integer, JCVariableDecl> potentialReplacements =
+        ASTHelpers.findEnclosingNode(state.getPath(), JCClassDecl.class)
+            .getMembers()
+            .stream()
+            .filter(JCVariableDecl.class::isInstance)
+            .map(JCVariableDecl.class::cast)
+            .filter(validFieldPredicate)
+            .collect(collectByEditDistanceTo(simpleNameOfIdentifierOrMemberAccess(input)));
+
+    return buildValidReplacements(
+        potentialReplacements, var -> SuggestedFix.replace(input, "this." + var.sym));
+  }
+
+  /**
+   * Suggest replacing {@code input} with a reference to a method parameter in the nearest enclosing
+   * method declaration with a similar or the same name as the {@code input} expression.
+   *
+   * @param input a MEMBER_SELECT or IDENTIFIER expression which should be replaced.
+   * @param validParameterPredicate Predicate used to decide which method parameters are appropriate
+   *     candidates for replacement (e.g.: is the appropriate type)
+   */
+  public static ImmutableList<Fix> fixesByReplacingExpressionWithMethodParameter(
+      ExpressionTree input, Predicate<JCVariableDecl> validParameterPredicate, VisitorState state) {
+    Preconditions.checkState(input.getKind() == IDENTIFIER || input.getKind() == MEMBER_SELECT);
+
+    // find a method parameter matching the input predicate and similar name and suggest it
+    // as the new argument
+    Multimap<Integer, JCVariableDecl> potentialReplacements =
+        ASTHelpers.findEnclosingNode(state.getPath(), JCMethodDecl.class)
+            .getParameters()
+            .stream()
+            .filter(validParameterPredicate)
+            .collect(collectByEditDistanceTo(simpleNameOfIdentifierOrMemberAccess(input)));
+
+    return buildValidReplacements(
+        potentialReplacements, var -> SuggestedFix.replace(input, var.sym.toString()));
+  }
+
+  private static ImmutableList<Fix> buildValidReplacements(
+      Multimap<Integer, JCVariableDecl> potentialReplacements,
+      Function<JCVariableDecl, Fix> replacementFunction) {
+    if (potentialReplacements.isEmpty()) {
+      return ImmutableList.of();
+    }
+
+    // Take all of the potential edit-distance replacements with the same minimum distance,
+    // then suggest them as individual fixes.
+    return potentialReplacements
+        .get(Collections.min(potentialReplacements.keySet()))
+        .stream()
+        .map(replacementFunction)
+        .collect(toImmutableList());
+  }
+
+  private static Collector<JCVariableDecl, ?, ImmutableMultimap<Integer, JCVariableDecl>>
+      collectByEditDistanceTo(String baseName) {
+    return Collectors.collectingAndThen(
+        Multimaps.toMultimap(
+            (JCVariableDecl varDecl) ->
+                LevenshteinEditDistance.getEditDistance(baseName, varDecl.name.toString()),
+            varDecl -> varDecl,
+            LinkedHashMultimap::create),
+        ImmutableMultimap::copyOf);
+  }
+
+  private static String simpleNameOfIdentifierOrMemberAccess(ExpressionTree tree) {
+    String name = null;
+    if (tree.getKind() == IDENTIFIER) {
+      name = ((JCIdent) tree).name.toString();
+    } else if (tree.getKind() == MEMBER_SELECT) {
+      name = ((JCFieldAccess) tree).name.toString();
+    }
+    return name;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SelfAssignment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SelfAssignment.java
@@ -23,12 +23,11 @@ import static com.google.errorprone.matchers.Matchers.staticMethod;
 import static com.sun.source.tree.Tree.Kind.CLASS;
 import static com.sun.source.tree.Tree.Kind.IDENTIFIER;
 import static com.sun.source.tree.Tree.Kind.MEMBER_SELECT;
-import static com.sun.source.tree.Tree.Kind.METHOD;
 import static com.sun.source.tree.Tree.Kind.METHOD_INVOCATION;
-import static com.sun.source.tree.Tree.Kind.VARIABLE;
 import static javax.lang.model.element.Modifier.STATIC;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
@@ -38,7 +37,6 @@ import com.google.errorprone.fixes.Fix;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.names.LevenshteinEditDistance;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.ExpressionTree;
@@ -46,17 +44,9 @@ import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
-import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
-import com.sun.tools.javac.tree.JCTree;
-import com.sun.tools.javac.tree.JCTree.JCClassDecl;
-import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
-import com.sun.tools.javac.tree.JCTree.JCIdent;
-import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
-import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
-import java.util.Objects;
 
 /**
  * TODO(eaftan): Consider cases where the parent is not a statement or there is no parent?
@@ -173,6 +163,7 @@ public class SelfAssignment extends BugChecker
       rhs = stripNullCheck(rhs, state);
     }
 
+    ImmutableList<Fix> exploratoryFieldFixes = ImmutableList.of();
     if (lhs.getKind() == MEMBER_SELECT) {
       // find a method parameter of the same type and similar name and suggest it
       // as the rhs
@@ -180,80 +171,30 @@ public class SelfAssignment extends BugChecker
       // rhs should be either identifier or field access
       Preconditions.checkState(rhs.getKind() == IDENTIFIER || rhs.getKind() == MEMBER_SELECT);
 
-      // get current name of rhs
-      String rhsName = null;
-      if (rhs.getKind() == IDENTIFIER) {
-        rhsName = ((JCIdent) rhs).name.toString();
-      } else if (rhs.getKind() == MEMBER_SELECT) {
-        rhsName = ((JCFieldAccess) rhs).name.toString();
-      }
-
-      // find method parameters of the same type
-      Type type = ((JCFieldAccess) lhs).type;
-      TreePath path = state.getPath();
-      while (path != null && path.getLeaf().getKind() != METHOD) {
-        path = path.getParentPath();
-      }
-      JCMethodDecl method = (JCMethodDecl) path.getLeaf();
-      int minEditDistance = Integer.MAX_VALUE;
-      String replacement = null;
-      for (JCVariableDecl var : method.params) {
-        if (Objects.equals(var.type, type)) {
-          int editDistance = LevenshteinEditDistance.getEditDistance(rhsName, var.name.toString());
-          if (editDistance < minEditDistance) {
-            // pick one with minimum edit distance
-            minEditDistance = editDistance;
-            replacement = var.name.toString();
-          }
-        }
-      }
-      if (replacement != null) {
-        // suggest replacing rhs with the parameter
-        fix = SuggestedFix.replace(rhs, replacement);
-      }
+      Type rhsType = ASTHelpers.getType(rhs);
+      exploratoryFieldFixes =
+          ReplacementVariableFinder.fixesByReplacingExpressionWithMethodParameter(
+              rhs, varDecl -> ASTHelpers.isSameType(rhsType, varDecl.type, state), state);
     } else if (rhs.getKind() == IDENTIFIER) {
       // find a field of the same type and similar name and suggest it as the lhs
-
       // lhs should be identifier
       Preconditions.checkState(lhs.getKind() == IDENTIFIER);
 
-      // get current name of lhs
-      String lhsName = ((JCIdent) rhs).name.toString();
-
-      // find class instance fields of the same type
-      Type type = ((JCIdent) lhs).type;
-      TreePath path = state.getPath();
-      while (path != null && !(path.getLeaf() instanceof JCClassDecl)) {
-        path = path.getParentPath();
-      }
-      if (path == null) {
-        throw new IllegalStateException("Expected to find an enclosing class declaration");
-      }
-      JCClassDecl klass = (JCClassDecl) path.getLeaf();
-      int minEditDistance = Integer.MAX_VALUE;
-      String replacement = null;
-      for (JCTree member : klass.getMembers()) {
-        if (member.getKind() == VARIABLE) {
-          JCVariableDecl var = (JCVariableDecl) member;
-          if (!Flags.isStatic(var.sym)
-              && (var.sym.flags() & Flags.FINAL) == 0
-              && Objects.equals(var.type, type)) {
-            int editDistance =
-                LevenshteinEditDistance.getEditDistance(lhsName, var.name.toString());
-            if (editDistance < minEditDistance) {
-              // pick one with minimum edit distance
-              minEditDistance = editDistance;
-              replacement = var.name.toString();
-            }
-          }
-        }
-      }
-      if (replacement != null) {
-        // suggest replacing lhs with the field
-        fix = SuggestedFix.replace(lhs, "this." + replacement);
-      }
+      Type lhsType = ASTHelpers.getType(lhs);
+      exploratoryFieldFixes =
+          ReplacementVariableFinder.fixesByReplacingExpressionWithLocallyDeclaredField(
+              lhs,
+              var ->
+                  !Flags.isStatic(var.sym)
+                      && (var.sym.flags() & Flags.FINAL) == 0
+                      && ASTHelpers.isSameType(lhsType, var.type, state),
+              state);
     }
 
-    return describeMatch(assignmentTree, fix);
+    if (exploratoryFieldFixes.isEmpty()) {
+      return describeMatch(assignmentTree, fix);
+    }
+
+    return buildDescription(assignmentTree).addAllFixes(exploratoryFieldFixes).build();
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/StringSplitterTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/StringSplitterTest.java
@@ -34,14 +34,14 @@ public class StringSplitterTest {
   public void positive() throws IOException {
     testHelper
         .addInputLines(
-            "in/Test.java",
+            "Test.java",
             "class Test {",
             "  void f() {",
             "    for (String s : \"\".split(\":\")) {}",
             "  }",
             "}")
         .addOutputLines(
-            "out/Test.java",
+            "Test.java",
             "import com.google.common.base.Splitter;",
             "class Test {",
             "  void f() {",
@@ -55,7 +55,7 @@ public class StringSplitterTest {
   public void varLoop() throws IOException {
     testHelper
         .addInputLines(
-            "in/Test.java",
+            "Test.java",
             "class Test {",
             "  void f() {",
             "    String[] pieces = \"\".split(\":\");",
@@ -63,7 +63,7 @@ public class StringSplitterTest {
             "  }",
             "}")
         .addOutputLines(
-            "out/Test.java",
+            "Test.java",
             "import com.google.common.base.Splitter;",
             "class Test {",
             "  void f() {",
@@ -78,7 +78,7 @@ public class StringSplitterTest {
   public void varLoopLength() throws IOException {
     testHelper
         .addInputLines(
-            "in/Test.java",
+            "Test.java",
             "class Test {",
             "  void f() {",
             "    String[] pieces = \"\".split(\":\");",
@@ -86,7 +86,7 @@ public class StringSplitterTest {
             "  }",
             "}")
         .addOutputLines(
-            "out/Test.java",
+            "Test.java",
             "import com.google.common.base.Splitter;",
             "import java.util.List;",
             "class Test {",
@@ -102,7 +102,7 @@ public class StringSplitterTest {
   public void varList() throws IOException {
     testHelper
         .addInputLines(
-            "in/Test.java",
+            "Test.java",
             "class Test {",
             "  void f() {",
             "    String[] pieces = \"\".split(\":\");",
@@ -111,7 +111,7 @@ public class StringSplitterTest {
             "  }",
             "}")
         .addOutputLines(
-            "out/Test.java",
+            "Test.java",
             "import com.google.common.base.Splitter;",
             "import java.util.List;",
             "class Test {",
@@ -128,14 +128,14 @@ public class StringSplitterTest {
   public void positiveRegex() throws IOException {
     testHelper
         .addInputLines(
-            "in/Test.java",
+            "Test.java",
             "class Test {",
             "  void f() {",
             "    for (String s : \"\".split(\".*foo\\\\t\")) {}",
             "  }",
             "}")
         .addOutputLines(
-            "out/Test.java",
+            "Test.java",
             "import com.google.common.base.Splitter;",
             "class Test {",
             "  void f() {",
@@ -149,7 +149,7 @@ public class StringSplitterTest {
   public void character() throws IOException {
     testHelper
         .addInputLines(
-            "in/Test.java",
+            "Test.java",
             "class Test {",
             "  void f() {",
             "    for (String s : \"\".split(\"c\")) {}",
@@ -157,7 +157,7 @@ public class StringSplitterTest {
             "  }",
             "}")
         .addOutputLines(
-            "out/Test.java",
+            "Test.java",
             "import com.google.common.base.Splitter;",
             "class Test {",
             "  void f() {",
@@ -186,7 +186,7 @@ public class StringSplitterTest {
   public void mutation() throws IOException {
     testHelper
         .addInputLines(
-            "in/Test.java",
+            "Test.java",
             "class Test {",
             "  void f() {",
             "    String[] xs = \"\".split(\"c\");",
@@ -195,7 +195,7 @@ public class StringSplitterTest {
             "  }",
             "}")
         .addOutputLines(
-            "out/Test.java",
+            "Test.java",
             "import com.google.common.base.Splitter;",
             "import java.util.ArrayList;",
             "import java.util.List;",
@@ -214,7 +214,7 @@ public class StringSplitterTest {
   public void b72088500() throws IOException {
     testHelper
         .addInputLines(
-            "in/Test.java",
+            "Test.java",
             "class Test {",
             "  void f(String input) {",
             "    String[] lines = input.split(\"\\\\r?\\\\n\");",
@@ -222,7 +222,7 @@ public class StringSplitterTest {
             "  }",
             "}")
         .addOutputLines(
-            "out/Test.java",
+            "Test.java",
             "import com.google.common.base.Splitter;",
             "import java.util.List;",
             "class Test {",
@@ -238,14 +238,14 @@ public class StringSplitterTest {
   public void escape() throws IOException {
     testHelper
         .addInputLines(
-            "in/Test.java",
+            "Test.java",
             "class Test {",
             "  void f() {",
             "    String[] pieces = \"\".split(\"\\n\\t\\r\\f\");",
             "  }",
             "}")
         .addOutputLines(
-            "out/Test.java",
+            "Test.java",
             "import com.google.common.base.Splitter;",
             "class Test {",
             "  void f() {",
@@ -259,7 +259,7 @@ public class StringSplitterTest {
   public void immediateArrayAccess() throws IOException {
     testHelper
         .addInputLines(
-            "in/Test.java",
+            "Test.java",
             "class Test {",
             "  void f() {",
             "    String x = \"\".split(\"c\")[0];",
@@ -267,7 +267,7 @@ public class StringSplitterTest {
             "  }",
             "}")
         .addOutputLines(
-            "out/Test.java",
+            "Test.java",
             "import com.google.common.base.Splitter;",
             "import com.google.common.collect.Iterables;",
             "class Test {",
@@ -297,14 +297,14 @@ public class StringSplitterTest {
   public void noSplitterOnClassPath() throws IOException {
     testHelper
         .addInputLines(
-            "in/Test.java",
+            "Test.java",
             "class Test {",
             "  void f() {",
             "    for (String s : \"\".split(\":\")) {}",
             "  }",
             "}")
         .addOutputLines(
-            "out/Test.java",
+            "Test.java",
             "class Test {",
             "  void f() {",
             "    for (String s : \"\".split(\":\", -1)) {}",

--- a/test_helpers/src/main/java/com/google/errorprone/BugCheckerRefactoringTestHelper.java
+++ b/test_helpers/src/main/java/com/google/errorprone/BugCheckerRefactoringTestHelper.java
@@ -151,8 +151,9 @@ public class BugCheckerRefactoringTestHelper {
   }
 
   public BugCheckerRefactoringTestHelper.ExpectOutput addInputLines(String path, String... input) {
-    assertThat(fileManager.exists(path)).isFalse();
-    return new ExpectOutput(fileManager.forSourceLines(path, input));
+    String inputPath = getPath("in/", path);
+    assertThat(fileManager.exists(inputPath)).isFalse();
+    return new ExpectOutput(fileManager.forSourceLines(inputPath, input));
   }
 
   public BugCheckerRefactoringTestHelper setFixChooser(FixChooser chooser) {
@@ -285,10 +286,11 @@ public class BugCheckerRefactoringTestHelper {
 
     public BugCheckerRefactoringTestHelper addOutputLines(String path, String... output)
         throws IOException {
-      if (fileManager.exists(path)) {
-        throw new FileAlreadyExistsException(path);
+      String outputPath = getPath("out/", path);
+      if (fileManager.exists(outputPath)) {
+        throw new FileAlreadyExistsException(outputPath);
       }
-      return addInputAndOutput(input, fileManager.forSourceLines(path, output));
+      return addInputAndOutput(input, fileManager.forSourceLines(outputPath, output));
     }
 
     public BugCheckerRefactoringTestHelper addOutput(String outputFilename) {
@@ -298,5 +300,12 @@ public class BugCheckerRefactoringTestHelper {
     public BugCheckerRefactoringTestHelper expectUnchanged() {
       return addInputAndOutput(input, input);
     }
+  }
+
+  private String getPath(String prefix, String path) {
+    // return prefix + path;
+    int insertAt = path.lastIndexOf('/');
+    insertAt = insertAt == -1 ? 0 : insertAt + 1;
+    return new StringBuilder(path).insert(insertAt, prefix + "/").toString();
   }
 }

--- a/test_helpers/src/test/java/com/google/errorprone/BugCheckerRefactoringTestHelperTest.java
+++ b/test_helpers/src/test/java/com/google/errorprone/BugCheckerRefactoringTestHelperTest.java
@@ -22,6 +22,7 @@ import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static org.junit.Assert.fail;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
+import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.AnnotationTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
@@ -33,7 +34,6 @@ import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ReturnTree;
 import java.io.IOException;
-import java.nio.file.FileAlreadyExistsException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -194,7 +194,8 @@ public class BugCheckerRefactoringTestHelperTest {
     summary = "Mock refactoring that replaces all returns with 'return null;' statement.",
     explanation = "For test purposes only.",
     category = JDK,
-    severity = SUGGESTION
+    severity = SUGGESTION,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION
   )
   public static class ReturnNullRefactoring extends BugChecker implements ReturnTreeMatcher {
     @Override
@@ -219,19 +220,6 @@ public class BugCheckerRefactoringTestHelperTest {
         return describeMatch(tree, SuggestedFix.replace(tree, ""));
       }
       return Description.NO_MATCH;
-    }
-  }
-
-  @Test
-  public void testFileAlreadyExists() throws IOException {
-    try {
-      helper
-          .addInputLines("Test.java", "public class Test {}")
-          .addOutputLines("Test.java", "public class Test {}")
-          .doTest();
-      fail();
-    } catch (FileAlreadyExistsException e) {
-      assertThat(e).hasMessage("Test.java");
     }
   }
 
@@ -270,7 +258,8 @@ public class BugCheckerRefactoringTestHelperTest {
     summary = "Mock refactoring that imports an ArrayList",
     explanation = "For test purposes only.",
     category = JDK,
-    severity = SUGGESTION
+    severity = SUGGESTION,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION
   )
   public static class ImportArrayList extends BugChecker implements CompilationUnitTreeMatcher {
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Let BugCheckerRefactoringTestHelper addInputLines and addOutputLines have the same file path.

RELNOTES: Improve BugCheckerRefactoringTestHelper usability.

33f5f150310fcdc4d339f655b68a794cc7522201

-------

<p> Re-use the "find an appropriate replacement" logic between
SelfAssignment/ModifyingCollectionByItself, and transition from Guava predicates/functions to Java 8 functions/streams.

RELNOTES: n/a

873db1872928e09c1c15ced39d9b6069f853d5b2