### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -734,7 +734,7 @@ public class SuggestedFixes {
     try {
       newTask.analyze();
     } catch (Throwable e) {
-      e.printStackTrace();
+      // ignored
     }
     return countErrors(diagnosticListener) == 0;
   }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadNestedImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadNestedImport.java
@@ -43,8 +43,7 @@ import com.sun.tools.javac.code.Symbol.ClassSymbol;
   providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION
 )
 public class BadNestedImport extends BugChecker implements IdentifierTreeMatcher {
-  private static final ImmutableSet<String> IDENTIFIERS_TO_REPLACE =
-      ImmutableSet.of("Builder", "Type", "Entry");
+  private static final ImmutableSet<String> IDENTIFIERS_TO_REPLACE = ImmutableSet.of("Builder");
 
   @Override
   public Description matchIdentifier(IdentifierTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassNamedLikeTypeParameter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassNamedLikeTypeParameter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.Category.JDK;
+import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.StandardTags;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.ClassTree;
+
+/** @author glorioso@google.com */
+@BugPattern(
+  name = "ClassNamedLikeTypeParameter",
+  summary = "This class's name looks like a Type Parameter.",
+  category = JDK,
+  severity = SUGGESTION,
+  tags = StandardTags.STYLE
+)
+public class ClassNamedLikeTypeParameter extends BugChecker implements ClassTreeMatcher {
+
+  @Override
+  public Description matchClass(ClassTree tree, VisitorState state) {
+    return TypeParameterNaming.matchesTypeParameterNamingScheme(tree.getSimpleName())
+        ? describeMatch(tree)
+        : Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -48,6 +48,7 @@ import com.google.errorprone.bugpatterns.ChainingConstructorIgnoresParameter;
 import com.google.errorprone.bugpatterns.CheckReturnValue;
 import com.google.errorprone.bugpatterns.ClassCanBeStatic;
 import com.google.errorprone.bugpatterns.ClassName;
+import com.google.errorprone.bugpatterns.ClassNamedLikeTypeParameter;
 import com.google.errorprone.bugpatterns.ClassNewInstance;
 import com.google.errorprone.bugpatterns.CollectionToArraySafeParameter;
 import com.google.errorprone.bugpatterns.CollectorShouldNotUseState;
@@ -567,6 +568,7 @@ public class BuiltInCheckerSuppliers {
           BinderIdentityRestoredDangerously.class, // TODO: enable this by default.
           BindingToUnqualifiedCommonType.class,
           ClassName.class,
+          ClassNamedLikeTypeParameter.class,
           ComparisonContractViolated.class,
           ConstantField.class,
           BooleanParameter.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ClassNamedLikeTypeParameterTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ClassNamedLikeTypeParameterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ClassNamedLikeTypeParameter} */
+@RunWith(JUnit4.class)
+public class ClassNamedLikeTypeParameterTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public final void setUp() {
+    compilationHelper =
+        CompilationTestHelper.newInstance(ClassNamedLikeTypeParameter.class, getClass());
+  }
+
+  @Test
+  public void positiveCases() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "public class Test {",
+            "  // BUG: Diagnostic contains: ",
+            "  static class A {}",
+            "  // BUG: Diagnostic contains: ",
+            "  static class B2 {}",
+            "  // BUG: Diagnostic contains: ",
+            "  static class FooT {}",
+            "  // BUG: Diagnostic contains: ",
+            "  static class X {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negativeCases() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "public class Test {",
+            "  static class CAPITALT {}",
+            "  static class MyClass {}",
+            "  static class FooBar {}",
+            "  static class HasGeneric<X> {",
+            "    public <T> void genericMethod(X foo, T bar) {}",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/docs/bugpattern/ClassNamedLikeTypeParameter.md
+++ b/docs/bugpattern/ClassNamedLikeTypeParameter.md
@@ -1,0 +1,30 @@
+In the [Google Style Guide][gsg], type parameters are named in one of two
+patterns:
+
+> *   A single capital letter, optionally followed by a single numeral (such as
+>     E, T, X, T2)
+> *   A name in the form used for classes..., followed by the capital letter T
+>     (examples: RequestT, FooBarT).
+
+If a regular class is named like this, then it might be confusing for users of
+your API:
+
+```java
+class Bar {
+  ...
+  public void doSomething(T object) {
+    // Here, object is the static class T in this file
+  }
+
+  public <T> void doSomethingElse(T object) {
+    // Here, object is a generic T
+  }
+  ...
+  public static class T {...}
+}
+```
+
+Looking at `T`, it's very likely to be confused as a type parameter instead of a
+class.
+
+[gsg]: https://google.github.io/styleguide/javaguide.html#s5.2.8-type-variable-names

--- a/test_helpers/src/test/java/com/google/errorprone/CompilationTestHelperTest.java
+++ b/test_helpers/src/test/java/com/google/errorprone/CompilationTestHelperTest.java
@@ -19,7 +19,7 @@ package com.google.errorprone;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
@@ -53,55 +53,55 @@ public class CompilationTestHelperTest {
 
   @Test
   public void fileWithNoBugMarkersAndErrorFails() {
-    try {
-      compilationHelper
-          .addSourceLines(
-              "Test.java",
-              "public class Test {",
-              "  public boolean doIt() {",
-              "    return true;",
-              "  }",
-              "}")
-          .doTest();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected.getMessage()).contains("Saw unexpected error on line 3");
-    }
+    AssertionError expected =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                compilationHelper
+                    .addSourceLines(
+                        "Test.java",
+                        "public class Test {",
+                        "  public boolean doIt() {",
+                        "    return true;",
+                        "  }",
+                        "}")
+                    .doTest());
+    assertThat(expected.getMessage()).contains("Saw unexpected error on line 3");
   }
 
   @Test
   public void fileWithBugMarkerAndNoErrorsFails() {
-    try {
-      compilationHelper
-          .addSourceLines(
-              "Test.java",
-              "public class Test {",
-              "  // BUG: Diagnostic contains:",
-              "  public void doIt() {}",
-              "}")
-          .doTest();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected.getMessage()).contains("Did not see an error on line 3");
-    }
+    AssertionError expected =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                compilationHelper
+                    .addSourceLines(
+                        "Test.java",
+                        "public class Test {",
+                        "  // BUG: Diagnostic contains:",
+                        "  public void doIt() {}",
+                        "}")
+                    .doTest());
+    assertThat(expected.getMessage()).contains("Did not see an error on line 3");
   }
 
   @Test
   public void fileWithBugMatcherAndNoErrorsFails() {
-    try {
-      compilationHelper
-          .addSourceLines(
-              "Test.java",
-              "public class Test {",
-              "  // BUG: Diagnostic matches: X",
-              "  public void doIt() {}",
-              "}")
-          .expectErrorMessage("X", Predicates.containsPattern(""))
-          .doTest();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected.getMessage()).contains("Did not see an error on line 3");
-    }
+    AssertionError expected =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                compilationHelper
+                    .addSourceLines(
+                        "Test.java",
+                        "public class Test {",
+                        "  // BUG: Diagnostic matches: X",
+                        "  public void doIt() {}",
+                        "}")
+                    .expectErrorMessage("X", Predicates.containsPattern(""))
+                    .doTest());
+    assertThat(expected.getMessage()).contains("Did not see an error on line 3");
   }
 
   @Test
