### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/AppliedFix.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/AppliedFix.java
@@ -62,8 +62,12 @@ public class AppliedFix {
     public AppliedFix apply(Fix suggestedFix) {
       StringBuilder replaced = new StringBuilder(source);
 
+      // We have to apply the replacements in descending order, since otherwise the positions in
+      // subsequent replacements are invalidated by earlier replacements.
+      Set<Replacement> replacements = descending(suggestedFix.getReplacements(endPositions));
+
       Set<Integer> modifiedLines = new HashSet<>();
-      for (Replacement repl : suggestedFix.getReplacements(endPositions)) {
+      for (Replacement repl : replacements) {
         replaced.replace(repl.startPosition(), repl.endPosition(), repl.replaceWith());
 
         // Find the line number(s) being modified
@@ -112,6 +116,13 @@ public class AppliedFix {
         // impossible since source is in-memory
       }
       return new AppliedFix(snippet, isRemoveLine);
+    }
+
+    /** Get the replacements in an appropriate order to apply correctly. */
+    private static Set<Replacement> descending(Set<Replacement> set) {
+      Replacements replacements = new Replacements();
+      set.forEach(replacements::add);
+      return replacements.descending();
     }
   }
 

--- a/check_api/src/test/java/com/google/errorprone/fixes/AppliedFixTest.java
+++ b/check_api/src/test/java/com/google/errorprone/fixes/AppliedFixTest.java
@@ -20,13 +20,18 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.sun.source.tree.TreeVisitor;
 import com.sun.tools.javac.tree.EndPosTable;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.Position;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -150,5 +155,20 @@ public class AppliedFixTest {
         AppliedFix.fromSource("package com.example;\n" + "import java.util.Map;\n", endPositions)
             .apply(SuggestedFix.delete(node));
     assertThat(fix.getNewCodeSnippet().toString(), equalTo("to remove this line"));
+  }
+
+  @Test
+  public void shouldApplyFixesInReverseOrder() {
+    // Have to use a mock Fix here in order to intentionally return Replacements in wrong order.
+    Set<Replacement> replacements = new LinkedHashSet<>();
+    replacements.add(Replacement.create(0, 1, ""));
+    replacements.add(Replacement.create(1, 1, ""));
+
+    Fix mockFix = mock(Fix.class);
+    when(mockFix.getReplacements(any())).thenReturn(replacements);
+
+    // If the fixes had been applied in the wrong order, this would fail.
+    // But it succeeds, so they were applied in the right order.
+    AppliedFix.fromSource(" ", endPositions).apply(mockFix);
   }
 }

--- a/docs/bugpattern/AssertThrowsMultipleStatements.md
+++ b/docs/bugpattern/AssertThrowsMultipleStatements.md
@@ -2,15 +2,23 @@ If the body of the lambda passed to `assertThrows` contains multiple statements,
 executation of the lambda will stop at the first statement that throws an
 exception and all subsequent statements will be ignored.
 
+This means that:
+
+*   Any set-up logic in the lambda will cause the test to incorrectly pass if it
+    throws the expected exception.
+*   Any assertions that run after the statement that throws will never be 
+    executed.
+
 Don't do this:
 
 ```java {.bad}
-ImmutableList<Integer> xs = ImmutableList.of();
+ImmutableList<Integer> xs;
 assertThrows(
     UnsupportedOperationException.class,
     () -> {
+        xs = ImmutableList.of(); // the test passes if this throws
         xs.add(0);
-        assertThat(xs).isEmpty(); // never executed!
+        assertThat(xs).isEmpty(); // this is never executed
     });
 ```
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Explicitly sort Replacements before applying them in AppliedFix.

RELNOTES: None

6e72ff3f7225d73079eabbcd6205eb7ebebfd663

-------

<p> Clarify that running code before the statement that is expected to throw is also problematic

6185d3d309f3c23c21e364e902f811aa2fa03fb1