### PR TITLE
Allow javac options to have directories that end in .java

### DIFF
--- a/check_api/pom.xml
+++ b/check_api/pom.xml
@@ -141,4 +141,18 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19.1</version>
+        <configuration>
+          <!-- set heap size to work around http://github.com/travis-ci/travis-ci/issues/3396 -->
+          <!-- put javac.jar on bootclasspath when executing tests -->
+          <argLine>-Xmx1024m -Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/check_api/src/main/java/com/google/errorprone/BaseErrorProneCompiler.java
+++ b/check_api/src/main/java/com/google/errorprone/BaseErrorProneCompiler.java
@@ -96,13 +96,17 @@ public class BaseErrorProneCompiler {
     }
     List<String> javacOpts = new ArrayList<>();
     List<String> sources = new ArrayList<>();
+
+    boolean nextArgIsUsedByJavacOption = false;
+    List<String> javacArgsThatTakeDirectories = ImmutableList.of("-d", "-h", "-s");
     for (String arg : argv) {
       // TODO(cushon): is there a better way to categorize javacopts?
-      if (!arg.startsWith("-") && arg.endsWith(".java")) {
+      if (!arg.startsWith("-") && arg.endsWith(".java") && !nextArgIsUsedByJavacOption) {
         sources.add(arg);
       } else {
         javacOpts.add(arg);
       }
+      nextArgIsUsedByJavacOption = javacArgsThatTakeDirectories.contains(arg);
     }
     StandardJavaFileManager fileManager = new MaskedFileManager();
     return run(

--- a/check_api/src/test/java/com/google/errorprone/BaseErrorProneCompilerTest.java
+++ b/check_api/src/test/java/com/google/errorprone/BaseErrorProneCompilerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone;
+
+import java.util.List;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class BaseErrorProneCompilerTest {
+  @Captor private ArgumentCaptor<String[]> argsCaptor;
+  @Captor private ArgumentCaptor<List<JavaFileObject>> javaFileObjectsCaptor;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void parseSourcesFromCommandLine() {
+    BaseErrorProneCompiler baseErrorProneCompiler = mock(BaseErrorProneCompiler.class);
+    when(baseErrorProneCompiler.run(any(String[].class))).thenCallRealMethod();
+
+    baseErrorProneCompiler.run(new String[]{
+        "-d", "classes",
+        "-source", "8",
+        "-target", "8",
+        "-classpath", "/tmp/a.jar:/tmp/b.jar",
+        "-Xep:StringSplitter:OFF",
+        "com/example/HelloWorld.java"});
+
+    verify(baseErrorProneCompiler).run(argsCaptor.capture(),
+        any(JavaFileManager.class),
+        javaFileObjectsCaptor.capture(),
+        any());
+
+    String[] capturedArgs = argsCaptor.<String[]> getValue();
+    assertEquals(9, capturedArgs.length);
+    assertEquals("-d", capturedArgs[0]);
+
+    List<JavaFileObject> capturedJavaFileObjects = javaFileObjectsCaptor.<List<JavaFileObject>>getValue();
+    assertEquals(1, capturedJavaFileObjects.size());
+    assertTrue(capturedJavaFileObjects.get(0).getName().endsWith("HelloWorld.java"));
+  }
+
+  @Test
+  public void parseOutputDirectoryEndsInJava() {
+    BaseErrorProneCompiler baseErrorProneCompiler = mock(BaseErrorProneCompiler.class);
+    when(baseErrorProneCompiler.run(any(String[].class))).thenCallRealMethod();
+
+    baseErrorProneCompiler.run(new String[]{
+        "-d", "classes.java",
+        "-classpath", "/tmp/a.jar:/tmp/b.jar",
+        "com/example/HelloWorld.java"});
+
+    verify(baseErrorProneCompiler).run(argsCaptor.capture(),
+        any(JavaFileManager.class),
+        javaFileObjectsCaptor.capture(),
+        any());
+
+    String[] capturedArgs = argsCaptor.<String[]> getValue();
+    assertEquals(4, capturedArgs.length);
+
+    List<JavaFileObject> capturedJavaFileObjects = javaFileObjectsCaptor.<List<JavaFileObject>>getValue();
+    assertEquals(1, capturedJavaFileObjects.size());
+    assertTrue(capturedJavaFileObjects.get(0).getName().endsWith("HelloWorld.java"));
+  }
+}


### PR DESCRIPTION
I ran into a problem where the output directory getting passed to Errorprone as a javac option ended in `.java` and it was mistakenly getting used for a source file.

e.g.

```
javac -d ouptut/com/hello.java com/exmplar/HelloWorld.java
```

I looked at using the Java Main or Arguments class to do the parsing via `processArgs()` instead but they changed it between Java 8 and Java 9 and say the API is use at your own risk.  
