### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/FloatingPointAssertionWithinEpsilon.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FloatingPointAssertionWithinEpsilon.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.Iterables.getLast;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.errorprone.BugPattern.Category.TRUTH;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.BugPattern.StandardTags;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers.MethodNameMatcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.BinaryTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.TypeTag;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * Detects usages of {@code Float,DoubleSubject.isWithin(TOLERANCE).of(EXPECTED)} where there are no
+ * other floating point values other than {@code EXPECTED} with satisfy the assertion, but {@code
+ * TOLERANCE} is not zero. Likewise for older-style JUnit assertions ({@code assertEquals(double,
+ * double, double)}).
+ *
+ * @author ghm@google.com (Graeme Morgan)
+ */
+@BugPattern(
+    name = "FloatingPointAssertionWithinEpsilon",
+    summary =
+        "This fuzzy equality check is using a tolerance less than the gap to the next number. "
+            + "You may want a less restrictive tolerance, or to assert equality.",
+    category = TRUTH,
+    severity = WARNING,
+    tags = StandardTags.SIMPLIFICATION,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+public final class FloatingPointAssertionWithinEpsilon extends BugChecker
+    implements MethodInvocationTreeMatcher {
+
+  private static final String DESCRIPTION =
+      "This fuzzy equality check is using a tolerance less than the gap to the next number "
+          + "(which is ~%.2g). You may want a less restrictive tolerance, or to assert equality.";
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    for (FloatingPointType floatingPointType : FloatingPointType.values()) {
+      Optional<Description> description = floatingPointType.match(this, tree, state);
+      if (description.isPresent()) {
+        return description.get();
+      }
+    }
+    return Description.NO_MATCH;
+  }
+
+  @SuppressWarnings("ImmutableEnumChecker")
+  private enum FloatingPointType {
+    FLOAT(
+        TypeTag.FLOAT, "float", "com.google.common.truth.FloatSubject", "TolerantFloatComparison") {
+      @Override
+      Float nextNumber(Number actual) {
+        float number = actual.floatValue();
+        return Math.min(Math.nextUp(number) - number, number - Math.nextDown(number));
+      }
+
+      @Override
+      boolean isIntolerantComparison(Number tolerance, Number actual) {
+        return tolerance.floatValue() != 0 && tolerance.floatValue() < nextNumber(actual);
+      }
+    },
+    DOUBLE(
+        TypeTag.DOUBLE,
+        "double",
+        "com.google.common.truth.DoubleSubject",
+        "TolerantDoubleComparison") {
+      @Override
+      Double nextNumber(Number actual) {
+        double number = actual.doubleValue();
+        return Math.min(Math.nextUp(number) - number, number - Math.nextDown(number));
+      }
+
+      @Override
+      boolean isIntolerantComparison(Number tolerance, Number actual) {
+        return tolerance.doubleValue() != 0 && tolerance.doubleValue() < nextNumber(actual);
+      }
+    };
+
+    private final TypeTag typeTag;
+    private final String typeName;
+    private final Matcher<MethodInvocationTree> truthOfCall;
+    private final Matcher<ExpressionTree> junitWithoutMessage;
+    private final Matcher<ExpressionTree> junitWithMessage;
+
+    private FloatingPointType(
+        TypeTag typeTag, String typeName, String subjectClass, String tolerantSubclass) {
+      this.typeTag = typeTag;
+      this.typeName = typeName;
+      String tolerantClass = subjectClass + "." + tolerantSubclass;
+      truthOfCall =
+          allOf(
+              instanceMethod().onDescendantOf(tolerantClass).named("of").withParameters(typeName),
+              Matchers.receiverOfInvocation(
+                  instanceMethod()
+                      .onDescendantOf(subjectClass)
+                      .withNameMatching(Pattern.compile("is(Not)?Within"))
+                      .withParameters(typeName)));
+      MethodNameMatcher junitAssert =
+          staticMethod().onClass("org.junit.Assert").named("assertEquals");
+      junitWithoutMessage = junitAssert.withParameters(typeName, typeName, typeName);
+      junitWithMessage =
+          junitAssert.withParameters("java.lang.String", typeName, typeName, typeName);
+    }
+
+    abstract Number nextNumber(Number actual);
+
+    abstract boolean isIntolerantComparison(Number tolerance, Number actual);
+
+    private Optional<Description> match(
+        BugChecker bugChecker, MethodInvocationTree tree, VisitorState state) {
+      if (junitWithoutMessage.matches(tree, state)) {
+        return check(tree.getArguments().get(2), tree.getArguments().get(0))
+            .map(
+                tolerance ->
+                    suggestJunitFix(bugChecker, tree)
+                        .setMessage(String.format(DESCRIPTION, tolerance))
+                        .build());
+      }
+      if (junitWithMessage.matches(tree, state)) {
+        return check(tree.getArguments().get(3), tree.getArguments().get(1))
+            .map(
+                tolerance ->
+                    suggestJunitFix(bugChecker, tree)
+                        .setMessage(String.format(DESCRIPTION, tolerance))
+                        .build());
+      }
+      if (truthOfCall.matches(tree, state)) {
+        return check(getReceiverArgument(tree), getOnlyElement(tree.getArguments()))
+            .map(
+                tolerance ->
+                    suggestTruthFix(bugChecker, tree, state)
+                        .setMessage(String.format(DESCRIPTION, tolerance))
+                        .build());
+      }
+      return Optional.empty();
+    }
+
+    /**
+     * Checks whether the provided {@code toleranceArgument} and {@code actualArgument} will lead to
+     * an equality check. If so, returns the smallest tolerance that wouldn't for diagnostic
+     * purposes.
+     */
+    private Optional<Double> check(
+        ExpressionTree toleranceArgument, ExpressionTree actualArgument) {
+      Number actual = ASTHelpers.constValue(actualArgument, Number.class);
+      Number tolerance = ASTHelpers.constValue(toleranceArgument, Number.class);
+      if (actual == null || tolerance == null) {
+        return Optional.empty();
+      }
+      return isIntolerantComparison(tolerance, actual)
+          ? Optional.of(nextNumber(actual).doubleValue())
+          : Optional.empty();
+    }
+
+    private static ExpressionTree getReceiverArgument(MethodInvocationTree tree) {
+      ExpressionTree receiver = ASTHelpers.getReceiver(tree);
+      return getOnlyElement(((MethodInvocationTree) receiver).getArguments());
+    }
+
+    /** Suggest replacing the tolerance with {@code 0} for JUnit assertions. */
+    private static Description.Builder suggestJunitFix(
+        BugChecker bugChecker, MethodInvocationTree tree) {
+      SuggestedFix fix = SuggestedFix.replace(getLast(tree.getArguments()), "0");
+      return bugChecker.buildDescription(tree).addFix(fix);
+    }
+
+    /** Suggest replacing {@code isWithin(..).of(foo)} with {@code isEqualTo(foo)} for Truth. */
+    private Description.Builder suggestTruthFix(
+        BugChecker bugChecker, MethodInvocationTree tree, VisitorState state) {
+      ExpressionTree within = ASTHelpers.getReceiver(tree);
+      ExpressionTree assertion = ASTHelpers.getReceiver(within);
+      String replacementMethod =
+          ASTHelpers.getSymbol(within).getSimpleName().toString().contains("Not")
+              ? "isNotEqualTo"
+              : "isEqualTo";
+      ExpressionTree argument = getOnlyElement(tree.getArguments());
+      SuggestedFix fix =
+          SuggestedFix.replace(
+              tree,
+              String.format(
+                  "%s.%s(%s)",
+                  state.getSourceForNode(assertion),
+                  replacementMethod,
+                  castArgumentIfNecessary(argument, state)));
+      return bugChecker.buildDescription(tree).addFix(fix);
+    }
+
+    private String castArgumentIfNecessary(ExpressionTree tree, VisitorState state) {
+      String source = state.getSourceForNode(tree);
+      Type type = ASTHelpers.getType(tree);
+      if (state.getTypes().unboxedTypeOrType(type).getTag() == typeTag) {
+        return source;
+      }
+      if (parenthesize(tree)) {
+        return String.format("(%s) (%s)", typeName, source);
+      }
+      return String.format("(%s) %s", typeName, source);
+    }
+
+    private static boolean parenthesize(ExpressionTree tree) {
+      return tree instanceof BinaryTree;
+    }
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -81,6 +81,7 @@ import com.google.errorprone.bugpatterns.FallThrough;
 import com.google.errorprone.bugpatterns.FieldCanBeFinal;
 import com.google.errorprone.bugpatterns.Finally;
 import com.google.errorprone.bugpatterns.FloatCast;
+import com.google.errorprone.bugpatterns.FloatingPointAssertionWithinEpsilon;
 import com.google.errorprone.bugpatterns.FloatingPointLiteralPrecision;
 import com.google.errorprone.bugpatterns.ForOverrideChecker;
 import com.google.errorprone.bugpatterns.FunctionalInterfaceClash;
@@ -579,6 +580,7 @@ public class BuiltInCheckerSuppliers {
           ExpectedExceptionChecker.class,
           FieldMissingNullable.class,
           FieldCanBeFinal.class,
+          FloatingPointAssertionWithinEpsilon.class,
           FunctionalInterfaceClash.class,
           FuzzyEqualsShouldNotBeUsedInEqualsMethod.class,
           HardCodedSdCardPath.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/FloatingPointAssertionWithinEpsilonTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/FloatingPointAssertionWithinEpsilonTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link FloatingPointAssertionWithinEpsilon} bug pattern.
+ *
+ * @author ghm@google.com (Graeme Morgan)
+ */
+@RunWith(JUnit4.class)
+public final class FloatingPointAssertionWithinEpsilonTest {
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(FloatingPointAssertionWithinEpsilon.class, getClass());
+
+  @Test
+  public void testPositiveCase() {
+    compilationHelper
+        .addSourceFile("FloatingPointAssertionWithinEpsilonPositiveCases.java")
+        .doTest();
+  }
+
+  @Test
+  public void testNegativeCase() {
+    compilationHelper
+        .addSourceFile("FloatingPointAssertionWithinEpsilonNegativeCases.java")
+        .doTest();
+  }
+
+  @Test
+  public void testFixes() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(
+            new FloatingPointAssertionWithinEpsilon(), getClass())
+        .addInput("FloatingPointAssertionWithinEpsilonPositiveCases.java")
+        .addOutput("FloatingPointAssertionWithinEpsilonPositiveCases_expected.java")
+        .doTest(TestMode.AST_MATCH);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/FloatingPointAssertionWithinEpsilonNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/FloatingPointAssertionWithinEpsilonNegativeCases.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Negative test cases for FloatingPointAssertionWithinEpsilon check.
+ *
+ * @author ghm@google.com (Graeme Morgan)
+ */
+final class FloatingPointAssertionWithinEpsilonNegativeCases {
+
+  private static final float TOLERANCE = 1e-5f;
+  private static final double TOLERANCE2 = 1e-10f;
+  private static final float VALUE = 1;
+
+  public void testFloat() {
+    String test = Boolean.TRUE.toString();
+    assertThat(1.0f).isWithin(1e-5f).of(1.0f);
+    assertThat(1f).isWithin(TOLERANCE).of(VALUE);
+    assertThat(1f).isWithin(1).of(1);
+
+    assertThat(1f).isNotWithin(0).of(2f);
+
+    assertThat(1f).isNotWithin(.5f).of(2f);
+
+    assertEquals(1f, 1f, TOLERANCE);
+  }
+
+  public void testDouble() {
+    String test = Boolean.TRUE.toString();
+    assertThat(1.0).isWithin(1e-10).of(1.0);
+    assertThat(1.0).isWithin(TOLERANCE2).of(1f);
+    assertThat(1.0).isWithin(TOLERANCE2).of(1);
+
+    assertEquals(1.0, 1.0, TOLERANCE);
+  }
+
+  public void testZeroCases() {
+    assertThat(1.0).isWithin(0.0).of(1.0);
+    assertThat(1f).isWithin(0f).of(1f);
+    assertThat(1f).isWithin(0).of(1f);
+
+    assertEquals(1f, 1f, 0f);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/FloatingPointAssertionWithinEpsilonPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/FloatingPointAssertionWithinEpsilonPositiveCases.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Positive test cases for FloatingPointAssertionWithinEpsilon check.
+ *
+ * @author ghm@google.com (Graeme Morgan)
+ */
+final class FloatingPointAssertionWithinEpsilonPositiveCases {
+
+  private static final float TOLERANCE = 1e-10f;
+  private static final double TOLERANCE2 = 1e-20f;
+  private static final float VALUE = 1;
+
+  public void testFloat() {
+    // BUG: Diagnostic contains: 6.0e-08
+    assertThat(1.0f).isWithin(1e-20f).of(1.0f);
+    // BUG: Diagnostic contains: 6.0e-08
+    assertThat(1f).isWithin(TOLERANCE).of(VALUE);
+    // BUG: Diagnostic contains: 1.0e+03
+    assertThat(1e10f).isWithin(1).of(1e10f);
+
+    // BUG: Diagnostic contains: 1.2e-07
+    assertThat(1f).isNotWithin(1e-10f).of(2);
+
+    // BUG: Diagnostic contains: 6.0e-08
+    assertEquals(1f, 1f, TOLERANCE);
+    // BUG: Diagnostic contains: 6.0e-08
+    assertEquals("equal!", 1f, 1f, TOLERANCE);
+  }
+
+  public void testDouble() {
+    // BUG: Diagnostic contains: 1.1e-16
+    assertThat(1.0).isWithin(1e-20).of(1.0);
+    // BUG: Diagnostic contains: 1.1e-16
+    assertThat(1.0).isWithin(TOLERANCE2).of(1f);
+    // BUG: Diagnostic contains: 1.1e-16
+    assertThat(1.0).isWithin(TOLERANCE2).of(1);
+    // BUG: Diagnostic contains: 1.6e+04
+    assertThat(1e20).isWithin(1).of(1e20);
+
+    // BUG: Diagnostic contains: 1.1e-16
+    assertEquals(1.0, 1.0, TOLERANCE2);
+    // BUG: Diagnostic contains: 1.1e-16
+    assertEquals("equal!", 1.0, 1.0, TOLERANCE2);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/FloatingPointAssertionWithinEpsilonPositiveCases_expected.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/FloatingPointAssertionWithinEpsilonPositiveCases_expected.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Expected refactoring output for FloatingPointAssertionWithinEpsilon bugpattern.
+ *
+ * @author ghm@google.com (Graeme Morgan)
+ */
+final class FloatingPointAssertionWithinEpsilonPositiveCases {
+
+  private static final float TOLERANCE = 1e-10f;
+  private static final double TOLERANCE2 = 1e-20f;
+  private static final float VALUE = 1;
+
+  public void testFloat() {
+    assertThat(1.0f).isEqualTo(1.0f);
+    assertThat(1f).isEqualTo(VALUE);
+    assertThat(1e10f).isEqualTo(1e10f);
+
+    assertThat(1f).isNotEqualTo((float) 2);
+
+    assertEquals(1f, 1f, 0);
+    assertEquals("equal!", 1f, 1f, 0);
+  }
+
+  public void testDouble() {
+    assertThat(1.0).isEqualTo(1.0);
+    assertThat(1.0).isEqualTo((double) 1f);
+    assertThat(1.0).isEqualTo((double) 1);
+    assertThat(1e20).isEqualTo(1e20);
+
+    assertEquals(1.0, 1.0, 0);
+    assertEquals("equal!", 1.0, 1.0, 0);
+  }
+}

--- a/docs/bugpattern/FloatingPointAssertionWithinEpsilon.md
+++ b/docs/bugpattern/FloatingPointAssertionWithinEpsilon.md
@@ -1,0 +1,25 @@
+Both JUnit and Truth allow for asserting equality of floating point numbers with
+an absolute tolerance. For example, the following statements are equivalent,
+
+```java
+double EPSILON = 1e-20;
+assertThat(actualValue).isWithin(EPSILON).of(Math.PI);
+assertEquals(Math.PI, actualValue, EPSILON);
+```
+
+What's not immediately obvious is that both of these assertions are checking
+exact equality between `Math.PI` and `actualValue`, because the next `double`
+after `Math.PI` is `Math.PI + 4.44e-16`.
+
+This means that using the same tolerance to compare several floating point
+values with different magnitude can be prone to error,
+
+```java
+float TOLERANCE = 1e-5f;
+assertThat(pressure).isWithin(TOLERANCE).of(1f); // GOOD
+assertThat(pressure).isWithin(TOLERANCE).of(10f); // GOOD
+assertThat(pressure).isWithin(TOLERANCE).of(100f); // BAD -- misleading equals check
+```
+
+A larger tolerance should be used if the goal of the test is to allow for some
+floating point errors, or, if not, `isEqualTo` makes the intention more clear.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Introduce an ErrorProne check to catch usages of tolerant floating-point comparisons where the tolerance leads to an equality comparison.

i.e:
  assertThat(Math.PI).isWithin(1e-100).of(3.14159...)
  assertEquals(1e10, 1e10, 1e-20)

And suggest using isEqualTo(..) so that the check is explicit.

RELNOTES: [FloatAssertionWithinEpsilon] Floating point comparisons should be exact or with a tolerance larger than ULP.

972f281a6609239936c4532acb5a9dce5cb2ff3c