@@ -135,41 +135,41 @@ public class CompilationTestHelperTest {
 
   @Test
   public void fileWithBugMarkerAndErrorOnWrongLineFails() {
-    try {
-      compilationHelper
-          .addSourceLines(
-              "Test.java",
-              "public class Test {",
-              "  // BUG: Diagnostic contains:",
-              "  public boolean doIt() {",
-              "    return true;",
-              "  }",
-              "}")
-          .doTest();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected.getMessage()).contains("Did not see an error on line 3");
-    }
+    AssertionError expected =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                compilationHelper
+                    .addSourceLines(
+                        "Test.java",
+                        "public class Test {",
+                        "  // BUG: Diagnostic contains:",
+                        "  public boolean doIt() {",
+                        "    return true;",
+                        "  }",
+                        "}")
+                    .doTest());
+    assertThat(expected.getMessage()).contains("Did not see an error on line 3");
   }
 
   @Test
   public void fileWithBugMatcherAndErrorOnWrongLineFails() {
-    try {
-      compilationHelper
-          .addSourceLines(
-              "Test.java",
-              "public class Test {",
-              "  // BUG: Diagnostic matches: X",
-              "  public boolean doIt() {",
-              "    return true;",
-              "  }",
-              "}")
-          .expectErrorMessage("X", Predicates.containsPattern(""))
-          .doTest();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected.getMessage()).contains("Did not see an error on line 3");
-    }
+    AssertionError expected =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                compilationHelper
+                    .addSourceLines(
+                        "Test.java",
+                        "public class Test {",
+                        "  // BUG: Diagnostic matches: X",
+                        "  public boolean doIt() {",
+                        "    return true;",
+                        "  }",
+                        "}")
+                    .expectErrorMessage("X", Predicates.containsPattern(""))
+                    .doTest());
+    assertThat(expected.getMessage()).contains("Did not see an error on line 3");
   }
 
   @Test
