### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -59,7 +59,7 @@ import com.sun.source.tree.VariableTree;
 import com.sun.source.util.DocTreePath;
 import com.sun.source.util.JavacTask;
 import com.sun.source.util.TreePath;
-import com.sun.tools.javac.api.JavacTaskImpl;
+import com.sun.tools.javac.api.BasicJavacTask;
 import com.sun.tools.javac.api.JavacTool;
 import com.sun.tools.javac.api.JavacTrees;
 import com.sun.tools.javac.code.BoundKind;
@@ -684,7 +684,7 @@ public class SuggestedFixes {
     }
     JCCompilationUnit compilationUnit = (JCCompilationUnit) state.getPath().getCompilationUnit();
     JavaFileObject modifiedFile = compilationUnit.getSourceFile();
-    JavacTaskImpl javacTask = (JavacTaskImpl) state.context.get(JavacTask.class);
+    BasicJavacTask javacTask = (BasicJavacTask) state.context.get(JavacTask.class);
     if (javacTask == null) {
       throw new IllegalArgumentException("No JavacTask in context.");
     }

--- a/check_api/src/main/java/com/google/errorprone/util/Commented.java
+++ b/check_api/src/main/java/com/google/errorprone/util/Commented.java
@@ -25,6 +25,13 @@ import com.sun.tools.javac.parser.Tokens.Comment;
 @AutoValue
 public abstract class Commented<T extends Tree> {
 
+  /** Identifies the position of a comment relative to the associated treenode. */
+  public enum Position {
+    BEFORE,
+    AFTER,
+    ANY
+  }
+
   public abstract T tree();
 
   public abstract ImmutableList<Comment> beforeComments();
@@ -44,21 +51,29 @@ public abstract class Commented<T extends Tree> {
 
     protected abstract ImmutableList.Builder<Comment> afterCommentsBuilder();
 
-    Builder<T> addComment(Comment comment, int nodePosition, int tokenizingOffset) {
+    Builder<T> addComment(
+        Comment comment, int nodePosition, int tokenizingOffset, Position position) {
       OffsetComment offsetComment = new OffsetComment(comment, tokenizingOffset);
 
       if (comment.getSourcePos(0) < nodePosition) {
-        beforeCommentsBuilder().add(offsetComment);
+        if (position.equals(Position.BEFORE) || position.equals(Position.ANY)) {
+          beforeCommentsBuilder().add(offsetComment);
+        }
       } else {
-        afterCommentsBuilder().add(offsetComment);
+        if (position.equals(Position.AFTER) || position.equals(Position.ANY)) {
+          afterCommentsBuilder().add(offsetComment);
+        }
       }
       return this;
     }
 
     Builder<T> addAllComment(
-        Iterable<? extends Comment> comments, int nodePosition, int tokenizingOffset) {
+        Iterable<? extends Comment> comments,
+        int nodePosition,
+        int tokenizingOffset,
+        Position position) {
       for (Comment comment : comments) {
-        addComment(comment, nodePosition, tokenizingOffset);
+        addComment(comment, nodePosition, tokenizingOffset, position);
       }
       return this;
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AssertThrowsMultipleStatements.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AssertThrowsMultipleStatements.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.Iterables.getLast;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.BlockTree;
+import com.sun.source.tree.ExpressionStatementTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.StatementTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.tree.JCTree;
+import java.util.List;
+
+/** @author cushon@google.com (Liam Miller-Cushon) */
+@BugPattern(
+    name = "AssertThrowsMultipleStatements",
+    summary = "The lambda passed to assertThows should contain exactly one statement",
+    severity = SeverityLevel.WARNING,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+public class AssertThrowsMultipleStatements extends BugChecker
+    implements MethodInvocationTreeMatcher {
+
+  private static final Matcher<ExpressionTree> MATCHER =
+      staticMethod().onClass("org.junit.Assert").named("assertThrows");
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (!MATCHER.matches(tree, state)) {
+      return NO_MATCH;
+    }
+    ExpressionTree arg = getLast(tree.getArguments());
+    if (!(arg instanceof LambdaExpressionTree)) {
+      return NO_MATCH;
+    }
+    Tree body = ((LambdaExpressionTree) arg).getBody();
+    if (!(body instanceof BlockTree)) {
+      return NO_MATCH;
+    }
+    List<? extends StatementTree> statements = ((BlockTree) body).getStatements();
+    if (statements.size() <= 1) {
+      return NO_MATCH;
+    }
+    StatementTree last = getLast(statements);
+    int startPosition = ((JCTree) statements.get(0)).getStartPosition();
+    int endPosition = state.getEndPosition(statements.get(statements.size() - 2));
+    SuggestedFix.Builder fix = SuggestedFix.builder();
+    // if the last statement is an expression, convert from a block to expression lambda
+    if (last instanceof ExpressionStatementTree) {
+      fix.replace(body, state.getSourceForNode(((ExpressionStatementTree) last).getExpression()));
+    } else {
+      fix.replace(startPosition, endPosition, "");
+    }
+    fix.prefixWith(
+        state.findEnclosing(StatementTree.class),
+        state.getSourceCode().subSequence(startPosition, endPosition).toString());
+    return describeMatch(last, fix.build());
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeFinal.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeFinal.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.Category.JDK;
+import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.google.errorprone.util.ASTHelpers.hasAnnotation;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.AssignmentTree;
+import com.sun.source.tree.BlockTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.CompoundAssignmentTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
+import com.sun.source.tree.UnaryTree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePathScanner;
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.util.Context;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
+
+/** @author Liam Miller-Cushon (cushon@google.com) */
+@BugPattern(
+  name = "FieldCanBeFinal",
+  category = JDK,
+  summary = "This field is only assigned during initialization; consider making it final",
+  severity = SUGGESTION,
+  providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION
+)
+public class FieldCanBeFinal extends BugChecker implements CompilationUnitTreeMatcher {
+
+  /** Annotations that imply a field is non-constant. */
+  // TODO(cushon): consider supporting @Var as a meta-annotation
+  private static final ImmutableSet<String> IMPLICIT_VAR_ANNOTATIONS =
+      ImmutableSet.of(
+          "javax.inject.Inject",
+          "com.google.inject.Inject",
+          "com.google.inject.testing.fieldbinder.Bind",
+          "com.googlecode.objectify.v5.annotation.Collection",
+          "com.googlecode.objectify.v5.annotation.Id",
+          "com.googlecode.objectify.v5.annotation.Index",
+          "com.googlecode.objectify.v5.annotation.Parent",
+          "com.googlecode.objectify.v5.annotation.Subclass",
+          "com.google.errorprone.annotations.Var",
+          "com.google.common.annotations.NonFinalForGwt",
+          "org.kohsuke.args4j.Argument",
+          "org.kohsuke.args4j.Option",
+          "org.mockito.Spy",
+          "javax.jdo.annotations.Persistent",
+          "javax.xml.bind.annotation.XmlAttribute",
+          "com.google.gwt.uibinder.client.UiField",
+          "com.beust.jcommander.Parameter",
+          "javax.persistence.Id");
+
+  /** Annotations that imply all fields in the annotated class are non-constant. */
+  private static final ImmutableSet<String> IMPLICIT_VAR_CLASS_ANNOTATIONS =
+      ImmutableSet.of(
+          "com.googlecode.objectify.v4.annotation.Entity",
+          "com.googlecode.objectify.v4.annotation.Embed",
+          "com.googlecode.objectify.v5.annotation.Entity",
+          "com.googlecode.objectify.v5.annotation.Embed");
+
+  /**
+   * Annotations that imply a field is non-constant, and that do not have a canonical
+   * implementation. Instead, we match on any annotation with one of the following simple names.
+   */
+  private static final ImmutableSet<String> IMPLICIT_VAR_ANNOTATION_SIMPLE_NAMES =
+      ImmutableSet.of("NonFinalForTesting", "NotFinalForTesting");
+
+  /** The initalization context where an assignment occurred. */
+  enum InitializationContext {
+    /** A class (static) initializer. */
+    STATIC,
+    /** An instance initializer. */
+    INSTANCE,
+    /** Neither a static or instance initializer. */
+    NONE
+  }
+
+  /** A record of all assignments to variables in the current compilation unit. */
+  static class VariableAssignmentRecords {
+
+    private final Map<VarSymbol, VariableAssignments> assignments = new LinkedHashMap<>();
+
+    /** Returns all {@link VariableAssignments} in the current compilation unit. */
+    public Iterable<VariableAssignments> getAssignments() {
+      return assignments.values();
+    }
+
+    /** Records an assignment to a variable. */
+    public void recordAssignment(Tree tree, InitializationContext init) {
+      Symbol sym = ASTHelpers.getSymbol(tree);
+      if (sym != null && sym.getKind() == ElementKind.FIELD) {
+        recordAssignment((VarSymbol) sym, init);
+      }
+    }
+
+    /** Records an assignment to a variable. */
+    public void recordAssignment(VarSymbol sym, InitializationContext init) {
+      getDeclaration(sym).recordAssignment(init);
+    }
+
+    private VariableAssignments getDeclaration(VarSymbol sym) {
+      VariableAssignments info = assignments.get(sym);
+      if (info == null) {
+        info = new VariableAssignments(sym);
+        assignments.put(sym, info);
+      }
+      return info;
+    }
+
+    /** Records a variable declaration. */
+    public void recordDeclaration(VarSymbol sym, VariableTree tree) {
+      getDeclaration(sym).recordDeclaration(tree);
+    }
+  }
+
+  /** A record of all assignments to a specific variable in the current compilation unit. */
+  static class VariableAssignments {
+
+    final VarSymbol sym;
+    final EnumSet<InitializationContext> writes = EnumSet.noneOf(InitializationContext.class);
+    VariableTree declaration;
+
+    VariableAssignments(VarSymbol sym) {
+      this.sym = sym;
+    }
+
+    /** Records an assignment to the variable. */
+    public void recordAssignment(InitializationContext init) {
+      writes.add(init);
+    }
+
+    /** Records that a variable was declared in this compilation unit. */
+    public void recordDeclaration(VariableTree tree) {
+      declaration = tree;
+    }
+
+    /** Returns true if the variable is effectively final. */
+    boolean isEffectivelyFinal() {
+      if (declaration == null) {
+        return false;
+      }
+      if (sym.getModifiers().contains(Modifier.FINAL)) {
+        // actually final != effectively final
+        return false;
+      }
+      if (writes.contains(InitializationContext.NONE)) {
+        return false;
+      }
+      // The unsound heuristic for effectively final fields is that they are initialized at least
+      // once in an initializer with the right static-ness. Multiple initializations are allowed
+      // because we don't consider control flow, and zero initializations are allowed to handle
+      // class and instance initializers, and delegating constructors that don't initialize the
+      // field directly.
+      InitializationContext wanted;
+      InitializationContext other;
+      if (sym.isStatic()) {
+        wanted = InitializationContext.STATIC;
+        other = InitializationContext.INSTANCE;
+      } else {
+        wanted = InitializationContext.INSTANCE;
+        other = InitializationContext.STATIC;
+      }
+      if (writes.contains(other)) {
+        return false;
+      }
+      return writes.contains(wanted) || (sym.flags() & Flags.HASINIT) == Flags.HASINIT;
+    }
+
+    VariableTree declaration() {
+      return declaration;
+    }
+  }
+
+  @Override
+  public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {
+    VariableAssignmentRecords writes = new VariableAssignmentRecords();
+    new FinalScanner(writes, state.context).scan(state.getPath(), InitializationContext.NONE);
+    outer:
+    for (VariableAssignments var : writes.getAssignments()) {
+      if (!var.isEffectivelyFinal()) {
+        continue;
+      }
+      if (!var.sym.isPrivate()) {
+        continue;
+      }
+      for (String annotation : IMPLICIT_VAR_ANNOTATIONS) {
+        if (ASTHelpers.hasAnnotation(var.sym, annotation, state)) {
+          continue outer;
+        }
+      }
+      VariableTree varDecl = var.declaration();
+      for (AnnotationTree anno : varDecl.getModifiers().getAnnotations()) {
+        if (IMPLICIT_VAR_ANNOTATION_SIMPLE_NAMES.contains(ASTHelpers.getAnnotationName(anno))) {
+          return Description.NO_MATCH;
+        }
+      }
+      SuggestedFixes.addModifiers(varDecl, state, Modifier.FINAL)
+          .ifPresent(
+              f -> {
+                if (SuggestedFixes.compilesWithFix(f, state)) {
+                  state.reportMatch(describeMatch(varDecl, f));
+                }
+              });
+    }
+    return Description.NO_MATCH;
+  }
+
+  /** Record assignments to possibly-final variables in a compilation unit. */
+  private static class FinalScanner extends TreePathScanner<Void, InitializationContext> {
+
+    private final VariableAssignmentRecords writes;
+    private final Context context;
+
+    public FinalScanner(VariableAssignmentRecords writes, Context context) {
+      this.writes = writes;
+      this.context = context;
+    }
+
+    @Override
+    public Void visitVariable(VariableTree node, InitializationContext init) {
+      VarSymbol sym = ASTHelpers.getSymbol(node);
+      if (sym.getKind() == ElementKind.FIELD) {
+        writes.recordDeclaration(sym, node);
+      }
+      return super.visitVariable(node, InitializationContext.NONE);
+    }
+
+    @Override
+    public Void visitBlock(BlockTree node, InitializationContext init) {
+      if (getCurrentPath().getParentPath().getLeaf().getKind() == Kind.CLASS) {
+        init = node.isStatic() ? InitializationContext.STATIC : InitializationContext.INSTANCE;
+      }
+      return super.visitBlock(node, init);
+    }
+
+    @Override
+    public Void visitMethod(MethodTree node, InitializationContext init) {
+      MethodSymbol sym = ASTHelpers.getSymbol(node);
+      if (sym != null && sym.isConstructor()) {
+        init = InitializationContext.INSTANCE;
+      }
+      return super.visitMethod(node, init);
+    }
+
+    @Override
+    public Void visitAssignment(AssignmentTree node, InitializationContext init) {
+      if (init == InitializationContext.INSTANCE && !isThisAccess(node.getVariable())) {
+        // don't record assignments in initializers that aren't to members of the object
+        // being initialized
+        init = InitializationContext.NONE;
+      }
+      writes.recordAssignment(node.getVariable(), init);
+      return super.visitAssignment(node, init);
+    }
+
+    boolean isThisAccess(Tree tree) {
+      if (tree.getKind() == Kind.IDENTIFIER) {
+        return true;
+      }
+      if (tree.getKind() != Kind.MEMBER_SELECT) {
+        return false;
+      }
+      ExpressionTree selected = ((MemberSelectTree) tree).getExpression();
+      if (!(selected instanceof IdentifierTree)) {
+        return false;
+      }
+      IdentifierTree ident = (IdentifierTree) selected;
+      return ident.getName().contentEquals("this");
+    }
+
+    @Override
+    public Void visitClass(ClassTree node, InitializationContext init) {
+      VisitorState state = new VisitorState(context).withPath(getCurrentPath());
+
+
+      for (String annotation : IMPLICIT_VAR_CLASS_ANNOTATIONS) {
+        if (ASTHelpers.hasAnnotation(getSymbol(node), annotation, state)) {
+          return null;
+        }
+      }
+
+      // reset the initialization context when entering a new declaration
+      return super.visitClass(node, InitializationContext.NONE);
+    }
+
+    @Override
+    public Void visitCompoundAssignment(CompoundAssignmentTree node, InitializationContext init) {
+      init = InitializationContext.NONE;
+      writes.recordAssignment(node.getVariable(), init);
+      return super.visitCompoundAssignment(node, init);
+    }
+
+    /** Unary operator kinds that implicitly assign to their operand. */
+    private static final EnumSet<Kind> UNARY_ASSIGNMENT =
+        EnumSet.of(
+            Kind.PREFIX_DECREMENT,
+            Kind.POSTFIX_DECREMENT,
+            Kind.PREFIX_INCREMENT,
+            Kind.POSTFIX_INCREMENT);
+
+    @Override
+    public Void visitUnary(UnaryTree node, InitializationContext init) {
+      if (UNARY_ASSIGNMENT.contains(node.getKind())) {
+        init = InitializationContext.NONE;
+        writes.recordAssignment(node.getExpression(), init);
+      }
+      return super.visitUnary(node, init);
+    }
+  }
+
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ObjectToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ObjectToString.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.Category.JDK;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+
+import com.google.common.base.Optional;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.fixes.Fix;
+import com.google.errorprone.predicates.TypePredicate;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Types;
+import java.util.Set;
+
+/**
+ * Warns against calling toString() on Objects which don't have toString() method overridden and
+ * won't produce meaningful output.
+ *
+ * @author bhagwani@google.com (Sumit Bhagwani)
+ */
+@BugPattern(
+  name = "ObjectToString",
+  summary =
+      "Calling toString on Objects that don't override toString() doesn't"
+          + " provide useful information",
+  category = JDK,
+  severity = WARNING,
+  providesFix = ProvidesFix.NO_FIX
+)
+public class ObjectToString extends AbstractToString {
+
+  private static boolean finalNoOverrides(Type type, VisitorState state) {
+    if (type == null) {
+      return false;
+    }
+    // We don't flag use of toString() on non-final objects because sub classes might have a
+    // meaningful toString() override.
+    if (!type.isFinal()) {
+      return false;
+    }
+    // We explore the superclasses of the receiver type as well as the interfaces it
+    // implements and we collect all overrides of java.lang.Object.toString(). If one of those
+    // overrides is present, then we don't flag it.
+    Types types = state.getTypes();
+    Set<MethodSymbol> overridesOfToString =
+        ASTHelpers.findMatchingMethods(
+            state.getName("toString"),
+            methodSymbol -> isToString(methodSymbol, state),
+            type,
+            types);
+
+    // only has Object.toString()
+    if (overridesOfToString.size() == 1) {
+      return true;
+    }
+    return false;
+  }
+
+  private static boolean isToString(MethodSymbol methodSymbol, VisitorState state) {
+    return !methodSymbol.isStatic()
+        && ((methodSymbol.flags() & Flags.SYNTHETIC) == 0)
+        && state.getTypes().isSameType(methodSymbol.getReturnType(), state.getSymtab().stringType)
+        && methodSymbol.getParameters().isEmpty();
+  }
+
+  @Override
+  protected TypePredicate typePredicate() {
+    return ObjectToString::finalNoOverrides;
+  }
+
+  @Override
+  protected Optional<String> descriptionMessageForDefaultMatch(Type type) {
+    String format =
+        "%1$s is final and does not override Object.toString, converting it to a string"
+            + " will print its identity (e.g. `%1$s@ 4488aabb`) instead of useful information.";
+    return Optional.of(String.format(format, type.toString()));
+  }
+
+  @Override
+  protected Optional<Fix> implicitToStringFix(ExpressionTree tree, VisitorState state) {
+    return Optional.absent();
+  }
+
+  @Override
+  protected Optional<Fix> toStringFix(Tree parent, ExpressionTree tree, VisitorState state) {
+    return Optional.absent();
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OrphanedFormatString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OrphanedFormatString.java
@@ -26,6 +26,8 @@ import static com.google.errorprone.matchers.method.MethodMatchers.instanceMetho
 
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
 import com.google.errorprone.bugpatterns.BugChecker.LiteralTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
@@ -33,11 +35,15 @@ import com.google.errorprone.predicates.TypePredicates;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LiteralTree;
+import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
 import edu.umd.cs.findbugs.formatStringChecker.Formatter;
 import edu.umd.cs.findbugs.formatStringChecker.MissingFormatArgumentException;
+import java.util.List;
 import java.util.regex.Pattern;
 
 /** @author cushon@google.com (Liam Miller-Cushon) */
@@ -47,7 +53,8 @@ import java.util.regex.Pattern;
     severity = WARNING)
 public class OrphanedFormatString extends BugChecker implements LiteralTreeMatcher {
 
-  private static final Matcher<Tree> MATCHER =
+  /** Method calls that developers commonly incorrectly assume to accept format arguments. */
+  private static final Matcher<Tree> LIKELY_MISTAKE_METHOD_CALL =
       toType(
           ExpressionTree.class,
           anyOf(
@@ -78,10 +85,52 @@ public class OrphanedFormatString extends BugChecker implements LiteralTreeMatch
       return NO_MATCH;
     }
     Tree parent = state.getPath().getParentPath().getLeaf();
-    if (!MATCHER.matches(parent, state)) {
-      return NO_MATCH;
+    if (LIKELY_MISTAKE_METHOD_CALL.matches(parent, state)) {
+
+      // If someone has added new API methods to a subtype of the commonly-misused classes, we can
+      // check to see if they made it @FormatMethod and the format-string slots in correctly.
+      if (parent.getKind() == Kind.METHOD_INVOCATION
+          && literalIsFormatMethodArg(tree, (MethodInvocationTree) parent, state)) {
+        return NO_MATCH;
+      }
+
+      return describeMatch(tree);
     }
-    return describeMatch(tree);
+    return NO_MATCH;
+  }
+
+  private static boolean literalIsFormatMethodArg(
+      LiteralTree tree, MethodInvocationTree methodInvocationTree, VisitorState state) {
+    MethodSymbol symbol = ASTHelpers.getSymbol(methodInvocationTree);
+    if (ASTHelpers.hasAnnotation(symbol, FormatMethod.class, state)) {
+      int indexOfParam = findIndexOfFormatStringParameter(state, symbol);
+      if (indexOfParam != -1) {
+        List<? extends ExpressionTree> args = methodInvocationTree.getArguments();
+        // This *shouldn't* be a problem, since this means that the format string is in a varargs
+        // position in a @FormatMethod declaration and the invocation contained no varargs
+        // arguments, but it doesn't hurt to check.
+        return args.size() > indexOfParam && args.get(indexOfParam) == tree;
+      }
+    }
+    return false;
+  }
+
+  private static int findIndexOfFormatStringParameter(VisitorState state, MethodSymbol symbol) {
+    // Find a parameter with @FormatString, if none, use the first String parameter
+    int indexOfFirstString = -1;
+    List<VarSymbol> params = symbol.params();
+    for (int i = 0; i < params.size(); i++) {
+      VarSymbol varSymbol = params.get(i);
+      if (ASTHelpers.hasAnnotation(varSymbol, FormatString.class, state)) {
+        return i;
+      }
+      if (indexOfFirstString == -1
+          && ASTHelpers.isSameType(varSymbol.type, state.getSymtab().stringType, state)) {
+        indexOfFirstString = i;
+      }
+    }
+
+    return indexOfFirstString;
   }
 
   /** Returns true for strings that contain format specifiers. */

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -76,6 +76,7 @@ import com.google.errorprone.bugpatterns.EqualsNaN;
 import com.google.errorprone.bugpatterns.EqualsReference;
 import com.google.errorprone.bugpatterns.ExpectedExceptionChecker;
 import com.google.errorprone.bugpatterns.FallThrough;
+import com.google.errorprone.bugpatterns.FieldCanBeFinal;
 import com.google.errorprone.bugpatterns.Finally;
 import com.google.errorprone.bugpatterns.FloatCast;
 import com.google.errorprone.bugpatterns.FloatingPointLiteralPrecision;
@@ -569,6 +570,7 @@ public class BuiltInCheckerSuppliers {
           EmptyTopLevelDeclaration.class,
           ExpectedExceptionChecker.class,
           FieldMissingNullable.class,
+          FieldCanBeFinal.class,
           FunctionalInterfaceClash.class,
           FuzzyEqualsShouldNotBeUsedInEqualsMethod.class,
           HardCodedSdCardPath.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -159,6 +159,7 @@ import com.google.errorprone.bugpatterns.NullableConstructor;
 import com.google.errorprone.bugpatterns.NullablePrimitive;
 import com.google.errorprone.bugpatterns.NullableVoid;
 import com.google.errorprone.bugpatterns.NumericEquality;
+import com.google.errorprone.bugpatterns.ObjectToString;
 import com.google.errorprone.bugpatterns.OperatorPrecedence;
 import com.google.errorprone.bugpatterns.OptionalEquality;
 import com.google.errorprone.bugpatterns.OptionalNotPresent;
@@ -514,6 +515,7 @@ public class BuiltInCheckerSuppliers {
           NullableConstructor.class,
           NullablePrimitive.class,
           NullableVoid.class,
+          ObjectToString.class,
           OperatorPrecedence.class,
           OptionalNotPresent.class,
           OrphanedFormatString.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -27,6 +27,7 @@ import com.google.errorprone.bugpatterns.ArrayHashCode;
 import com.google.errorprone.bugpatterns.ArrayToString;
 import com.google.errorprone.bugpatterns.ArraysAsListPrimitiveArray;
 import com.google.errorprone.bugpatterns.AssertFalse;
+import com.google.errorprone.bugpatterns.AssertThrowsMultipleStatements;
 import com.google.errorprone.bugpatterns.AssertionFailureIgnored;
 import com.google.errorprone.bugpatterns.AsyncCallableReturnsNull;
 import com.google.errorprone.bugpatterns.AsyncFunctionReturnsNull;
@@ -457,6 +458,7 @@ public class BuiltInCheckerSuppliers {
           AmbiguousMethodReference.class,
           ArgumentSelectionDefectChecker.class,
           AssertEqualsArgumentOrderChecker.class,
+          AssertThrowsMultipleStatements.class,
           AssertionFailureIgnored.class,
           BadAnnotationImplementation.class,
           BadComparable.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/AssertThrowsMultipleStatementsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/AssertThrowsMultipleStatementsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** {@link AssertThrowsMultipleStatements}Test */
+@RunWith(JUnit4.class)
+public class AssertThrowsMultipleStatementsTest {
+
+  private final BugCheckerRefactoringTestHelper compilationHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new AssertThrowsMultipleStatements(), getClass());
+
+  @Test
+  public void ignoreInThrowingRunnables() throws Exception {
+    compilationHelper
+        .addInputLines(
+            "Test.java",
+            "import static org.junit.Assert.assertThrows;",
+            "class Test {",
+            "  void f() {",
+            "   assertThrows(IllegalStateException.class, () -> {",
+            "     System.err.println();",
+            "   });",
+            "   IllegalStateException e = assertThrows(IllegalStateException.class, () -> {",
+            "     System.err.println(1);",
+            "     System.err.println(2);",
+            "   });",
+            "   assertThrows(IllegalStateException.class, () -> {",
+            "     int x = 2;",
+            "     int y = x;",
+            "   });",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import static org.junit.Assert.assertThrows;",
+            "class Test {",
+            "  void f() {",
+            "   assertThrows(IllegalStateException.class, () -> {",
+            "     System.err.println();",
+            "   });",
+            "   System.err.println(1);",
+            "   IllegalStateException e = assertThrows(IllegalStateException.class,",
+            "       () -> System.err.println(2));",
+            "   int x = 2;",
+            "   assertThrows(IllegalStateException.class, () -> {",
+            "     int y = x;",
+            "   });",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/FieldCanBeFinalTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/FieldCanBeFinalTest.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.annotations.Var;
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** @author cushon@google.com (Liam Miller-Cushon) */
+@RunWith(JUnit4.class)
+public class FieldCanBeFinalTest {
+
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(FieldCanBeFinal.class, getClass());
+
+  @Test
+  public void annotationFieldsAreAlreadyFinal() {
+    compilationHelper
+        .addSourceLines(
+            "Anno.java", //
+            "public @interface Anno {",
+            "  int x = 42;",
+            "  static int y = 42;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void simple() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  // BUG: Diagnostic contains: private final int x",
+            "  private int x;",
+            "  Test() {",
+            "    x = 42;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void initializerBlocks() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  // BUG: Diagnostic contains: private final int x1",
+            "  private int x1;",
+            "  private int x2;",
+            "  // BUG: Diagnostic contains: private static final int y1",
+            "  private static int y1;",
+            "  private static int y2;",
+            "  {",
+            "    x1 = 42;",
+            "    x2 = 42;",
+            "  }",
+            "  static {",
+            "    y1 = 42;",
+            "    y2 = 42;",
+            "  }",
+            "  void mutate() {",
+            "    x2 = 0;",
+            "    y2 = 0;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void staticSetFromInstance() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  // BUG: Diagnostic contains: private static final int x1",
+            "  private static int x1;",
+            "  private static int x2;",
+            "  static {",
+            "    x1 = 42;",
+            "    x2 = 42;",
+            "  }",
+            "  {",
+            "    x2 = 42;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  // the nullary constructor doesn't set x directly, but that's OK
+  @Test
+  public void constructorChaining() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  // BUG: Diagnostic contains: private final int x",
+            "  private int x;",
+            "  Test(int x) {",
+            "    this.x = x;",
+            "  }",
+            "  Test() {",
+            "    this(42);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  // we currently handle this by ignoring control flow and looking for at least one initialization
+  @Test
+  public void controlFlow() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  // BUG: Diagnostic contains: private final int x",
+            "  private int x;",
+            "  Test(boolean flag, int x, int y) {",
+            "    if (flag) {",
+            "      this.x = x;",
+            "    } else {",
+            "      this.x = y;",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void doubleInitialization() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  private int x;",
+            "  Test(int x) {",
+            "    this.x = x;",
+            "    this.x = x;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void compoundAssignment() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  private int x;",
+            "  Test() {",
+            "    this.x = 42;",
+            "  }",
+            "  void incr() {",
+            "    x += 1;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void unaryAssignment() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  private int x;",
+            "  Test() {",
+            "    this.x = 42;",
+            "  }",
+            "  void incr() {",
+            "    x++;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void constructorAssignmentToOtherInstance() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  private int x;",
+            "  // BUG: Diagnostic contains: private final int y",
+            "  private int y;",
+            "  Test(Test other) {",
+            "    x = 42;",
+            "    y = 42;",
+            "    other.x = x;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void assignmentFromOutsideCompilationUnit() {
+    compilationHelper
+        .addSourceLines(
+            "A.java",
+            "class A {",
+            "  int x;",
+            "  A(B b) {",
+            "    x = 42;",
+            "    b.x = 42;",
+            "  }",
+            "}")
+        .addSourceLines(
+            "B.java",
+            "class B {",
+            "  int x;",
+            "  B(A a) {",
+            "    x = 42;",
+            "    a.x = 42;",
+            "  }",
+            "}")
+        // hackily force processing of both compilation units so we can verify both diagnostics
+        .setArgs(Arrays.asList("-XDshouldStopPolicyIfError=FLOW"))
+        .doTest();
+  }
+
+  // don't report an error if the field has an initializer and is also written
+  // in the constructor
+  @Test
+  public void guardInitialization() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            String.format("import %s;", Var.class.getCanonicalName()),
+            "class Test {",
+            "  private boolean initialized = false;",
+            "  Test() {",
+            "    initialized = true;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void fieldInitialization() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  // BUG: Diagnostic contains: private final boolean flag",
+            "  private boolean flag = false;",
+            "  Test() {",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void ignoreInject() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import javax.inject.Inject;",
+            "class Test {",
+            "  @Inject private Object x;",
+            "  Test() {",
+            "    this.x = x;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+
+  @Test
+  public void allowNonFinal_nonFinalForTesting() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "@interface NonFinalForTesting {}",
+            "class Test {",
+            "  @NonFinalForTesting private int x;",
+            "  Test(int x) {",
+            "    this.x = x;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void visibleForTesting() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.annotations.VisibleForTesting;",
+            "class Test {",
+            "  @VisibleForTesting public int x;",
+            "  Test() {",
+            "    x = 42;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void protectedField() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.annotations.VisibleForTesting;",
+            "class Test {",
+            "  protected int x;",
+            "  Test() {",
+            "    x = 42;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nonPrivateField() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.annotations.VisibleForTesting;",
+            "class Test {",
+            "  public int x;",
+            "  int y;",
+            "  Test() {",
+            "    x = 42;",
+            "    y = 42;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void allowObjectifyClasses() {
+    compilationHelper
+        .addSourceLines(
+            "com/googlecode/objectify/v4/annotation/Entity.java",
+            "package com.googlecode.objectify.v4.annotation;",
+            "public @interface Entity {}")
+        .addSourceLines(
+            "Test.java",
+            "import com.googlecode.objectify.v4.annotation.Entity;",
+            "@Entity class Test {",
+            "  private int x;",
+            "  Test(int x) {",
+            "    this.x = x;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void initInLambda() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  private int x;",
+            "  private final Runnable r;",
+            "  Test() {",
+            "    r = () -> x = 1;",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ObjectToStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ObjectToStringTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** @author bhagwani@google.com (Sumit Bhagwani) */
+@RunWith(JUnit4.class)
+public class ObjectToStringTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setUp() {
+    compilationHelper = CompilationTestHelper.newInstance(ObjectToString.class, getClass());
+  }
+
+  @Test
+  public void testPositiveCase() throws Exception {
+    compilationHelper.addSourceFile("ObjectToStringPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void testNegativeCase() throws Exception {
+    compilationHelper.addSourceFile("ObjectToStringNegativeCases.java").doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/OrphanedFormatStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/OrphanedFormatStringTest.java
@@ -67,4 +67,34 @@ public class OrphanedFormatStringTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void formatMethod() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.errorprone.annotations.FormatMethod;",
+            "import com.google.errorprone.annotations.FormatString;",
+            "class Test {",
+            "  static class MyPrintWriter extends java.io.PrintWriter {",
+            "    MyPrintWriter() throws java.io.FileNotFoundException {super((String) null);}",
+            "    @FormatMethod",
+            "    public void println(String first, Object...args) {}",
+            "    @FormatMethod",
+            "    public void print(String first,"
+                + " @FormatString String second, Object...args) {}",
+            "  }",
+            "  void f(MyPrintWriter pw) {",
+            "    pw.println(\"%s %s\", \"\", \"\");",
+            "    pw.print(\"\", \"%s\");",
+            // Here, %s in the first position is a non-format String arg
+            "    // BUG: Diagnostic contains: ",
+            "    pw.print(\"%s\", \"%s\");",
+            // The first argument to the format string is another format string
+            "    // BUG: Diagnostic contains: ",
+            "    pw.print(\"\", \"%s\", \"%d\");",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ParameterCommentTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ParameterCommentTest.java
@@ -136,4 +136,28 @@ public class ParameterCommentTest {
             "}")
         .doTest(TestMode.TEXT_MATCH);
   }
+
+  @Test
+  public void parameterComment_doesNotChange_whenNestedComment() throws IOException {
+    testHelper
+        .addInputLines(
+            "in/Test.java",
+            "abstract class Test {",
+            "  abstract void target(Object first, Object second);",
+            "  abstract Object target2(Object second);",
+            "  void test(Object first, Object second) {",
+            "    target(first, target2(/* second= */ second));",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "abstract class Test {",
+            "  abstract void target(Object first, Object second);",
+            "  abstract Object target2(Object second);",
+            "  void test(Object first, Object second) {",
+            "    target(first, target2(/* second= */ second));",
+            "  }",
+            "}")
+        .doTest(TestMode.TEXT_MATCH);
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ObjectToStringNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ObjectToStringNegativeCases.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+/** @author bhagwani@google.com (Sumit Bhagwani) */
+public class ObjectToStringNegativeCases {
+
+  public static final class FinalObjectClassWithoutToString {}
+
+  public static class NonFinalObjectClassWithoutToString {}
+
+  public static final class FinalObjectClassWithToString {
+
+    @Override
+    public String toString() {
+      return "hakuna";
+    }
+  }
+
+  public static class NonFinalObjectClassWithToString {
+
+    @Override
+    public String toString() {
+      return "matata";
+    }
+  }
+
+  public void log(Object o) {
+    System.out.println(o.toString());
+  }
+
+  void directToStringCalls() {
+    NonFinalObjectClassWithoutToString nonFinalObjectClassWithoutToString =
+        new NonFinalObjectClassWithoutToString();
+    System.out.println(nonFinalObjectClassWithoutToString.toString());
+
+    FinalObjectClassWithToString finalObjectClassWithToString = new FinalObjectClassWithToString();
+    System.out.println(finalObjectClassWithToString.toString());
+
+    NonFinalObjectClassWithToString nonFinalObjectClassWithToString =
+        new NonFinalObjectClassWithToString();
+    System.out.println(nonFinalObjectClassWithToString.toString());
+  }
+
+  void callsTologMethod() {
+    FinalObjectClassWithoutToString finalObjectClassWithoutToString =
+        new FinalObjectClassWithoutToString();
+    log(finalObjectClassWithoutToString);
+
+    NonFinalObjectClassWithoutToString nonFinalObjectClassWithoutToString =
+        new NonFinalObjectClassWithoutToString();
+    log(nonFinalObjectClassWithoutToString);
+
+    FinalObjectClassWithToString finalObjectClassWithToString = new FinalObjectClassWithToString();
+    log(finalObjectClassWithToString);
+
+    NonFinalObjectClassWithToString nonFinalObjectClassWithToString =
+        new NonFinalObjectClassWithToString();
+    log(nonFinalObjectClassWithToString);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ObjectToStringPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ObjectToStringPositiveCases.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+/** @author bhagwani@google.com (Sumit Bhagwani) */
+public class ObjectToStringPositiveCases {
+
+  public static final class FinalObjectClassWithoutToString {}
+
+  void directToStringCalls() {
+    FinalObjectClassWithoutToString finalObjectClassWithoutToString =
+        new FinalObjectClassWithoutToString();
+    // BUG: Diagnostic contains: ObjectToString
+    System.out.println(finalObjectClassWithoutToString.toString());
+  }
+}

--- a/core/src/test/java/com/google/errorprone/util/CommentsTest.java
+++ b/core/src/test/java/com/google/errorprone/util/CommentsTest.java
@@ -48,10 +48,11 @@ public class CommentsTest {
    * line of source ending at that position
    */
   @BugPattern(
-      name = "ComputeEndPosition",
-      category = Category.ONE_OFF,
-      severity = SeverityLevel.ERROR,
-      summary = "Calls computeEndPosition and prints results")
+    name = "ComputeEndPosition",
+    category = Category.ONE_OFF,
+    severity = SeverityLevel.ERROR,
+    summary = "Calls computeEndPosition and prints results"
+  )
   public static class ComputeEndPosition extends BugChecker implements MethodInvocationTreeMatcher {
 
     @Override
@@ -120,12 +121,13 @@ public class CommentsTest {
 
   /** A {@link BugChecker} that prints the contents of comments around arguments */
   @BugPattern(
-      name = "PrintCommentsForArguments",
-      category = Category.ONE_OFF,
-      severity = SeverityLevel.ERROR,
-      summary =
-          "Prints comments occurring around arguments. Matches calls to methods named "
-              + "'target' and all constructors")
+    name = "PrintCommentsForArguments",
+    category = Category.ONE_OFF,
+    severity = SeverityLevel.ERROR,
+    summary =
+        "Prints comments occurring around arguments. Matches calls to methods named "
+            + "'target' and all constructors"
+  )
   public static class PrintCommentsForArguments extends BugChecker
       implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
 
@@ -434,14 +436,47 @@ public class CommentsTest {
         .doTest();
   }
 
+  @Test
+  public void findCommentsForArguments_noCommentOnOuterMethod_whenCommentOnNestedMethod() {
+    CompilationTestHelper.newInstance(PrintCommentsForArguments.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            "abstract class Test {",
+            "  abstract Object nested(Object param);",
+            "  abstract void target(Object param);",
+            "  void test(Object param) {",
+            "    // BUG: Diagnostic contains: [[] nested(param) []]",
+            "    target(nested(/* 1 */ param));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void findCommentsForArguments_findsCommentOnOuterMethodOnly_whenCommentOnNestedMethod() {
+    CompilationTestHelper.newInstance(PrintCommentsForArguments.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            "abstract class Test {",
+            "  abstract Object nested(Object param);",
+            "  abstract void target(Object param);",
+            "  void test(Object param) {",
+            "    // BUG: Diagnostic contains: [[1] nested(param) [4]]",
+            "    target(/* 1 */ nested(/* 2 */ param /* 3 */) /* 4 */);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   /** A {@link BugChecker} that prints the source code at comment positions */
   @BugPattern(
-      name = "PrintTextAtCommentPosition",
-      category = Category.ONE_OFF,
-      severity = SeverityLevel.ERROR,
-      summary =
-          "Prints the source code text which is under the comment position. Matches calls to "
-              + "methods called target and constructors only")
+    name = "PrintTextAtCommentPosition",
+    category = Category.ONE_OFF,
+    severity = SeverityLevel.ERROR,
+    summary =
+        "Prints the source code text which is under the comment position. Matches calls to "
+            + "methods called target and constructors only"
+  )
   public static class PrintTextAtCommentPosition extends BugChecker
       implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
 

--- a/docs/bugpattern/AssertThrowsMultipleStatements.md
+++ b/docs/bugpattern/AssertThrowsMultipleStatements.md
@@ -1,0 +1,25 @@
+If the body of the lambda passed to `assertThrows` contains multiple statements,
+executation of the lambda will stop at the first statement that throws an
+exception and all subsequent statements will be ignored.
+
+Don't do this:
+
+```java {.bad}
+ImmutableList<Integer> xs = ImmutableList.of();
+assertThrows(
+    UnsupportedOperationException.class,
+    () -> {
+        xs.add(0);
+        assertThat(xs).isEmpty(); // never executed!
+    });
+```
+
+Do this instead:
+
+```java {.good}
+ImmutableList<Integer> xs = ImmutableList.of();
+assertThrows(
+    UnsupportedOperationException.class,
+    () -> xs.add(0));
+assertThat(xs).isEmpty();
+```

--- a/docs/bugpattern/ObjectToString.md
+++ b/docs/bugpattern/ObjectToString.md
@@ -1,0 +1,5 @@
+Calling `toString` on objects that don't override `toString()` doesn't provide
+useful information (just the class name and the `hashCode()`).
+
+Consider overriding toString() function to return a meaningful String describing
+the object.

--- a/examples/ant/ant_fork/build.xml
+++ b/examples/ant/ant_fork/build.xml
@@ -19,7 +19,7 @@
     <mkdir dir="build"/>
     <!-- external compile (fork="yes") -->
     <componentdef name="errorprone" classname="com.google.errorprone.ErrorProneExternalCompilerAdapter"
-      classpath="../../../ant/target/error_prone_ant-2.2.1-SNAPSHOT.jar"/>
+      classpath="../../../ant/target/error_prone_ant-2.3.1-SNAPSHOT.jar"/>
     <javac srcdir="src" destdir="build" fork="yes" includeantruntime="no">
       <errorprone/>
     </javac>

--- a/examples/gradle/build.gradle
+++ b/examples/gradle/build.gradle
@@ -10,5 +10,5 @@ repositories {
   }
 }
 dependencies {
-  errorprone 'com.google.errorprone:error_prone_core:2.2.1-SNAPSHOT'
+  errorprone 'com.google.errorprone:error_prone_core:2.3.1-SNAPSHOT'
 }

--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -51,7 +51,7 @@
           <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_core</artifactId>
-            <version>2.2.1-SNAPSHOT</version>
+            <version>2.3.1-SNAPSHOT</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/examples/plugin/bazel/WORKSPACE
+++ b/examples/plugin/bazel/WORKSPACE
@@ -1,6 +1,6 @@
 maven_jar(
     name = "error_prone",
-    artifact = "com.google.errorprone:error_prone_ant:2.2.1-SNAPSHOT",
+    artifact = "com.google.errorprone:error_prone_ant:2.3.1-SNAPSHOT",
     repository = "https://oss.sonatype.org/content/repositories/snapshots",
 )
 

--- a/examples/plugin/gradle/build.gradle
+++ b/examples/plugin/gradle/build.gradle
@@ -18,6 +18,6 @@ subprojects {
   apply plugin: 'net.ltgt.apt'
 
   dependencies {
-    errorprone 'com.google.errorprone:error_prone_core:2.2.1-SNAPSHOT'
+    errorprone 'com.google.errorprone:error_prone_core:2.3.1-SNAPSHOT'
   }
 }

--- a/examples/plugin/gradle/sample_plugin/build.gradle
+++ b/examples/plugin/gradle/sample_plugin/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-  compileOnly 'com.google.errorprone:error_prone_core:2.2.1-SNAPSHOT'
-  compileOnly 'com.google.errorprone:error_prone_annotation:2.2.1-SNAPSHOT'
+  compileOnly 'com.google.errorprone:error_prone_core:2.3.1-SNAPSHOT'
+  compileOnly 'com.google.errorprone:error_prone_annotation:2.3.1-SNAPSHOT'
 
   compileOnly         'com.google.auto.service:auto-service:1.0-rc4'
   annotationProcessor 'com.google.auto.service:auto-service:1.0-rc4'

--- a/examples/plugin/maven/hello/pom.xml
+++ b/examples/plugin/maven/hello/pom.xml
@@ -67,7 +67,7 @@
           <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_core</artifactId>
-            <version>2.2.1-SNAPSHOT</version>
+            <version>2.3.1-SNAPSHOT</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/examples/plugin/maven/sample_plugin/pom.xml
+++ b/examples/plugin/maven/sample_plugin/pom.xml
@@ -31,13 +31,13 @@
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_core</artifactId>
-      <version>2.2.1-SNAPSHOT</version>
+      <version>2.3.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotation</artifactId>
-      <version>2.2.1-SNAPSHOT</version>
+      <version>2.3.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add FieldCanBeFinal - an optional check to identify fields that are only
assigned within a constructor.

RELNOTES: New optional (disabled by default) check: FieldCanBeFinal - to
identify fields that could be made final as they are only assigned once in
constructors or field initializers.

GOOGLE: moving it from the refaster directory and leaving it as a refaster
cleanup.

bf52036d2d3f5c311d930f6d39f520095c785cd8

-------

<p> Flag toString() on Objects without toString() overrides and final type

RELNOTES: Flag toString() on Objects without toString() overrides and final type

b9ea0177d57a88ac8abe898a3985c32f9751e2cb

-------

<p> Fix bug in comment parser when there is a comment on a nested method call.

RELNOTES: Fix bug in comment parser when there is a comment on a nested method call.

22e8298e3c82f250bb7d2fe0db581a8ddd839b39

-------

<p> Change cast in SuggestedFixes.compilesWithFix.

BasicJavacTask is a superclass of JavacTaskImpl, and provides the necessary getContext() method.

RELNOTES: n/a

736928cc0358e3031c4045d2cff3648b18b20696

-------

<p> Add a check to discourage assertThrows with block lambdas with >1 statement

RELNOTES: [AssertThrowsMultipleStatements] The lambda passed to assertThows should contain exactly one statement

b3442865df98d2252e0e35607652f89985f329a1

-------

<p> Make OrphanedFormatString detect instances where format string literals are
passed to @FormatMethod methods in the right position.

RELNOTES: OrphanedFormatString detects string literals correctly passed to
@FormatMethod methods

df39c21f6637cc4b985d17690ec074ef6ca04d14

-------

<p> Update examples for 2.3.0 release.

1ca0d1c0f33b8f453ac29b0a69d05abed1fe7783