### PR TITLE
Moe Sync

### DIFF
--- a/annotations/src/main/java/com/google/errorprone/annotations/concurrent/LazyInit.java
+++ b/annotations/src/main/java/com/google/errorprone/annotations/concurrent/LazyInit.java
@@ -22,22 +22,39 @@ import java.lang.annotation.Target;
 
 /**
  * Use this annotation on any static or field that will be initialized lazily, where races yield no
- * semantic difference in the code. The canonical example of this is String.hashCode():
+ * semantic difference in the code (as, for example, is the case with {@link String#hashCode}). Note
+ * that lazily initializing a non-volatile field is hard to do correctly, and one should rarely use
+ * this. It should also only be done by developers who clearly understand the potential issues, and
+ * then, always using the pattern as presented in the {@code getData} method of this sample code
+ * below:
  *
  * <pre>{@code
- * public int hashCode() {
- *   int h = hash;
- *   if (h == 0 && value.length > 0) {
- *     char val[] = value;
+ * private final String source;
+ * {@literal @}LazyInit private String data;
  *
- *     for (int i = 0; i < value.length; i++) {
- *       h = 31 * h + val[i];
- *     }
- *     hash = h;
+ * public String getData() {
+ *   String local = data;
+ *   if (local == null) {
+ *     local = data = expensiveCalculation(source);
  *   }
- *   return h;
+ *   return local;
+ *  }
+ *
+ * private static String expensiveCalculation(String string) {
+ *   return string.replaceAll(" ", "_");
  * }
  * }</pre>
+ *
+ * <p>The need for using the {@code local} variable is detailed in
+ * http://jeremymanson.blogspot.com/2008/12/benign-data-races-in-java.html (see, particularly, the
+ * part after "Now, let's break the code").
+ *
+ * <p>Also note that {@code LazyInit} must not be used on 64-bit primitives (such as {@code long}s
+ * and {@code double}s), because the Java Language Specification does not guarantee that writing to
+ * these is made atomically. Furthermore, when using for non-primitives, the non-primitive must be
+ * either truly immutable or at least thread safe (in the Java memory model sense). Again, unless
+ * you really understand this <b>and</b> you really need the performance benefits of avoiding the
+ * data race, do not use this construct.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadNestedImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadNestedImport.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.IdentifierTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.google.errorprone.util.FindIdentifiers;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.ImportTree;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+
+/** @author awturner@google.com (Andy Turner) */
+@BugPattern(
+  name = "BadNestedImport",
+  summary =
+      "Importing nested classes with commonly-used names can make code harder to read, because "
+          + "it may not be clear from the context exactly which type is being referred to. "
+          + "Qualifying the name with that of the containing class can make the code clearer.",
+  severity = WARNING,
+  providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION
+)
+public class BadNestedImport extends BugChecker implements IdentifierTreeMatcher {
+  private static final ImmutableSet<String> IDENTIFIERS_TO_REPLACE =
+      ImmutableSet.of("Builder", "Type", "Entry");
+
+  @Override
+  public Description matchIdentifier(IdentifierTree tree, VisitorState state) {
+    Symbol symbol = ASTHelpers.getSymbol(tree);
+    if (!(symbol instanceof ClassSymbol)) {
+      return Description.NO_MATCH;
+    }
+    if (!IDENTIFIERS_TO_REPLACE.contains(symbol.getSimpleName().toString())) {
+      return Description.NO_MATCH;
+    }
+    if (!findImport(symbol, state)) {
+      return Description.NO_MATCH;
+    }
+
+    Symbol parent = symbol.getEnclosingElement();
+    if (!(parent instanceof ClassSymbol)) {
+      return Description.NO_MATCH;
+    }
+
+    Symbol found = FindIdentifiers.findIdent(parent.getSimpleName().toString(), state);
+    if (found instanceof ClassSymbol && !parent.equals(found)) {
+      // There is another symbol already with this name.
+      return Description.NO_MATCH;
+    }
+
+    return describeMatch(
+        tree,
+        SuggestedFix.builder()
+            .addImport(parent.toString())
+            .replace(tree, parent.getSimpleName() + "." + symbol.getSimpleName())
+            .build());
+  }
+
+  private static boolean findImport(Symbol symbol, VisitorState state) {
+    // Inspect the imports to make sure we actually are importing this name.
+    CompilationUnitTree compilationUnitTree = state.findEnclosing(CompilationUnitTree.class);
+    if (compilationUnitTree == null) {
+      // Something is very odd if we hit this... just don't bail.
+      return false;
+    }
+
+    for (ImportTree importTree : compilationUnitTree.getImports()) {
+      Symbol imported = ASTHelpers.getSymbol(importTree.getQualifiedIdentifier());
+      if (symbol.equals(imported)) {
+        // We are importing this identifier, so we want to stop doing that.
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/CloseableProvides.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/CloseableProvides.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.inject;
+
+import static com.google.errorprone.BugPattern.Category.INJECT;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.methodReturns;
+import static com.google.errorprone.matchers.Matchers.not;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.InjectMatchers;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.MethodTree;
+
+/** @author bhagwani@google.com (Sumit Bhagwani) */
+@BugPattern(
+  name = "CloseableProvides",
+  summary = "Providing Closeable resources makes their lifecycle unclear",
+  category = INJECT,
+  severity = WARNING,
+  providesFix = ProvidesFix.NO_FIX
+)
+public class CloseableProvides extends BugChecker implements MethodTreeMatcher {
+
+  private static final Matcher<MethodTree> CLOSEABLE_PROVIDES_MATCHER =
+      allOf(
+          InjectMatchers.hasProvidesAnnotation(),
+          methodReturns(Matchers.isSubtypeOf("java.io.Closeable"))
+          );
+
+  @Override
+  public Description matchMethod(MethodTree tree, VisitorState state) {
+    if (!CLOSEABLE_PROVIDES_MATCHER.matches(tree, state)) {
+      return Description.NO_MATCH;
+    }
+    return describeMatch(tree);
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -261,6 +261,7 @@ import com.google.errorprone.bugpatterns.formatstring.FormatStringAnnotationChec
 import com.google.errorprone.bugpatterns.inject.AssistedInjectAndInjectOnConstructors;
 import com.google.errorprone.bugpatterns.inject.AssistedInjectAndInjectOnSameConstructor;
 import com.google.errorprone.bugpatterns.inject.AutoFactoryAtInject;
+import com.google.errorprone.bugpatterns.inject.CloseableProvides;
 import com.google.errorprone.bugpatterns.inject.InjectOnConstructorOfAbstractClass;
 import com.google.errorprone.bugpatterns.inject.InjectedConstructorAnnotations;
 import com.google.errorprone.bugpatterns.inject.InvalidTargetingOnScopingAnnotation;
@@ -473,6 +474,7 @@ public class BuiltInCheckerSuppliers {
           CatchFail.class,
           ClassCanBeStatic.class,
           ClassNewInstance.class,
+          CloseableProvides.class,
           CollectionToArraySafeParameter.class,
           CollectorShouldNotUseState.class,
           ComparableAndComparator.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -33,6 +33,7 @@ import com.google.errorprone.bugpatterns.AsyncCallableReturnsNull;
 import com.google.errorprone.bugpatterns.AsyncFunctionReturnsNull;
 import com.google.errorprone.bugpatterns.BadAnnotationImplementation;
 import com.google.errorprone.bugpatterns.BadComparable;
+import com.google.errorprone.bugpatterns.BadNestedImport;
 import com.google.errorprone.bugpatterns.BadShiftAmount;
 import com.google.errorprone.bugpatterns.BigDecimalLiteralDouble;
 import com.google.errorprone.bugpatterns.BooleanParameter;
@@ -463,6 +464,7 @@ public class BuiltInCheckerSuppliers {
           AssertionFailureIgnored.class,
           BadAnnotationImplementation.class,
           BadComparable.class,
+          BadNestedImport.class,
           BoxedPrimitiveConstructor.class,
           ByteBufferBackingArray.class,
           CannotMockFinalClass.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/BadNestedImportTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/BadNestedImportTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link BadNestedImport}. */
+@RunWith(JUnit4.class)
+public final class BadNestedImportTest {
+  CompilationTestHelper compilationTestHelper;
+
+  @Before
+  public void setup() {
+    compilationTestHelper = CompilationTestHelper.newInstance(BadNestedImport.class, getClass());
+  }
+
+  @Test
+  public void positiveCases() {
+    compilationTestHelper.addSourceFile("BadNestedImportPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void negativeCases() {
+    compilationTestHelper.addSourceFile("BadNestedImportNegativeCases.java").doTest();
+  }
+
+  @Test
+  public void testFixes() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(new BadNestedImport(), getClass())
+        .addInput("BadNestedImportPositiveCases.java")
+        .addOutput("BadNestedImportPositiveCases_expected.java")
+        .doTest(TestMode.AST_MATCH);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/CloseableProvidesTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/CloseableProvidesTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.inject;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** @author bhagwani@google.com (Sumit Bhagwani) */
+@RunWith(JUnit4.class)
+public class CloseableProvidesTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setUp() {
+    compilationHelper = CompilationTestHelper.newInstance(CloseableProvides.class, getClass());
+  }
+
+  @Test
+  public void testPositiveCase() throws Exception {
+    compilationHelper.addSourceFile("CloseableProvidesPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void testNegativeCase() throws Exception {
+    compilationHelper.addSourceFile("CloseableProvidesNegativeCases.java").doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/testdata/CloseableProvidesNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/testdata/CloseableProvidesNegativeCases.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.inject.testdata;
+
+import com.google.inject.Provides;
+import javax.inject.Singleton;
+
+/** @author bhagwani@google.com (Sumit Bhagwani) */
+public class CloseableProvidesNegativeCases {
+
+  static class DoesNotImplementsClosable {
+    public void close() {
+      // no op
+    }
+  }
+
+  @Provides
+  DoesNotImplementsClosable providesDoesNotImplementsClosable() throws Exception {
+    return new DoesNotImplementsClosable();
+  }
+
+  @Provides
+  @Singleton
+  Object providesObject() throws Exception {
+    return new Object();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/testdata/CloseableProvidesPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/testdata/CloseableProvidesPositiveCases.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.inject.testdata;
+
+import com.google.inject.Provides;
+import java.io.Closeable;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import javax.inject.Singleton;
+
+/** @author bhagwani@google.com (Sumit Bhagwani) */
+public class CloseableProvidesPositiveCases {
+
+  static class ImplementsClosable implements Closeable {
+    public void close() {
+      // no op
+    }
+  }
+
+  @Provides
+  // BUG: Diagnostic contains: CloseableProvides
+  ImplementsClosable providesImplementsClosable() throws Exception {
+    return new ImplementsClosable();
+  }
+
+  @Provides
+  @Singleton
+  // BUG: Diagnostic contains: CloseableProvides
+  PrintWriter providesPrintWriter() throws Exception {
+    return new PrintWriter("some_file_path", StandardCharsets.UTF_8.name());
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/BadNestedImportNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/BadNestedImportNegativeCases.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.testdata;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+
+/**
+ * Tests for {@link BadNestedImport}.
+ *
+ * @author awturner@google.com (Andy Turner)
+ */
+public class BadNestedImportNegativeCases {
+  public void qualified() {
+    ImmutableList.Builder<String> qualified;
+    com.google.common.collect.ImmutableList.Builder<String> fullyQualified;
+    ImmutableList.Builder raw;
+
+    new ImmutableList.Builder<String>();
+  }
+
+  static class Nested {
+    static class Builder {}
+
+    void useNestedBuilder() {
+      new Builder();
+    }
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/BadNestedImportPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/BadNestedImportPositiveCases.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.testdata;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+
+/**
+ * Tests for {@link BadNestedImport}.
+ *
+ * @author awturner@google.com (Andy Turner)
+ */
+class BadNestedImportPositiveCases {
+  public void variableDeclarations() {
+    // BUG: Diagnostic contains: ImmutableList.Builder
+    Builder<String> qualified;
+    // BUG: Diagnostic contains: ImmutableList.Builder
+    Builder raw;
+  }
+
+  public void variableDeclarationsNestedGenerics() {
+    // BUG: Diagnostic contains: ImmutableList.Builder
+    Builder<Builder<String>> builder1;
+    // BUG: Diagnostic contains: ImmutableList.Builder
+    Builder<Builder> builder1Raw;
+    // BUG: Diagnostic contains: ImmutableList.Builder
+    ImmutableList.Builder<Builder<String>> builder2;
+    // BUG: Diagnostic contains: ImmutableList.Builder
+    ImmutableList.Builder<Builder> builder2Raw;
+  }
+
+  public void newClass() {
+    // BUG: Diagnostic contains: ImmutableList.Builder
+    new Builder<String>();
+    // BUG: Diagnostic contains: ImmutableList.Builder
+    new Builder<Builder<String>>();
+  }
+
+  // BUG: Diagnostic contains: ImmutableList.Builder
+  Builder<String> returnGenericExplicit() {
+    // BUG: Diagnostic contains: ImmutableList.Builder
+    return new Builder<String>();
+  }
+
+  // BUG: Diagnostic contains: ImmutableList.Builder
+  Builder<String> returnGenericDiamond() {
+    // BUG: Diagnostic contains: ImmutableList.Builder
+    return new Builder<>();
+  }
+
+  // BUG: Diagnostic contains: ImmutableList.Builder
+  Builder returnRaw() {
+    // BUG: Diagnostic contains: ImmutableList.Builder
+    return new Builder();
+  }
+
+  void classLiteral() {
+    // BUG: Diagnostic contains: ImmutableList.Builder
+    System.out.println(Builder.class);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/BadNestedImportPositiveCases_expected.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/BadNestedImportPositiveCases_expected.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.testdata;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+
+/**
+ * Tests for {@link BadNestedImport}.
+ *
+ * @author awturner@google.com (Andy Turner)
+ */
+class BadNestedImportPositiveCases {
+  public void variableDeclarations() {
+    ImmutableList.Builder<String> qualified;
+    ImmutableList.Builder raw;
+  }
+
+  public void variableDeclarationsNestedGenerics() {
+    ImmutableList.Builder<ImmutableList.Builder<String>> builder1;
+    ImmutableList.Builder<ImmutableList.Builder> builder1Raw;
+    ImmutableList.Builder<ImmutableList.Builder<String>> builder2;
+    ImmutableList.Builder<ImmutableList.Builder> builder2Raw;
+  }
+
+  public void newClass() {
+    new ImmutableList.Builder<String>();
+    new ImmutableList.Builder<ImmutableList.Builder<String>>();
+  }
+
+  ImmutableList.Builder<String> returnGenericExplicit() {
+    return new ImmutableList.Builder<String>();
+  }
+
+  ImmutableList.Builder<String> returnGenericDiamond() {
+    return new ImmutableList.Builder<>();
+  }
+
+  ImmutableList.Builder returnRaw() {
+    return new ImmutableList.Builder();
+  }
+
+  void classLiteral() {
+    System.out.println(ImmutableList.Builder.class);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ObjectToStringNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ObjectToStringNegativeCases.java
@@ -16,6 +16,8 @@
 
 package com.google.errorprone.bugpatterns.testdata;
 
+import org.joda.time.Duration;
+
 /** @author bhagwani@google.com (Sumit Bhagwani) */
 public class ObjectToStringNegativeCases {
 
@@ -71,5 +73,13 @@ public class ObjectToStringNegativeCases {
     NonFinalObjectClassWithToString nonFinalObjectClassWithToString =
         new NonFinalObjectClassWithToString();
     log(nonFinalObjectClassWithToString);
+  }
+
+  public void overridePresentInAbstractClassInHierarchy(Duration durationArg) {
+    String unusedString = Duration.standardSeconds(86400).toString();
+    System.out.println("test joda string " + Duration.standardSeconds(86400));
+
+    unusedString = durationArg.toString();
+    System.out.println("test joda string " + durationArg);
   }
 }

--- a/docs/bugpattern/CloseableProvides.md
+++ b/docs/bugpattern/CloseableProvides.md
@@ -1,0 +1,108 @@
+If you provide
+[`Closeable`](https://docs.oracle.com/javase/7/docs/api/java/io/Closeable.html)
+resources through dependency injection, it can be difficult to effectively
+manage the lifecycle of the Closable:
+
+```java
+class MyModule extends AbstractModule() {
+  @Provides
+  FileOutputStream provideFileStream() {
+    return new FileOutputStream("/tmp/outfile");
+  }
+}
+
+...
+
+class Client {
+  private final FileOutputStream fos;
+  @Inject Client(FileOutputStream fos, OtherDependency other, ...) {
+     this.fos = fos;
+  }
+  void doSomething() throws IOException {
+    fos.write("hello!");
+  }
+}
+```
+
+There are a number of issues with this approach as it relates to resource
+management:
+
+*   If multiple Client classes are constructed, multiple output streams are
+    opened against the same file, and writes to the file may clash with
+    eachother.
+*   It's not clear which class has the responsibility of closing the
+    `FileOutputStream` resource:
+
+    *   If the resource is created for the sole ownership of `Client`, then it
+        makes sense for the client to close it.
+    *   However, if the resource is scoped (e.g.: you add `@Singleton` to the
+        `@Provides` method), then suddenly it's *not* the responsibility of
+        `Client` to close the resource. If one `Client` closes the stream, then
+        all of the other users of that stream will be dealing with a closed
+        resource. There needs to be some other 'resource manager' object that
+        also gets that stream, and its closing functions are call in the right
+        place. That can be tricky to do correctly.
+
+*   If, for example, the construction of the other dependencies of `Client`
+    fails (resulting in a `ProvisionException`), then the `FileOutputStream`
+    that may have been constructed leaks and isn't properly closed, even if
+    `Client` normally closes its resources correctly.
+
+The preferred solution is to not inject closable resources, but instead, objects
+that can expose short-lived closable resources that are used as necessary. The
+following example uses Guava's
+[CharSource](https://github.com/google/guava/wiki/IOExplained#sources-and-sinks)
+as the resource manager object:
+
+```java
+class MyModule extends AbstractModule() {
+  @Provides
+  CharSink provideCharSink() {
+    return Files.asCharSink(new File("/tmp/outfile"), StandardCharsets.UTF_8);
+  }
+}
+
+...
+
+class Client {
+  private final CharSink sink;
+  @Inject Client(CharSink sink, OtherDependency other, ...) {
+     this.sink = sink;
+  }
+  void doSomething() throws IOException {
+    sink.write("hello!"); // Opens the file at this point, and closes once its done.
+  }
+}
+```
+
+If there's not a similar non-closable resource, you can write a simple wrapper:
+
+```java
+class ResourceManager {
+  @Inject ResourceManager(@Config String configs, ...) {}
+
+  /**
+   * Returns a new thing for you to use and dispose of
+   */
+  OutputStream provideInstance() { return new...(); }
+}
+
+...
+class Client {
+  private final ResourceManager resource;
+  @Inject Client(ResourceManager resource, OtherDependency other, ...) {
+     this.resource = resource;
+  }
+  void doSomething() {
+    try (OutputStream actualStream = resource.provideInstance()) {
+      // write to actualStream, closing with try-with-resources
+    }
+  }
+}
+
+```
+
+This pattern can be extended to other resources: as opposed to injecting
+database connection handles directly, inject connection pool objects that
+require your object to ask for those connection objects when they're needed and
+close them safely.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add joda.time.Duration eg for ObjectToString negative cases.

RELNOTES: N/A

08528b79a9bb627a6c795c344541b73514ddba42

-------

<p> Improve LazyInit's documentation

There are several issues with the current documentation that I am attempting to address with this CL:

1. before this CL, hashCode is used to exemplify the situations where it's ok for an initialization to be racy; but hashCode's use of a local variable is evidently needed because it is not atomically constructed in this method, which masks the fact that, even if the hashCode was calculated atomically, a local variable would also be required to avoid the problem of out-of-order reading of the (non-volatile) field; this is aggravated by the fact that the javadoc does not state the problem

2. also, using hashCode as an example precludes demonstrating how to apply the @LazyInit annotation (which is not present in String.hash).

To address these problems:

a. the example code has been change to be minimal and self-contained, and provide a template for people to copy-and-paste when using the annotation; this example code now also includes the field that is annotated with @LazyInit

b. a caution has been added to say that the (weird) pattern is necessary, and a link has been added for the extensive documentation

c. the note on "hashCode" has been left, but it simply links to the code in String.java, rather than copy and paste it

RELNOTES: None

cc8fe93a6fa1bcb7798166684d1e68351e8421f6

-------

<p> Add BadNestedImport to errorprone

RELNOTES: Add suggestion not to import "bad" nested imports, like Builder, Type and Entry.

4e21ef2fdb466ac13c2860911032f1bf2fdd8162

-------

<p> Flag Closeable provide methods

RELNOTES: New check: CloseableProvides - to warn on methods which provide closeable objects using dependency injection. This is done because the lifecycle of such objects is unclear

c54426da3e31f65cf7bcc33b3514f770c1454058