@@ -231,22 +231,23 @@ public class CompilationTestHelperTest {
 
   @Test
   public void fileWithSyntaxErrorFails() throws Exception {
-    try {
-      compilationHelper
-          .addSourceLines(
-              "Test.java",
-              "class Test {",
-              "  void m() {",
-              "    // BUG: Diagnostic contains:",
-              "    return}", // there's a syntax error on this line, but it shouldn't register as
-              // an error-prone diagnostic
-              "}")
-          .doTest();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected.getMessage())
-          .contains("Test program failed to compile with non Error Prone error");
-    }
+    AssertionError expected =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                compilationHelper
+                    .addSourceLines(
+                        "Test.java",
+                        "class Test {",
+                        "  void m() {",
+                        "    // BUG: Diagnostic contains:",
+                        // There's a syntax error on this line, but it shouldn't register as an
+                        // Error Prone diagnostic
+                        "    return}",
+                        "}")
+                    .doTest());
+    assertThat(expected.getMessage())
+        .contains("Test program failed to compile with non Error Prone error");
   }
 
   @Test
@@ -259,15 +260,15 @@ public class CompilationTestHelperTest {
 
   @Test
   public void expectedResultDiffersFromActualResultFails() {
-    try {
-      compilationHelper
-          .expectResult(Result.ERROR)
-          .addSourceLines("Test.java", "public class Test {}")
-          .doTest();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected.getMessage()).contains("Expected compilation result ERROR, but was OK");
-    }
+    AssertionError expected =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                compilationHelper
+                    .expectResult(Result.ERROR)
+                    .addSourceLines("Test.java", "public class Test {}")
+                    .doTest());
+    assertThat(expected.getMessage()).contains("Expected compilation result ERROR, but was OK");
   }
 
   @Test
