### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -64,6 +64,7 @@ import com.sun.source.tree.VariableTree;
 import com.sun.source.tree.WhileLoopTree;
 import com.sun.source.util.TreePath;
 import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.api.JavacTrees;
 import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.Attribute.Compound;
 import com.sun.tools.javac.code.Flags;
@@ -476,6 +477,24 @@ public class ASTHelpers {
       return Arrays.asList(rightOperand, leftOperand);
     }
     return null;
+  }
+
+  /**
+   * Returns the method tree that matches the given symbol within the compilation unit, or null if
+   * none was found.
+   */
+  @Nullable
+  public static MethodTree findMethod(MethodSymbol symbol, VisitorState state) {
+    return JavacTrees.instance(state.context).getTree(symbol);
+  }
+
+  /**
+   * Returns the class tree that matches the given symbol within the compilation unit, or null if
+   * none was found.
+   */
+  @Nullable
+  public static ClassTree findClass(ClassSymbol symbol, VisitorState state) {
+    return JavacTrees.instance(state.context).getTree(symbol);
   }
 
   @Nullable

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BooleanParameter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BooleanParameter.java
@@ -61,7 +61,7 @@ public class BooleanParameter extends BugChecker implements MethodInvocationTree
       // single-argument methods are often self-documentating
       return NO_MATCH;
     }
