### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/matchers/method/ConstructorClassMatcherImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/ConstructorClassMatcherImpl.java
@@ -50,11 +50,16 @@ class ConstructorClassMatcherImpl extends AbstractChainedMatcher<MatchState, Mat
 
   @Override
   public ParameterMatcher withParameters(String... parameters) {
-    return withParameters(Suppliers.fromStrings(Arrays.asList(parameters)));
+    return withParameters(Arrays.asList(parameters));
   }
 
   @Override
-  public ParameterMatcher withParameters(Iterable<Supplier<Type>> parameters) {
+  public ParameterMatcher withParameters(Iterable<String> parameters) {
+    return withParametersOfType(Suppliers.fromStrings(parameters));
+  }
+
+  @Override
+  public ParameterMatcher withParametersOfType(Iterable<Supplier<Type>> parameters) {
     return new ParameterMatcherImpl(this, ImmutableList.copyOf(parameters));
   }
 }

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/MethodMatchers.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/MethodMatchers.java
@@ -127,7 +127,10 @@ public class MethodMatchers {
     ParameterMatcher withParameters(String... parameters);
 
     /** Match constructors whose formal parameters have the given types. */
-    ParameterMatcher withParameters(Iterable<Supplier<Type>> parameters);
+    ParameterMatcher withParameters(Iterable<String> parameters);
+
+    /** Match constructors whose formal parameters have the given types. */
+    ParameterMatcher withParametersOfType(Iterable<Supplier<Type>> parameters);
   }
 
   public interface ParameterMatcher extends Matcher<ExpressionTree> {}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DefaultCharset.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DefaultCharset.java
@@ -137,20 +137,20 @@ public class DefaultCharset extends BugChecker
       anyOf(
           constructor()
               .forClass(String.class.getName())
-              .withParameters(ImmutableList.of(Suppliers.arrayOf(Suppliers.BYTE_TYPE))),
+              .withParametersOfType(ImmutableList.of(Suppliers.arrayOf(Suppliers.BYTE_TYPE))),
           constructor()
               .forClass(String.class.getName())
-              .withParameters(
+              .withParametersOfType(
                   ImmutableList.of(
                       Suppliers.arrayOf(Suppliers.BYTE_TYPE),
                       Suppliers.INT_TYPE,
                       Suppliers.INT_TYPE)),
           constructor()
               .forClass(OutputStreamWriter.class.getName())
-              .withParameters(ImmutableList.of(Suppliers.typeFromClass(OutputStream.class))),
+              .withParametersOfType(ImmutableList.of(Suppliers.typeFromClass(OutputStream.class))),
           constructor()
               .forClass(InputStreamReader.class.getName())
-              .withParameters(ImmutableList.of(Suppliers.typeFromClass(InputStream.class))));
+              .withParametersOfType(ImmutableList.of(Suppliers.typeFromClass(InputStream.class))));
 
   private static final Matcher<ExpressionTree> BYTESTRING_COPY_FROM =
       staticMethod().onClass("com.google.protobuf.ByteString").named("copyFrom");

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TryFailThrowable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TryFailThrowable.java
@@ -79,8 +79,7 @@ import java.util.List;
  *   <li>{@code org.junit.Assert},
  *   <li>{@code junit.framework.Assert},
  *   <li>{@code junit.framework.TestCase} - which overrides the methods from Assert in order to
- *       deprecate them,
- *   <li>{@code com.google.testing.util.MoreAsserts} and
+ *       deprecate them and
  *   <li>every class whose name ends with "MoreAsserts".
  * </ul>
  *
@@ -88,7 +87,6 @@ import java.util.List;
  *
  * <ul>
  *   <li>support multiple catch() blocks
- *   <li>support MoreAsserts
  * </ul>
  *
  * @author adamwos@google.com (Adam Wos)

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableCheckerTest.java
@@ -1777,4 +1777,24 @@ public class ImmutableCheckerTest {
             "}")
         .doTest();
   }
+
+  // regression test for b/77781008
+  @Test
+  public void immutableTypeParameter_twoInstantiations() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.errorprone.annotations.ImmutableTypeParameter;",
+            "import com.google.errorprone.annotations.Immutable;",
+            "import com.google.common.collect.ImmutableList;",
+            "@Immutable class Test<@ImmutableTypeParameter T> {",
+            "  <@ImmutableTypeParameter T> T f(T t) { return t; }",
+            "  <@ImmutableTypeParameter T> void g(T a, T b) {}",
+            "  @Immutable interface I {}",
+            "  void test(I i) {",
+            "    g(f(i), f(i));",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix a crash in ThreadSafety#getInstantiation

RELNOTES: N/A

e035521e24d8005e3276dc7366665eb9bd7d3871

-------

<p> MoreAsserts is dead!

RELNOTES: remove MoreAsserts from TryFailThrowable

fa58dbb972d6a091658ad552919159aa5be4f0d4

-------

<p> Rename ConstructorClassMatcher.withParameters(Iterable<Supplier<Type>>) to withParametersOfType(Iterable<Supplier<Type>>)
Add ConstructorClassMatcher.withParameters(Iterable<String>)

RELNOTES: rename ConstructorClassMatcher methods.

9a67f14e2bb81bbd05802004db1fd23765a65e2d