@@ -289,62 +290,63 @@ public class CompilationTestHelperTest {
 
   @Test
   public void expectNoDiagnoticsButDiagnosticsProducedFails() {
-    try {
-      compilationHelper
-          .expectNoDiagnostics()
-          .addSourceLines(
-              "Test.java",
-              "public class Test {",
-              "  public boolean doIt() {",
-              "    // BUG: Diagnostic contains:",
-              "    return true;",
-              "  }",
-              "}")
-          .doTest();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected.getMessage()).contains("Expected no diagnostics produced, but found 1");
-    }
+    AssertionError expected =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                compilationHelper
+                    .expectNoDiagnostics()
+                    .addSourceLines(
+                        "Test.java",
+                        "public class Test {",
+                        "  public boolean doIt() {",
+                        "    // BUG: Diagnostic contains:",
+                        "    return true;",
+                        "  }",
+                        "}")
+                    .doTest());
+    assertThat(expected.getMessage()).contains("Expected no diagnostics produced, but found 1");
   }
 
   @Test
   public void expectNoDiagnoticsButDiagnosticsProducedFailsWithMatches() {
-    try {
-      compilationHelper
-          .expectNoDiagnostics()
-          .addSourceLines(
-              "Test.java",
-              "public class Test {",
-              "  public boolean doIt() {",
-              "    // BUG: Diagnostic matches: X",
-              "    return true;",
-              "  }",
-              "}")
-          .expectErrorMessage("X", Predicates.containsPattern(""))
-          .doTest();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected.getMessage()).contains("Expected no diagnostics produced, but found 1");
-    }
+    AssertionError expected =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                compilationHelper
+                    .expectNoDiagnostics()
+                    .addSourceLines(
+                        "Test.java",
+                        "public class Test {",
+                        "  public boolean doIt() {",
+                        "    // BUG: Diagnostic matches: X",
+                        "    return true;",
+                        "  }",
+                        "}")
+                    .expectErrorMessage("X", Predicates.containsPattern(""))
+                    .doTest());
+    assertThat(expected.getMessage()).contains("Expected no diagnostics produced, but found 1");
   }
 
   @Test
   public void failureWithErrorAndNoDiagnosticFails() {
-    try {
-      compilationHelper
-          .expectNoDiagnostics()
-          .addSourceLines("Test.java", "public class Test {}")
-          .setArgs(ImmutableList.of("-Xep:ReturnTreeChecker:Squirrels")) // Bad flag crashes.
-          .ignoreJavacErrors()
-          .doTest();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected.getMessage())
-          .contains(
-              "Expected compilation result to be OK, but was CMDERR. No diagnostics were"
-                  + " emitted.");
-      assertThat(expected.getMessage()).contains("InvalidCommandLineOptionException");
-    }
+    AssertionError expected =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                compilationHelper
+                    .expectNoDiagnostics()
+                    .addSourceLines("Test.java", "public class Test {}")
+                    .setArgs(
+                        ImmutableList.of("-Xep:ReturnTreeChecker:Squirrels")) // Bad flag crashes.
+                    .ignoreJavacErrors()
+                    .doTest());
+    assertThat(expected.getMessage())
+        .contains(
+            "Expected compilation result to be OK, but was CMDERR. No diagnostics were"
+                + " emitted.");
+    assertThat(expected.getMessage()).contains("InvalidCommandLineOptionException");
   }
 
   @Test
@@ -365,14 +367,15 @@ public class CompilationTestHelperTest {
 
   @Test
   public void missingExpectErrorFails() {
-    try {
-      compilationHelper
-          .addSourceLines("Test.java", " // BUG: Diagnostic matches: X", "public class Test {}")
-          .doTest();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected.getMessage()).contains("No expected error message with key [X]");
-    }
+    AssertionError expected =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                compilationHelper
+                    .addSourceLines(
+                        "Test.java", " // BUG: Diagnostic matches: X", "public class Test {}")
+                    .doTest());
+    assertThat(expected.getMessage()).contains("No expected error message with key [X]");
   }
 
   @BugPattern(
@@ -390,14 +393,14 @@ public class CompilationTestHelperTest {
 
   @Test
   public void unexpectedDiagnosticOnFirstLine() {
-    try {
-      CompilationTestHelper.newInstance(PackageTreeChecker.class, getClass())
-          .addSourceLines("test/Test.java", "package test;", "public class Test {}")
-          .doTest();
-      fail();
-    } catch (AssertionError expected) {
-      assertThat(expected.getMessage()).contains("Package declaration found");
-    }
+    AssertionError expected =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                CompilationTestHelper.newInstance(PackageTreeChecker.class, getClass())
+                    .addSourceLines("test/Test.java", "package test;", "public class Test {}")
+                    .doTest());
+    assertThat(expected.getMessage()).contains("Package declaration found");
   }
 
   @BugPattern(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Create checker to enforce that names aren't named like type parameters.

RELNOTES: New, disabled-by-default checker [ClassNamedLikeTypeParameter], to
detect classes that looks like type parameters (e.g.: T, X, R1, R2)

bab06007ef1cb27a83d15aba9dae76091365dec8

-------

<p> Focus on the 'Builder' import case for now

RELNOTES: N/A

7e814fc7df0f35feb407f39da5b4b0973cbc0aef

-------

<p> Remove a call to printStackTrace

RELNOTES: N/A

b298498c6ccbfe95be41d902d97524352d79029e

-------

<p> Change CompilationTestHelperTest's assertions to use assertThrows to avoid issues with catching AssertionError from fail statements.

RELNOTES: n/a

549b98f4c875430534d2f1ff4cb9ac35104136b4