-    if (arguments.stream().noneMatch(a -> a.getKind() == Kind.BOOLEAN_LITERAL)) {
+    if (arguments.stream().noneMatch(BooleanParameter::isBooleanLiteral)) {
       return NO_MATCH;
     }
     MethodSymbol sym = ASTHelpers.getSymbol(tree);
@@ -88,7 +88,7 @@ public class BooleanParameter extends BugChecker implements MethodInvocationTree
       int start,
       Deque<ErrorProneToken> tokens,
       VisitorState state) {
-    if (a.getKind() != Kind.BOOLEAN_LITERAL) {
+    if (!isBooleanLiteral(a)) {
       return;
     }
     String name = paramSym.getSimpleName().toString();
@@ -129,5 +129,9 @@ public class BooleanParameter extends BugChecker implements MethodInvocationTree
                 NamedParameterComment.PARAMETER_COMMENT_PATTERN
                     .matcher(Comments.getTextFromComment(c))
                     .matches());
+  }
+
+  private static boolean isBooleanLiteral(ExpressionTree a) {
+    return a.getKind() == Kind.BOOLEAN_LITERAL;
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ByteBufferBackingArray.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ByteBufferBackingArray.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.errorprone.BugPattern.Category.JDK;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.isSameType;
+import static com.google.errorprone.matchers.Matchers.staticMethod;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.AssignmentTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+/**
+ * Checks when ByteBuffer.array() is used without calling .arrayOffset() to know the offset of the
+ * array, or when the buffer wasn't initialized using ByteBuffer.wrap() or ByteBuffer.allocate().
+ */
+@BugPattern(
+  name = "ByteBufferBackingArray",
+  summary =
+      "ByteBuffer.array() shouldn't be called unless ByteBuffer.arrayOffset() is used or "
+          + "if the ByteBuffer was initialized using ByteBuffer.wrap() or ByteBuffer.allocate().",
+  category = JDK,
+  severity = WARNING,
+  generateExamplesFromTestCases = false
+)
+public class ByteBufferBackingArray extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private static final Matcher<ExpressionTree> BYTE_BUFFER_ARRAY_MATCHER =
+      anyOf(instanceMethod().onDescendantOf(ByteBuffer.class.getName()).named("array"));
+
+  private static final Matcher<ExpressionTree> BYTE_BUFFER_ARRAY_OFFSET_MATCHER =
+      anyOf(instanceMethod().onDescendantOf(ByteBuffer.class.getName()).named("arrayOffset"));
+
+  private static final Matcher<ExpressionTree> BYTE_BUFFER_ALLOWED_INITIALIZERS_MATCHER =
+      anyOf(
+          staticMethod().onClass(ByteBuffer.class.getName()).named("allocate"),
+          staticMethod().onClass(ByteBuffer.class.getName()).named("wrap"));
+
+  private static final Matcher<ExpressionTree> BYTE_BUFFER_MATCHER = isSameType(ByteBuffer.class);
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (!BYTE_BUFFER_ARRAY_MATCHER.matches(tree, state)) {
+      return Description.NO_MATCH;
+    }
+
+    // Checks for validating use on method call chain.
+    ExpressionTree receiver = tree;
+    do {
+      receiver = ASTHelpers.getReceiver(receiver);
+      if (isValidInitializerOrNotAByteBuffer(receiver, state)) {
+        return Description.NO_MATCH;
+      }
+    } while (receiver instanceof MethodInvocationTree);
+
+    Symbol bufferSymbol = ASTHelpers.getSymbol(receiver);
+
+    // Checks for validating use on method scope.
+    if (bufferSymbol.owner instanceof MethodSymbol) {
+      MethodTree enclosingMethod = ASTHelpers.findMethod((MethodSymbol) bufferSymbol.owner, state);
+      if (enclosingMethod == null
+          || ValidByteBufferArrayScanner.scan(enclosingMethod, state, bufferSymbol)) {
+        return Description.NO_MATCH;
+      }
+    }
+
+    // Checks for validating use on fields.
+    if (bufferSymbol.owner instanceof ClassSymbol) {
+      ClassTree enclosingClass = ASTHelpers.findClass((ClassSymbol) bufferSymbol.owner, state);
+      if (enclosingClass == null) {
+        return Description.NO_MATCH;
+      }
+      Optional<? extends Tree> validMemberTree =
+          enclosingClass
+              .getMembers()
+              .stream()
+              .filter(
+                  memberTree -> ValidByteBufferArrayScanner.scan(memberTree, state, bufferSymbol))
+              .findFirst();
+      if (validMemberTree.isPresent()) {
+        return Description.NO_MATCH;
+      }
+    }
+
+    return describeMatch(tree);
+  }
+
+  private static boolean isValidInitializerOrNotAByteBuffer(
+      ExpressionTree receiver, VisitorState state) {
+    return BYTE_BUFFER_ALLOWED_INITIALIZERS_MATCHER.matches(receiver, state)
+        || !BYTE_BUFFER_MATCHER.matches(receiver, state);
+  }
+
+  /**
+   * Scan for a call to ByteBuffer.arrayOffset() or check if buffer was initialized with either
+   * ByteBuffer.wrap() or ByteBuffer.allocate().
+   */
+  private static class ValidByteBufferArrayScanner extends TreeScanner<Void, VisitorState> {
+
+    private final Symbol searchedBufferSymbol;
+    private boolean visited;
+    private boolean valid;
+
+    static boolean scan(Tree tree, VisitorState state, Symbol searchedBufferSymbol) {
+      ValidByteBufferArrayScanner visitor = new ValidByteBufferArrayScanner(searchedBufferSymbol);
+      tree.accept(visitor, state);
+      return visitor.valid;
+    }
+
+    private ValidByteBufferArrayScanner(Symbol searchedBufferSymbol) {
+      this.searchedBufferSymbol = searchedBufferSymbol;
+    }
+
+    @Override
+    public Void visitVariable(VariableTree tree, VisitorState state) {
+      checkForInitializer(ASTHelpers.getSymbol(tree), tree.getInitializer(), state);
+      return super.visitVariable(tree, state);
+    }
+
+    @Override
+    public Void visitAssignment(AssignmentTree tree, VisitorState state) {
+      checkForInitializer(ASTHelpers.getSymbol(tree.getVariable()), tree.getExpression(), state);
+      return super.visitAssignment(tree, state);
+    }
+
+    @Override
+    public Void visitMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+      if (valid) {
+        return null;
+      }
+      Symbol bufferSymbol = ASTHelpers.getSymbol(ASTHelpers.getReceiver(tree));
+      if (searchedBufferSymbol.equals(bufferSymbol)) {
+        if (BYTE_BUFFER_ARRAY_MATCHER.matches(tree, state)) {
+          visited = true;
+        } else if (BYTE_BUFFER_ARRAY_OFFSET_MATCHER.matches(tree, state)) {
+          valid = true;
+        }
+      }
+      return super.visitMethodInvocation(tree, state);
+    }
+
+    private void checkForInitializer(
+        Symbol foundSymbol, ExpressionTree expression, VisitorState state) {
+      if (visited || valid) {
+        return;
+      }
+      if (!searchedBufferSymbol.equals(foundSymbol)) {
+        return;
+      }
+      if (expression == null) {
+        return;
+      }
+      if (ValidByteBufferInitializerScanner.scan(expression, state)) {
+        valid = true;
+      }
+    }
+  }
+
+  /** Scan for a call to ByteBuffer.wrap() or ByteBuffer.allocate(). */
+  private static class ValidByteBufferInitializerScanner
+      extends TreeScanner<Boolean, VisitorState> {
+
+    static Boolean scan(ExpressionTree tree, VisitorState state) {
+      ValidByteBufferInitializerScanner visitor = new ValidByteBufferInitializerScanner();
+      return firstNonNull(tree.accept(visitor, state), false);
+    }
+
+    private ValidByteBufferInitializerScanner() {}
+
+    @Override
+    public Boolean visitMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+      boolean b1 = BYTE_BUFFER_ALLOWED_INITIALIZERS_MATCHER.matches(tree, state);
+      boolean b2 = super.visitMethodInvocation(tree, state);
+      return b1 || b2;
+    }
+
+    @Override
+    public Boolean reduce(Boolean r1, Boolean r2) {
+      return firstNonNull(r1, false) || firstNonNull(r2, false);
+    }
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InconsistentCapitalization.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InconsistentCapitalization.java
@@ -107,9 +107,10 @@ public class InconsistentCapitalization extends BugChecker implements ClassTreeM
       state.reportMatch(
           buildDescription(parameterPath.getLeaf())
               .setMessage(
-                  "Found a field with the same name as a parameter but with different "
-                      + "capitalization: "
-                      + fieldName)
+                  String.format(
+                      "Found the field '%s' with the same name as the parameter '%s' but with "
+                          + "different capitalization.",
+                      fieldName, ((VariableTree) parameterPath.getLeaf()).getName()))
               .addFix(fix.build())
               .build());
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/PrivateConstructorForNoninstantiableModule.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/PrivateConstructorForNoninstantiableModule.java
@@ -43,7 +43,7 @@ import com.sun.source.tree.Tree;
 
 /** @author gak@google.com (Gregory Kick) */
 @BugPattern(
-  name = "PrivateConstructorForNoninstantiableModuleTest",
+  name = "PrivateConstructorForNoninstantiableModule",
   summary = "Add a private constructor to modules that will not be instantiated by Dagger.",
   explanation =
       "Modules that contain abstract binding methods (@Binds, @Multibinds) or only static"

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -37,6 +37,7 @@ import com.google.errorprone.bugpatterns.BigDecimalLiteralDouble;
 import com.google.errorprone.bugpatterns.BooleanParameter;
 import com.google.errorprone.bugpatterns.BoxedPrimitiveConstructor;
 import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.ByteBufferBackingArray;
 import com.google.errorprone.bugpatterns.CannotMockFinalClass;
 import com.google.errorprone.bugpatterns.CanonicalDuration;
 import com.google.errorprone.bugpatterns.CatchAndPrintStackTrace;
@@ -457,6 +458,7 @@ public class BuiltInCheckerSuppliers {
           BadAnnotationImplementation.class,
           BadComparable.class,
           BoxedPrimitiveConstructor.class,
+          ByteBufferBackingArray.class,
           CannotMockFinalClass.class,
           CanonicalDuration.class,
           CatchAndPrintStackTrace.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ByteBufferBackingArrayTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ByteBufferBackingArrayTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Test for ByteBufferBackingArray bug checker */
+@RunWith(JUnit4.class)
+public class ByteBufferBackingArrayTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setUp() {
+    compilationHelper = CompilationTestHelper.newInstance(ByteBufferBackingArray.class, getClass());
+  }
+
+  @Test
+  public void testPositiveCases() throws Exception {
+    compilationHelper.addSourceFile("ByteBufferBackingArrayPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void testNegativeCases() throws Exception {
+    compilationHelper.addSourceFile("ByteBufferBackingArrayNegativeCases.java").doTest();
+  }
+
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/HidingFieldTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/HidingFieldTest.java
@@ -35,13 +35,13 @@ public class HidingFieldTest {
   }
 
   @Test
-  public void testHidingFieldPositiveCases() throws Exception {
+  public void testHidingFieldPositiveCases() {
     compilationHelper.addSourceFile("HidingFieldPositiveCases1.java").doTest();
     compilationHelper.addSourceFile("HidingFieldPositiveCases2.java").doTest();
   }
 
   @Test
-  public void testHidingFieldNegativeCases() throws Exception {
+  public void testHidingFieldNegativeCases() {
     compilationHelper.addSourceFile("HidingFieldNegativeCases.java").doTest();
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ByteBufferBackingArrayNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ByteBufferBackingArrayNegativeCases.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+import com.google.errorprone.bugpatterns.ByteBufferBackingArrayTest;
+import java.nio.ByteBuffer;
+import java.util.function.Function;
+
+/** Negative cases for {@link ByteBufferBackingArrayTest}. */
+public class ByteBufferBackingArrayNegativeCases {
+
+  void noArrayCall_isNotFlagged() {
+    ByteBuffer buffer = null;
+    buffer.position();
+  }
+
+  void array_precededByArrayOffset_isNotFlagged() {
+    ByteBuffer buffer = null;
+    buffer.arrayOffset();
+    buffer.array();
+  }
+
+  void array_precededByArrayOffset_onOuterScope_isNotFlagged() {
+    ByteBuffer buffer = null;
+    buffer.arrayOffset();
+    if (true) {
+      while (true) {
+        buffer.array();
+      }
+    }
+  }
+
+  void array_precededByByteBufferWrap_isNotFlagged() {
+    ByteBuffer buffer = ByteBuffer.wrap(new byte[] {1});
+    buffer.array();
+  }
+
+  void array_precededByByteBufferAllocate_isNotFlagged() {
+    ByteBuffer buffer = ByteBuffer.allocate(1);
+    buffer.array();
+  }
+
+  // Ideally, this case should be flagged though.
+  void array_followedByByteBufferArrayOffset_isNotFlagged() {
+    ByteBuffer buffer = null;
+    buffer.array();
+    buffer.arrayOffset();
+  }
+
+  // Ideally, this case should be flagged though.
+  void array_followedByArrayOffset_inExpression_isNotFlagged() {
+    ByteBuffer buffer = null;
+    byte[] outBytes;
+    int outOffset;
+    int outPos;
+    if (buffer.hasArray()) {
+      outBytes = buffer.array();
+      outPos = outOffset = buffer.arrayOffset() + buffer.position();
+    }
+  }
+
+  void array_precededByByteBufferAllocate_inSplitMethodChain_isNotFlagged() {
+    ByteBuffer buffer = ByteBuffer.allocate(1).put((byte) 'a');
+    buffer.array();
+  }
+
+  public void array_immediatelyPrecededByByteBufferAllocate_inContinuousMethodChain_isNotFlagged()
+      throws Exception {
+    ByteBuffer.allocate(0).array();
+  }
+
+  void array_precededByByteBufferAllocate_inContinuousMethodChain_isNotFlagged() {
+    ByteBuffer.allocate(Long.SIZE / Byte.SIZE).putLong(1L).array();
+  }
+
+  byte[] array_inMethodChain_precededByByteBufferAllocate_isNotFlagged() {
+    ByteBuffer buffer = ByteBuffer.allocate(1);
+    return buffer.put(new byte[] {1}).array();
+  }
+
+  class A {
+    // Ideally, this case should be flagged though.
+    void array_inMethodChain_whereByteBufferIsNotAtStartOfChain_isNotFlagged() {
+      A helper = new A();
+      helper.getBuffer().put((byte) 1).array();
+    }
+
+    ByteBuffer getBuffer() {
+      return null;
+    }
+  }
+
+  class B {
+    ByteBuffer buffer = ByteBuffer.allocate(1);
+
+    void array_precededByByteBufferAllocate_inField_isNotFlagged() {
+      buffer.array();
+    }
+  }
+
+  class C {
+    ByteBuffer buffer = ByteBuffer.allocate(1);
+
+    class A {
+      void array_precededByByteBufferAllocate_inFieldOfParentClass_isNotFlagged() {
+        buffer.array();
+      }
+    }
+  }
+
+  class ArrayInFieldPrecededByByteBufferAllocateInFieldIsNotFlagged {
+    ByteBuffer buffer = ByteBuffer.allocate(1);
+    byte[] array = buffer.array();
+  }
+
+  void array_inAnonymousClass_precededByByteBufferAllocate_isNotFlagged() {
+    final ByteBuffer buffer = ByteBuffer.allocate(0);
+
+    new Function<Object, Object>() {
+      @Override
+      public Object apply(Object o) {
+        buffer.array();
+        return null;
+      }
+    };
+  }
+
+  void array_inLambdaExpression_precededByByteBufferAllocate_isNotFlagged() {
+    final ByteBuffer buffer = ByteBuffer.allocate(0);
+
+    Function<Void, Void> f =
+        (Void unused) -> {
+          buffer.array();
+          return null;
+        };
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ByteBufferBackingArrayPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ByteBufferBackingArrayPositiveCases.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+import com.google.errorprone.bugpatterns.ByteBufferBackingArrayTest;
+import java.nio.ByteBuffer;
+
+/** Positive cases for {@link ByteBufferBackingArrayTest}. */
+public class ByteBufferBackingArrayPositiveCases {
+
+  public void array_notPrecededByOffsetNorValidInitializer_asLocalVariable_isFlagged() {
+    ByteBuffer buff = null;
+    // BUG: Diagnostic contains: ByteBuffer.array()
+    buff.array();
+  }
+
+  class A {
+
+    ByteBuffer buff = null;
+
+    void array_notPrecededByOffsetNorValidInitializer_asField_isFlagged() {
+      // BUG: Diagnostic contains: ByteBuffer.array()
+      buff.array();
+    }
+  }
+
+  class ArrayCalledInFieldNotPrecededByOffsetNorValidInitializerAsFieldIsFlagged {
+    ByteBuffer buffer = null;
+    // BUG: Diagnostic contains: ByteBuffer.array()
+    byte[] array = buffer.array();
+  }
+
+  void array_notPrecededByOffsetNorValidInitializer_asMethodParameter_isFlagged(ByteBuffer buffer) {
+    // BUG: Diagnostic contains: ByteBuffer.array()
+    buffer.array();
+  }
+
+  void array_followedByWrap_isFlagged() {
+    ByteBuffer buff = null;
+    // BUG: Diagnostic contains: ByteBuffer.array()
+    buff.array();
+    buff = ByteBuffer.wrap(new byte[] {1});
+  }
+
+  void array_followedByAllocate_isFlagged() {
+    ByteBuffer buff = null;
+    // BUG: Diagnostic contains: ByteBuffer.array()
+    buff.array();
+    buff = ByteBuffer.allocate(1);
+  }
+
+  void array_precededByAllocateDirect_isFlagged() {
+    ByteBuffer buff = null;
+    buff = ByteBuffer.allocateDirect(1);
+    // BUG: Diagnostic contains: ByteBuffer.array()
+    buff.array();
+  }
+
+  void array_precededByAllocateOnAnotherBuffer_isFlagged() {
+    ByteBuffer otherBuff = ByteBuffer.allocate(1);
+    ByteBuffer buff = null;
+    otherBuff.arrayOffset();
+    // BUG: Diagnostic contains: ByteBuffer.array()
+    buff.array();
+  }
+
+  void array_precededByNotAValidMethod_isFlagged() {
+    ByteBuffer buff = null;
+    buff.position();
+    // BUG: Diagnostic contains: ByteBuffer.array()
+    buff.array();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/HidingFieldNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/HidingFieldNegativeCases.java
@@ -35,7 +35,12 @@ public class HidingFieldNegativeCases {
 
   // subclass with initialized member variable of different name
   static class ClassC extends ClassB {
+    // publicly-visible static members in superclasses are pretty uncommon, and generally
+    // referred to by qualification, so this 'override' is OK
     private String varFour = "Test";
+
+    // The supertype's visibility is private, so this redeclaration is OK.
+    private int varThree;
 
     // warning suppressed when overshadowing variable in parent
     @SuppressWarnings("HidingField")

--- a/docs/bugpattern/ByteBufferBackingArray.md
+++ b/docs/bugpattern/ByteBufferBackingArray.md
@@ -1,0 +1,73 @@
+`ByteBuffer` provides a view of an underlying bytes storage. The two most common
+implementations are the non-direct byte buffers, which are backed by a bytes
+array, and direct byte buffers, which usually are off-heap directly mapped to
+memory. Thus, not all `ByteBuffer` implementations are backed by a bytes array,
+and so it is needed to call `.hasArray()` before calling `.array()`.
+
+On the other hand, the beginning of the array returned by `.array()` does not
+necessarily correspond to the beginning of the `ByteBuffer`, and in this way,
+accessing the returned array without knowing the `.arrayOffset()` may cause
+undesired results.
+
+For this reason, the `array()` method should only be used when the programmer
+knows that the underlying ByteBuffer has a backing array (for example:
+constructing the ByteBuffer with `ByteBuffer.wrap()` or `ByteBuffer.allocate()`)
+. In addition, the `.arrayOffset()` should also be used to know the starting
+position of the `ByteBuffer` content in such array.
+
+Do this:
+
+``` {.good}
+// This will use the current buffer position
+public void foo(ByteBuffer buffer) throws Exception {
+   byte[] bytes = new byte[buffer.remaining()];
+   buffer.get(bytes);
+   buffer.position(buffer.position() - bytes.length); // Restores the buffer position
+   // ...
+}
+```
+
+or this:
+
+``` {.good}
+// This is an example of a correct usage of .array()
+public void foo(ByteBuffer buffer) throws Exception {
+   if (buffer.hasArray()) {
+     bar(buffer.array(), /* offset */ buffer.arrayOffset() + buffer.position(),
+         /* length */ buffer.remaining());
+   }
+   // ...
+}
+```
+
+or this:
+
+``` {.good}
+public void foo() throws Exception {
+      ByteBuffer buffer = ByteBuffer.allocate(Long.SIZE / Byte.SIZE);
+      buffer.putLong(1L);
+      // ...
+      buffer.array();
+      // ...
+}
+```
+
+or this:
+
+``` {.good}
+public void foo(byte[] bytes) throws Exception {
+   ByteBuffer buffer = ByteBuffer.wrap(bytes);
+   // ...
+   buffer.array();
+   // ...
+}
+```
+
+Not this:
+
+``` {.bad}
+public void foo(ByteBuffer buffer) {
+   byte[] dataAsBytesArray = buffer.array();
+   // ...
+}
+```

--- a/docs/bugpattern/InconsistentCapitalization.md
+++ b/docs/bugpattern/InconsistentCapitalization.md
@@ -1,0 +1,9 @@
+It is confusing to have two or more variables under the same scope that differ
+only in capitalization. Make sure that both of these follow the casing guide
+([Google Java Style Guide §5.3][styleCamelCase]) and to be consistent if more
+than one option is possible.
+
+This checker will only find parameters that differ in capitalization with fields
+that can be accessed from the parameter's scope.
+
+[styleCamelCase]: https://google.github.io/styleguide/javaguide.html#s5.3-camel-case


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Updating finding message of inconsistent capitalization checker.

RELNOTES: N/A.

cda89e8c731ce317ebbd2c4df21cdcdb4d3d5998

-------

<p> Factor out Kind.BOOLEAN_LITERAL check.

I made local modifications to use INT_LITERAL and NULL_LITERAL for automating
cleanups (see b/74685890), and found it easier to centralize the kind check.

RELNOTES: N/A

2c9f0345c5f224522b65f7ab4fd62622b2b3d781

-------

<p> Add tests to ensure that private members in superclasses aren't 'detected' by
HidingField.

RELNOTES: n/a

747fe79a5d604147fb11d09211479d4957017f91

-------

<p> Remove "Test" from PrivateConstructorForNoninstantiableModule's bug checker name

RELNOTES: n/a

c28abb4d55c6a9e7469b4862d32b6922fe04b527

-------

<p> BugChecker for ByteBuffer.array() being called without calling before or after
.arrayOffset() or by creating the array with ByteBuffer.wrap() or
ByteBuffer.allocate().

RELNOTES: Adding bug checker for inappropriate use of ByteBuffer.array()

902eef9d1ad9761828b66a29d96dc8ce6004b83a