### PR TITLE
Moe Sync

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <name>@BugPattern annotation</name>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <name>error-prone annotations</name>

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>error_prone_parent</artifactId>
     <groupId>com.google.errorprone</groupId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/check_api/pom.xml
+++ b/check_api/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <name>error-prone check api</name>

--- a/check_api/src/main/java/com/google/errorprone/fixes/AppliedFix.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/AppliedFix.java
@@ -16,6 +16,8 @@
 
 package com.google.errorprone.fixes;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.sun.tools.javac.tree.EndPosTable;
 import java.io.IOException;
 import java.io.LineNumberReader;
@@ -68,6 +70,11 @@ public class AppliedFix {
 
       Set<Integer> modifiedLines = new HashSet<>();
       for (Replacement repl : replacements) {
+        checkArgument(
+            repl.endPosition() <= source.length(),
+            "End [%s] should not exceed source length [%s]",
+            repl.endPosition(),
+            source.length());
         replaced.replace(repl.startPosition(), repl.endPosition(), repl.replaceWith());
 
         // Find the line number(s) being modified

--- a/check_api/src/main/java/com/google/errorprone/fixes/IndexedPosition.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/IndexedPosition.java
@@ -16,6 +16,8 @@
 
 package com.google.errorprone.fixes;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.sun.tools.javac.tree.EndPosTable;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
@@ -27,6 +29,8 @@ public class IndexedPosition implements DiagnosticPosition {
   final int endPos;
 
   public IndexedPosition(int startPos, int endPos) {
+    checkArgument(startPos >= 0, "Start [%s] should not be less than zero", startPos);
+    checkArgument(startPos <= endPos, "Start [%s] should not be after end [%s]", startPos, endPos);
     this.startPos = startPos;
     this.endPos = endPos;
   }

--- a/check_api/src/test/java/com/google/errorprone/dataflow/nullnesspropagation/NonNullAssumptionsTest.java
+++ b/check_api/src/test/java/com/google/errorprone/dataflow/nullnesspropagation/NonNullAssumptionsTest.java
@@ -111,6 +111,19 @@ public class NonNullAssumptionsTest {
     }
   }
 
+  @Test
+  public void testEqualsParameters() throws Exception {
+    int found = 0;
+    for (Method method : loadClass("java.lang.Object").getMethods()) {
+      if (!method.getName().equals("equals")) {
+        continue;
+      }
+      found++;
+      assertThat(invokeWithSingleNullArgument(method, 0)).isEqualTo(Boolean.FALSE);
+    }
+    assertWithMessage("equals()").that(found).isGreaterThan(0);
+  }
+
   private static Object invokeWithSingleNullArgument(Method method, int nullParam)
       throws IllegalAccessException, InvocationTargetException {
     Class<?>[] params = method.getParameterTypes();

--- a/check_api/src/test/java/com/google/errorprone/fixes/AppliedFixTest.java
+++ b/check_api/src/test/java/com/google/errorprone/fixes/AppliedFixTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -141,10 +142,11 @@ public class AppliedFixTest {
     assertNull(fix);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldThrowExceptionOnIllegalRange() {
-    AppliedFix.fromSource("public class Foo {}", endPositions)
-        .apply(SuggestedFix.replace(0, -1, ""));
+    assertThrows(IllegalArgumentException.class, () -> SuggestedFix.replace(0, -1, ""));
+    assertThrows(IllegalArgumentException.class, () -> SuggestedFix.replace(-1, -1, ""));
+    assertThrows(IllegalArgumentException.class, () -> SuggestedFix.replace(-1, 1, ""));
   }
 
   @Test
@@ -170,5 +172,12 @@ public class AppliedFixTest {
     // If the fixes had been applied in the wrong order, this would fail.
     // But it succeeds, so they were applied in the right order.
     AppliedFix.fromSource(" ", endPositions).apply(mockFix);
+  }
+
+  @Test
+  public void shouldThrowIfReplacementOutsideSource() {
+    AppliedFix.Applier applier = AppliedFix.fromSource("Hello", endPositions);
+    SuggestedFix fix = SuggestedFix.replace(0, 6, "World!");
+    assertThrows(IllegalArgumentException.class, () -> applier.apply(fix));
   }
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,7 +37,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <name>error-prone library</name>

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadNestedImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadNestedImport.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
-import com.google.errorprone.bugpatterns.BugChecker.IdentifierTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.ImportTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.util.ASTHelpers;
@@ -29,6 +29,9 @@ import com.google.errorprone.util.FindIdentifiers;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.ImportTree;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.code.Kinds.KindSelector;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 
@@ -42,57 +45,77 @@ import com.sun.tools.javac.code.Symbol.ClassSymbol;
   severity = WARNING,
   providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION
 )
-public class BadNestedImport extends BugChecker implements IdentifierTreeMatcher {
+public class BadNestedImport extends BugChecker implements ImportTreeMatcher {
   private static final ImmutableSet<String> IDENTIFIERS_TO_REPLACE = ImmutableSet.of("Builder");
 
   @Override
-  public Description matchIdentifier(IdentifierTree tree, VisitorState state) {
-    Symbol symbol = ASTHelpers.getSymbol(tree);
-    if (!(symbol instanceof ClassSymbol)) {
+  public Description matchImport(ImportTree tree, VisitorState state) {
+    if (tree.isStatic()) {
+      return Description.NO_MATCH;
+    }
+    Symbol symbol = ASTHelpers.getSymbol(tree.getQualifiedIdentifier());
+    if (symbol == null) {
       return Description.NO_MATCH;
     }
     if (!IDENTIFIERS_TO_REPLACE.contains(symbol.getSimpleName().toString())) {
       return Description.NO_MATCH;
     }
-    if (!findImport(symbol, state)) {
-      return Description.NO_MATCH;
-    }
 
-    Symbol parent = symbol.getEnclosingElement();
-    if (!(parent instanceof ClassSymbol)) {
-      return Description.NO_MATCH;
-    }
-
-    Symbol found = FindIdentifiers.findIdent(parent.getSimpleName().toString(), state);
-    if (found instanceof ClassSymbol && !parent.equals(found)) {
-      // There is another symbol already with this name.
-      return Description.NO_MATCH;
-    }
-
-    return describeMatch(
-        tree,
-        SuggestedFix.builder()
-            .addImport(parent.toString())
-            .replace(tree, parent.getSimpleName() + "." + symbol.getSimpleName())
-            .build());
-  }
-
-  private static boolean findImport(Symbol symbol, VisitorState state) {
-    // Inspect the imports to make sure we actually are importing this name.
-    CompilationUnitTree compilationUnitTree = state.findEnclosing(CompilationUnitTree.class);
-    if (compilationUnitTree == null) {
-      // Something is very odd if we hit this... just don't bail.
-      return false;
-    }
-
-    for (ImportTree importTree : compilationUnitTree.getImports()) {
-      Symbol imported = ASTHelpers.getSymbol(importTree.getQualifiedIdentifier());
-      if (symbol.equals(imported)) {
-        // We are importing this identifier, so we want to stop doing that.
-        return true;
+    String enclosingReplacement = "";
+    for (Symbol enclosing = symbol.getEnclosingElement();
+        enclosing instanceof ClassSymbol;
+        enclosing = enclosing.getEnclosingElement()) {
+      enclosingReplacement = enclosing.getSimpleName() + "." + enclosingReplacement;
+      if (!hasConflictingSymbol(state, enclosing)) {
+        return buildDescription(symbol, enclosing, enclosingReplacement, state);
       }
     }
+    return Description.NO_MATCH;
+  }
 
-    return false;
+  private Description buildDescription(
+      Symbol symbol, Symbol enclosing, String enclosingReplacement, VisitorState state) {
+    SuggestedFix.Builder builder = SuggestedFix.builder();
+    builder.removeImport(symbol.getQualifiedName().toString());
+    builder.addImport(enclosing.getQualifiedName().toString());
+
+    IdentifierTree firstFound =
+        new TreeScanner<IdentifierTree, Void>() {
+          @Override
+          public IdentifierTree reduce(IdentifierTree r1, IdentifierTree r2) {
+            return (r2 != null) ? r2 : r1;
+          }
+
+          @Override
+          public IdentifierTree visitIdentifier(IdentifierTree node, Void aVoid) {
+            Symbol nodeSymbol = ASTHelpers.getSymbol(node);
+            if (symbol.equals(nodeSymbol)) {
+              builder.prefixWith(node, enclosingReplacement);
+              return node;
+            }
+            return super.visitIdentifier(node, aVoid);
+          }
+        }.scan(state.getPath().getCompilationUnit(), null);
+    if (firstFound == null) {
+      // If no usage of the symbol was found, just leave the import to be cleaned up by the unused
+      // import fix.
+      return Description.NO_MATCH;
+    }
+    return describeMatch(firstFound, builder.build());
+  }
+
+  private static boolean hasConflictingSymbol(VisitorState state, Symbol parent) {
+    CompilationUnitTree compilationUnit = state.getPath().getCompilationUnit();
+    VisitorState checkState;
+    if (!compilationUnit.getTypeDecls().isEmpty()) {
+      checkState =
+          state.withPath(TreePath.getPath(compilationUnit, compilationUnit.getTypeDecls().get(0)));
+    } else {
+      checkState = state;
+    }
+
+    Symbol found =
+        FindIdentifiers.findIdent(parent.getSimpleName().toString(), checkState, KindSelector.TYP);
+    return found instanceof ClassSymbol && !parent.equals(found);
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ProtoRedundantSet.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ProtoRedundantSet.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.Category.TRUTH;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.BugPattern.StandardTags;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import com.sun.tools.javac.code.Type;
+import java.util.Collection;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Checks that protocol buffers built with chained builders don't set the same field twice.
+ *
+ * @author ghm@google.com (Graeme Morgan)
+ */
+@BugPattern(
+    name = "ProtoRedundantSet",
+    summary = "A field on a protocol buffer was set twice in the same chained expression.",
+    category = TRUTH,
+    severity = WARNING,
+    tags = StandardTags.FRAGILE_CODE,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+public final class ProtoRedundantSet extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private static final String DESCRIPTION =
+      "%s. Setting the same field multiple times in a proto builder might be hiding a bug, "
+          + "especially if it's set to different values.";
+
+  /** Matches a chainable proto builder method. */
+  private static final Matcher<ExpressionTree> PROTO_FLUENT_METHOD =
+      instanceMethod()
+          .onDescendantOfAny(
+              "com.google.protobuf.GeneratedMessage.Builder",
+              "com.google.protobuf.GeneratedMessageLite.Builder")
+          .withNameMatching(Pattern.compile("^(set|add|clear|put).+"));
+
+  /**
+   * Matches a terminal proto builder method. That is, a chainable builder method which is either
+   * not followed by another method invocation, or by a method invocation which is not a {@link
+   * #PROTO_FLUENT_METHOD}.
+   */
+  private static final Matcher<ExpressionTree> TERMINAL_PROTO_FLUENT_METHOD =
+      allOf(
+          PROTO_FLUENT_METHOD,
+          (tree, state) -> {
+            Tree nextLeaf = state.getPath().getParentPath().getLeaf();
+            return !(nextLeaf instanceof ExpressionTree)
+                || !PROTO_FLUENT_METHOD.matches((ExpressionTree) nextLeaf, state);
+          });
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (!TERMINAL_PROTO_FLUENT_METHOD.matches(tree, state)) {
+      return Description.NO_MATCH;
+    }
+    ListMultimap<ProtoField, String> setters = ArrayListMultimap.create();
+    SuggestedFix.Builder suggestedFixes = SuggestedFix.builder();
+    Type type = ASTHelpers.getReturnType(tree);
+    for (ExpressionTree current = tree;
+        PROTO_FLUENT_METHOD.matches(current, state);
+        current = ASTHelpers.getReceiver(current)) {
+      MethodInvocationTree method = (MethodInvocationTree) current;
+      if (!type.equals(ASTHelpers.getReturnType(current))) {
+        break;
+      }
+      Symbol symbol = ASTHelpers.getSymbol(current);
+      if (!(symbol instanceof MethodSymbol)) {
+        break;
+      }
+      String methodName = symbol.getSimpleName().toString();
+      // Break on methods like "addFooBuilder", otherwise we might be building a nested proto of the
+      // same type.
+      if (methodName.endsWith("Builder")) {
+        break;
+      }
+      match(method, state, methodName, setters, suggestedFixes);
+    }
+
+    setters.asMap().entrySet().removeIf(entry -> entry.getValue().size() <= 1);
+
+    if (setters.isEmpty()) {
+      return Description.NO_MATCH;
+    }
+
+    String description =
+        String.format(
+            DESCRIPTION,
+            setters
+                .asMap()
+                .entrySet()
+                .stream()
+                .map(entry -> describeField(entry.getKey(), entry.getValue()))
+                .collect(Collectors.joining(", ")));
+    return buildDescription(tree).setMessage(description).addFix(suggestedFixes.build()).build();
+  }
+
+  private static void match(
+      MethodInvocationTree method,
+      VisitorState state,
+      String methodName,
+      ListMultimap<ProtoField, String> setters,
+      SuggestedFix.Builder suggestedFixes) {
+    for (FieldType fieldType : FieldType.values()) {
+      FieldWithValue match = fieldType.match(methodName, method);
+      if (match != null) {
+        Collection<String> previousArguments = setters.get(match.getField());
+        // We flag up all duplicate sets, but only suggest a fix if the setter is given the same
+        // argument (based on source code). This is to avoid the temptation to apply the fix in
+        // cases like,
+        //   MyProto.newBuilder().setFoo(copy.getFoo()).setFoo(copy.getBar())
+        // where the correct fix is probably to replace the second 'setFoo' with 'setBar'.
+        if (!previousArguments.isEmpty()
+            && previousArguments.stream().allMatch(argument -> argument.equals(match.getValue()))) {
+          int startPos = state.getEndPosition(ASTHelpers.getReceiver(method));
+          int endPos = state.getEndPosition(method);
+          suggestedFixes.replace(startPos, endPos, "");
+        }
+        setters.put(match.getField(), match.getValue());
+      }
+    }
+  }
+
+  private static String describeField(ProtoField field, Collection<String> arguments) {
+    boolean sameArguments = arguments.stream().distinct().count() == 1;
+    return String.format(
+        "%s was called %s with %s",
+        field,
+        nTimes(arguments.size()),
+        sameArguments ? "the same argument" : "different arguments");
+  }
+
+  private static final String nTimes(int n) {
+    return n == 2 ? "twice" : String.format("%d times", n);
+  }
+
+  interface ProtoField {}
+
+  enum FieldType {
+    SINGLE {
+      @Override
+      FieldWithValue match(String name, MethodInvocationTree tree) {
+        if (name.startsWith("set") && tree.getArguments().size() == 1) {
+          return FieldWithValue.of(SingleField.of(name), tree.getArguments().get(0));
+        }
+        return null;
+      }
+    },
+    REPEATED {
+      @Override
+      FieldWithValue match(String name, MethodInvocationTree tree) {
+        if (name.startsWith("set") && tree.getArguments().size() == 2) {
+          Integer index = ASTHelpers.constValue(tree.getArguments().get(0), Integer.class);
+          if (index != null) {
+            return FieldWithValue.of(RepeatedField.of(name, index), tree.getArguments().get(1));
+          }
+        }
+        return null;
+      }
+    },
+    MAP {
+      @Override
+      FieldWithValue match(String name, MethodInvocationTree tree) {
+        if (name.startsWith("put") && tree.getArguments().size() == 2) {
+          Object key = ASTHelpers.constValue(tree.getArguments().get(0), Object.class);
+          if (key != null) {
+            return FieldWithValue.of(MapField.of(name, key), tree.getArguments().get(1));
+          }
+        }
+        return null;
+      }
+    };
+
+    abstract FieldWithValue match(String name, MethodInvocationTree tree);
+  }
+
+  @AutoValue
+  abstract static class SingleField implements ProtoField {
+    abstract String getName();
+
+    static SingleField of(String name) {
+      return new AutoValue_ProtoRedundantSet_SingleField(name);
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%s(..)", getName());
+    }
+  }
+
+  @AutoValue
+  abstract static class RepeatedField implements ProtoField {
+    abstract String getName();
+
+    abstract int getIndex();
+
+    static RepeatedField of(String name, int index) {
+      return new AutoValue_ProtoRedundantSet_RepeatedField(name, index);
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%s(%s, ..)", getName(), getIndex());
+    }
+  }
+
+  @AutoValue
+  abstract static class MapField implements ProtoField {
+    abstract String getName();
+
+    abstract Object getKey();
+
+    static MapField of(String name, Object key) {
+      return new AutoValue_ProtoRedundantSet_MapField(name, key);
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%s(%s, ..)", getName(), getKey());
+    }
+  }
+
+  @AutoValue
+  abstract static class FieldWithValue {
+    abstract ProtoField getField();
+
+    abstract String getValue();
+
+    static FieldWithValue of(ProtoField field, ExpressionTree argumentTree) {
+      return new AutoValue_ProtoRedundantSet_FieldWithValue(field, argumentTree.toString());
+    }
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/EqualsBrokenForNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/EqualsBrokenForNull.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.nullness;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.isSameType;
+import static com.google.errorprone.matchers.Matchers.methodHasParameters;
+import static com.google.errorprone.matchers.Matchers.methodIsNamed;
+import static com.google.errorprone.matchers.Matchers.methodReturns;
+import static com.google.errorprone.matchers.Matchers.variableType;
+import static com.google.errorprone.suppliers.Suppliers.BOOLEAN_TYPE;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
+import com.google.errorprone.dataflow.nullnesspropagation.Nullness;
+import com.google.errorprone.dataflow.nullnesspropagation.NullnessAnalysis;
+import com.google.errorprone.fixes.Fix;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import java.util.Objects;
+
+/**
+ * {@link BugChecker} adds a null check to equals() method implementations which don't satisfy the
+ * null contract of equals() method i.e. Object.equals(null) should return false.
+ *
+ * @author bhagwani@google.com (Sumit Bhagwani)
+ */
+@BugPattern(
+    name = "EqualsBrokenForNull",
+    summary = "equals() implementation throws NullPointerException when given null",
+    severity = SeverityLevel.WARNING,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+public class EqualsBrokenForNull extends BugChecker implements MethodTreeMatcher {
+
+  private static final Matcher<MethodTree> MATCHER =
+      allOf(
+          methodIsNamed("equals"),
+          methodHasParameters(variableType(isSameType("java.lang.Object"))),
+          methodReturns(BOOLEAN_TYPE));
+
+  @Override
+  public Description matchMethod(MethodTree tree, VisitorState state) {
+    if (!MATCHER.matches(tree, state)) {
+      return NO_MATCH;
+    }
+    VarSymbol varSymbol = ASTHelpers.getSymbol(getOnlyElement(tree.getParameters()));
+    NullnessAnalysis analysis = NullnessAnalysis.instance(state.context);
+    // we run nullness analysis on all the subtrees and match if there is a method invocation on
+    // the argument to the equals method.
+    boolean[] crashesWithNull = {false};
+    new TreePathScanner<Void, Void>() {
+      @Override
+      public Void visitMemberSelect(MemberSelectTree node, Void aVoid) {
+        if (!crashesWithNull[0]) {
+          if (Objects.equals(varSymbol, ASTHelpers.getSymbol(node.getExpression()))) {
+            Nullness nullness =
+                analysis.getNullness(
+                    new TreePath(getCurrentPath(), node.getExpression()), state.context);
+            if (nullness == Nullness.NULLABLE) {
+              crashesWithNull[0] = true;
+            }
+          }
+        }
+        return super.visitMemberSelect(node, aVoid);
+      }
+    }.scan(state.getPath(), null);
+    if (!crashesWithNull[0]) {
+      return NO_MATCH;
+    }
+    String stringAddition =
+        String.format("if (%s == null) { return false; }\n", varSymbol.name.toString());
+    Fix fix = SuggestedFix.prefixWith(tree.getBody().getStatements().get(0), stringAddition);
+    return describeMatch(tree, fix);
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -183,6 +183,7 @@ import com.google.errorprone.bugpatterns.PrivateConstructorForUtilityClass;
 import com.google.errorprone.bugpatterns.PrivateSecurityContractProtoAccess;
 import com.google.errorprone.bugpatterns.ProtoFieldNullComparison;
 import com.google.errorprone.bugpatterns.ProtoFieldPreconditionsCheckNotNull;
+import com.google.errorprone.bugpatterns.ProtoRedundantSet;
 import com.google.errorprone.bugpatterns.ProtoStringFieldReferenceEquality;
 import com.google.errorprone.bugpatterns.ProtocolBufferOrdinal;
 import com.google.errorprone.bugpatterns.ProvidesFixChecker;
@@ -534,6 +535,7 @@ public class BuiltInCheckerSuppliers {
           ParameterName.class,
           PreconditionsInvalidPlaceholder.class,
           ProtoFieldPreconditionsCheckNotNull.class,
+          ProtoRedundantSet.class,
           QualifierOrScopeOnInjectMethod.class,
           ReachabilityFenceUsage.class,
           ReferenceEquality.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -291,6 +291,7 @@ import com.google.errorprone.bugpatterns.inject.guice.InjectOnFinalField;
 import com.google.errorprone.bugpatterns.inject.guice.OverridesGuiceInjectableMethod;
 import com.google.errorprone.bugpatterns.inject.guice.OverridesJavaxInjectableMethod;
 import com.google.errorprone.bugpatterns.inject.guice.ProvidesMethodOutsideOfModule;
+import com.google.errorprone.bugpatterns.nullness.EqualsBrokenForNull;
 import com.google.errorprone.bugpatterns.nullness.FieldMissingNullable;
 import com.google.errorprone.bugpatterns.nullness.ParameterNotNullable;
 import com.google.errorprone.bugpatterns.nullness.ReturnMissingNullable;
@@ -581,6 +582,7 @@ public class BuiltInCheckerSuppliers {
           EmptyIfStatement.class,
           EmptySetMultibindingContributions.class,
           EmptyTopLevelDeclaration.class,
+          EqualsBrokenForNull.class,
           ExpectedExceptionChecker.class,
           FieldMissingNullable.class,
           FieldCanBeFinal.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/BadNestedImportTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/BadNestedImportTest.java
@@ -39,6 +39,68 @@ public final class BadNestedImportTest {
   }
 
   @Test
+  public void positiveCases_parentNotAlreadyImported() {
+    // Ensure that the snippet reports on the first occurrence, not the import.
+    compilationTestHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableList.Builder;",
+            "class Test {",
+            "  // BUG: Diagnostic contains: ImmutableList.Builder<String> builder = null;",
+            "  Builder<String> builder = null;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positiveCases_conflictingName() {
+    // Ensure that the snippet reports on the first occurrence, not the import.
+    compilationTestHelper
+        .addSourceLines(
+            "thing/A.java",
+            "package thing;",
+            "public class A {",
+            "  public static class B {",
+            "    public static class Builder {",
+            "    }",
+            "  }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "import thing.A.B.Builder;",
+            "class Test {",
+            "  // BUG: Diagnostic contains: A.B.Builder builder;",
+            "  Builder builder;",
+            "  static class B {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negativeCases_conflictingNames_noResolution() {
+    // Ensure that the snippet reports on the first occurrence, not the import.
+    compilationTestHelper
+        .addSourceLines(
+            "thing/A.java",
+            "package thing;",
+            "public class A {",
+            "  public static class B {",
+            "    public static class Builder {",
+            "    }",
+            "  }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "import thing.A.B.Builder;",
+            "class Test {",
+            "  Builder builder;",
+            "  static class A {}",
+            "  static class B {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void negativeCases() {
     compilationTestHelper.addSourceFile("BadNestedImportNegativeCases.java").doTest();
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ProtoRedundantSetTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ProtoRedundantSetTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import org.junit.Ignore;
+
+/**
+ * Tests for {@link ProtoRedundantSet} bugpattern.
+ *
+ * @author ghm@google.com (Graeme Morgan)
+ */
+@Ignore("b/74365407 test proto sources are broken")
+@RunWith(JUnit4.class)
+public final class ProtoRedundantSetTest {
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ProtoRedundantSet.class, getClass());
+
+  private static final String[] POSITIVE_LINES =
+      new String[] {
+        "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestFieldProtoMessage;",
+        "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestProtoMessage;",
+        "final class ProtoRedundantSetPositiveCases {",
+        "  private static final TestFieldProtoMessage foo =",
+        "      TestFieldProtoMessage.getDefaultInstance();",
+        "  private static final TestFieldProtoMessage bar =",
+        "      TestFieldProtoMessage.getDefaultInstance();",
+        "  private void singleField() {",
+        "    TestProtoMessage twice =",
+        "        TestProtoMessage.newBuilder()",
+        "            .setMessage(foo)",
+        "            .addMultiField(bar)",
+        "            .setMessage(foo)",
+        "            // BUG: Diagnostic contains: setMessage",
+        "            .addMultiField(bar)",
+        "            .build();",
+        "  }",
+        "  private void repeatedField() {",
+        "    TestProtoMessage.Builder again =",
+        "        TestProtoMessage.newBuilder()",
+        "            .setMessage(foo)",
+        "            .setMessage(foo)",
+        "            .setMessage(foo)",
+        "            .setMultiField(0, bar)",
+        "            .setMultiField(1, foo)",
+        "            // BUG: Diagnostic contains: setMultiField",
+        "            .setMultiField(1, bar);",
+        "  }",
+        "}"
+      };
+
+  private static final String[] EXPECTED_LINES =
+      new String[] {
+        "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestFieldProtoMessage;",
+        "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestProtoMessage;",
+        "final class ProtoRedundantSetPositiveCases {",
+        "  private static final TestFieldProtoMessage foo =",
+        "      TestFieldProtoMessage.getDefaultInstance();",
+        "  private static final TestFieldProtoMessage bar =",
+        "      TestFieldProtoMessage.getDefaultInstance();",
+        "  private void singleField() {",
+        "    TestProtoMessage twice =",
+        "        TestProtoMessage.newBuilder()",
+        "            .addMultiField(bar)",
+        "            .setMessage(foo)",
+        "            // BUG: Diagnostic contains: setMessage",
+        "            .addMultiField(bar)",
+        "            .build();",
+        "  }",
+        "  private void repeatedField() {",
+        "    TestProtoMessage.Builder again =",
+        "        TestProtoMessage.newBuilder()",
+        "            .setMessage(foo)",
+        "            .setMultiField(0, bar)",
+        "            .setMultiField(1, foo)",
+        "            // BUG: Diagnostic contains: setMultiField",
+        "            .setMultiField(1, bar);",
+        "  }",
+        "}"
+      };
+
+  @Test
+  public void testPositiveCase() throws Exception {
+    compilationHelper
+        .addSourceLines("ProtoRedundantSetPositiveCases.java", POSITIVE_LINES)
+        .doTest();
+  }
+
+  @Test
+  public void singleField() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "SingleField.java",
+            "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestFieldProtoMessage;",
+            "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestProtoMessage;",
+            "final class ProtoRedundantSetNegativeCases {",
+            "  private void singleField() {",
+            "    TestProtoMessage.Builder builder =",
+            "        TestProtoMessage.newBuilder()",
+            "            .setMessage(TestFieldProtoMessage.getDefaultInstance())",
+            "            .addMultiField(TestFieldProtoMessage.getDefaultInstance())",
+            "            .addMultiField(TestFieldProtoMessage.getDefaultInstance());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void repeatedField() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "RepeatedField.java",
+            "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestFieldProtoMessage;",
+            "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestProtoMessage;",
+            "final class ProtoRedundantSetNegativeCases {",
+            "  private void repeatedField() {",
+            "    TestProtoMessage.Builder builder =",
+            "        TestProtoMessage.newBuilder()",
+            "            .setMessage(TestFieldProtoMessage.getDefaultInstance())",
+            "            .setMultiField(0, TestFieldProtoMessage.getDefaultInstance())",
+            "            .setMultiField(1, TestFieldProtoMessage.getDefaultInstance());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void complexChaining() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "ComplexChaining.java",
+            "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestFieldProtoMessage;",
+            "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestProtoMessage;",
+            "final class ProtoRedundantSetNegativeCases {",
+            "  private void intermediateBuild() {",
+            "    TestProtoMessage message =",
+            "        TestProtoMessage.newBuilder()",
+            "            .setMessage(TestFieldProtoMessage.getDefaultInstance())",
+            "            .build()",
+            "            .toBuilder()",
+            "            .setMessage(TestFieldProtoMessage.getDefaultInstance())",
+            "            .build();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testFixes() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(new ProtoRedundantSet(), getClass())
+        .addInputLines("ProtoRedundantSetPositiveCases.java", POSITIVE_LINES)
+        .addOutputLines("ProtoRedundantSetExpected.java", EXPECTED_LINES)
+        .doTest(TestMode.AST_MATCH);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/EqualsBrokenForNullTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/EqualsBrokenForNullTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.nullness;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** @author bhagwani@google.com (Sumit Bhagwani) */
+@RunWith(JUnit4.class)
+public class EqualsBrokenForNullTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setUp() {
+    compilationHelper = CompilationTestHelper.newInstance(EqualsBrokenForNull.class, getClass());
+  }
+
+  @Test
+  public void testPositiveCase() throws Exception {
+    compilationHelper.addSourceFile("EqualsBrokenForNullPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void testNegativeCase() throws Exception {
+    compilationHelper.addSourceFile("EqualsBrokenForNullNegativeCases.java").doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/testdata/EqualsBrokenForNullNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/testdata/EqualsBrokenForNullNegativeCases.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.nullness.testdata;
+
+/**
+ * Negative test cases for EqualsBrokenForNull check.
+ *
+ * @author bhagwani@google.com (Sumit Bhagwani)
+ */
+public class EqualsBrokenForNullNegativeCases {
+
+  private class ExplicitNullCheckFirst {
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == null) {
+        return false;
+      }
+      if (!getClass().equals(obj.getClass())) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private class CheckWithSuperFirst {
+    @Override
+    public boolean equals(Object obj) {
+      if (!super.equals(obj)) {
+        return false;
+      }
+      if (!getClass().equals(obj.getClass())) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private class NullCheckAndObjectGetClassNotEqualTo {
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || this.getClass() != o.getClass()) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private class NullCheckAndObjectGetClassArgToEquals {
+    @Override
+    public boolean equals(Object obj) {
+      if (obj != null && !getClass().equals(obj.getClass())) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private class NullCheckAndObjectGetClassReceiverToEquals {
+    @Override
+    public boolean equals(Object obj) {
+      if (obj != null && !obj.getClass().equals(getClass())) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private class NullCheckAndObjectGetClassLeftOperandDoubleEquals {
+    @Override
+    public boolean equals(Object other) {
+      if (other != null
+          && other.getClass() == NullCheckAndObjectGetClassLeftOperandDoubleEquals.class) {
+        return true;
+      }
+      return false;
+    }
+  }
+
+  private class UsesInstanceOfWithNullCheck {
+    @Override
+    public boolean equals(Object other) {
+      if (other != null && other instanceof UsesInstanceOfWithNullCheck) {
+        return true;
+      }
+      return false;
+    }
+  }
+
+  // https://stackoverflow.com/questions/2950319/is-null-check-needed-before-calling-instanceof
+  private class UsesInstanceOfWithoutNullCheck {
+    @Override
+    public boolean equals(Object other) {
+      if (other instanceof UsesInstanceOfWithoutNullCheck) {
+        return true;
+      }
+      return false;
+    }
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/testdata/EqualsBrokenForNullPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/testdata/EqualsBrokenForNullPositiveCases.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.nullness.testdata;
+
+/**
+ * Positive test cases for EqualsBrokenForNull check.
+ *
+ * @author bhagwani@google.com (Sumit Bhagwani)
+ */
+public class EqualsBrokenForNullPositiveCases {
+
+  private class ObjectGetClassArgToEquals {
+    @Override
+    // BUG: Diagnostic contains: if (obj == null) { return false; }
+    public boolean equals(Object obj) {
+      if (!getClass().equals(obj.getClass())) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private class ObjectGetClassArgToEqualsMultiLine {
+    @Override
+    // BUG: Diagnostic contains: if (obj == null) { return false; }
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (!getClass().equals(obj.getClass())) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private class ObjectGetClassArgToIsAssignableFrom {
+    @Override
+    // BUG: Diagnostic contains: if (obj == null) { return false; }
+    public boolean equals(Object obj) {
+      if (!getClass().isAssignableFrom(obj.getClass())) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private class ObjectGetClassArgToEquals2 {
+    @Override
+    // BUG: Diagnostic contains: if (obj == null) { return false; }
+    public boolean equals(Object obj) {
+      if (!ObjectGetClassArgToEquals2.class.equals(obj.getClass())) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private class ObjectGetClassReceiverToEquals {
+    @Override
+    // BUG: Diagnostic contains: if (obj == null) { return false; }
+    public boolean equals(Object obj) {
+      if (!obj.getClass().equals(getClass())) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private class ObjectGetClassReceiverToEquals2 {
+    @Override
+    // BUG: Diagnostic contains: if (obj == null) { return false; }
+    public boolean equals(Object obj) {
+      if (!obj.getClass().equals(ObjectGetClassReceiverToEquals2.class)) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private class ObjectGetClassReceiverToIsAssignableFrom {
+    @Override
+    // BUG: Diagnostic contains: if (obj == null) { return false; }
+    public boolean equals(Object obj) {
+      if (!obj.getClass().isAssignableFrom(getClass())) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private class ObjectGetClassLeftOperandDoubleEquals {
+    @Override
+    // BUG: Diagnostic contains: if (other == null) { return false; }
+    public boolean equals(Object other) {
+      if (other.getClass() == ObjectGetClassLeftOperandDoubleEquals.class) {
+        return true;
+      }
+      return false;
+    }
+  }
+
+  private class ObjectGetClassRightOperandDoubleEquals {
+    @Override
+    // BUG: Diagnostic contains: if (other == null) { return false; }
+    public boolean equals(Object other) {
+      if (ObjectGetClassRightOperandDoubleEquals.class == other.getClass()) {
+        return true;
+      }
+      return false;
+    }
+  }
+
+  private class ObjectGetClassLeftOperandNotEquals {
+    @Override
+    // BUG: Diagnostic contains: if (obj == null) { return false; }
+    public boolean equals(Object obj) {
+      if (obj.getClass() != ObjectGetClassLeftOperandNotEquals.class) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private class ObjectGetClassRightOperandNotEquals {
+    @Override
+    // BUG: Diagnostic contains: if (obj == null) { return false; }
+    public boolean equals(Object obj) {
+      if (ObjectGetClassRightOperandNotEquals.class != obj.getClass()) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private class UnusedNullCheckWithNotEqualToInLeftOperand {
+    @Override
+    // BUG: Diagnostic contains: if (o == null) { return false; }
+    public boolean equals(Object o) {
+      if (this.getClass() != o.getClass() || o == null) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private class UnusedNullCheckWithGetClassInEqualsArg {
+    @Override
+    // BUG: Diagnostic contains: if (o == null) { return false; }
+    public boolean equals(Object o) {
+      if (this.getClass().equals(o.getClass()) || o == null) {
+        return false;
+      }
+      return true;
+    }
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/BadComparablePositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/BadComparablePositiveCases.java
@@ -16,6 +16,7 @@
 
 package com.google.errorprone.bugpatterns.testdata;
 
+import java.io.File;
 import java.util.Comparator;
 
 /** @author irogers@google.com (Ian Rogers) */
@@ -51,6 +52,14 @@ public class BadComparablePositiveCases {
         public int compare(Long n1, Long n2) {
           // BUG: Diagnostic contains: return n1.compareTo(n2)
           return (int) (n1 - n2);
+        }
+      };
+
+  static final Comparator<File> COMPARATOR_FILE_INT_CAST =
+      new Comparator<File>() {
+        public int compare(File lhs, File rhs) {
+          // BUG: Diagnostic contains: return Long.compare(rhs.lastModified(), lhs.lastModified())
+          return (int) (rhs.lastModified() - lhs.lastModified());
         }
       };
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/BadNestedImportNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/BadNestedImportNegativeCases.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns.testdata;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 
 /**
  * Tests for {@link BadNestedImport}.

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/BadNestedImportPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/BadNestedImportPositiveCases.java
@@ -25,50 +25,37 @@ import com.google.common.collect.ImmutableList.Builder;
  */
 class BadNestedImportPositiveCases {
   public void variableDeclarations() {
+    // Only the first match is reported; but all occurrences are fixed.
     // BUG: Diagnostic contains: ImmutableList.Builder
     Builder<String> qualified;
-    // BUG: Diagnostic contains: ImmutableList.Builder
     Builder raw;
   }
 
   public void variableDeclarationsNestedGenerics() {
-    // BUG: Diagnostic contains: ImmutableList.Builder
     Builder<Builder<String>> builder1;
-    // BUG: Diagnostic contains: ImmutableList.Builder
     Builder<Builder> builder1Raw;
-    // BUG: Diagnostic contains: ImmutableList.Builder
     ImmutableList.Builder<Builder<String>> builder2;
-    // BUG: Diagnostic contains: ImmutableList.Builder
     ImmutableList.Builder<Builder> builder2Raw;
   }
 
   public void newClass() {
-    // BUG: Diagnostic contains: ImmutableList.Builder
     new Builder<String>();
-    // BUG: Diagnostic contains: ImmutableList.Builder
     new Builder<Builder<String>>();
   }
 
-  // BUG: Diagnostic contains: ImmutableList.Builder
   Builder<String> returnGenericExplicit() {
-    // BUG: Diagnostic contains: ImmutableList.Builder
     return new Builder<String>();
   }
 
-  // BUG: Diagnostic contains: ImmutableList.Builder
   Builder<String> returnGenericDiamond() {
-    // BUG: Diagnostic contains: ImmutableList.Builder
     return new Builder<>();
   }
 
-  // BUG: Diagnostic contains: ImmutableList.Builder
   Builder returnRaw() {
-    // BUG: Diagnostic contains: ImmutableList.Builder
     return new Builder();
   }
 
   void classLiteral() {
-    // BUG: Diagnostic contains: ImmutableList.Builder
     System.out.println(Builder.class);
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/BadNestedImportPositiveCases_expected.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/BadNestedImportPositiveCases_expected.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns.testdata;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 
 /**
  * Tests for {@link BadNestedImport}.

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/FloatingPointAssertionWithinEpsilonPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/FloatingPointAssertionWithinEpsilonPositiveCases.java
@@ -51,7 +51,7 @@ final class FloatingPointAssertionWithinEpsilonPositiveCases {
     // BUG: Diagnostic contains: 1.1e-16
     assertThat(1.0).isWithin(1e-20).of(1.0);
     // BUG: Diagnostic contains: 1.1e-16
-    assertThat(1.0).isWithin(TOLERANCE2).of(1f);
+    assertThat(1.0).isWithin(TOLERANCE2).of(1.0f);
     // BUG: Diagnostic contains: 1.1e-16
     assertThat(1.0).isWithin(TOLERANCE2).of(1);
     // BUG: Diagnostic contains: 1.6e+04

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/FloatingPointAssertionWithinEpsilonPositiveCases_expected.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/FloatingPointAssertionWithinEpsilonPositiveCases_expected.java
@@ -34,19 +34,16 @@ final class FloatingPointAssertionWithinEpsilonPositiveCases {
     assertThat(1.0f).isEqualTo(1.0f);
     assertThat(1f).isEqualTo(VALUE);
     assertThat(1e10f).isEqualTo(1e10f);
-
-    assertThat(1f).isNotEqualTo((float) 2);
-
+    assertThat(1f).isNotEqualTo(2f);
     assertEquals(1f, 1f, 0);
     assertEquals("equal!", 1f, 1f, 0);
   }
 
   public void testDouble() {
     assertThat(1.0).isEqualTo(1.0);
-    assertThat(1.0).isEqualTo((double) 1f);
-    assertThat(1.0).isEqualTo((double) 1);
+    assertThat(1.0).isEqualTo(1.0);
+    assertThat(1.0).isEqualTo(1d);
     assertThat(1e20).isEqualTo(1e20);
-
     assertEquals(1.0, 1.0, 0);
     assertEquals("equal!", 1.0, 1.0, 0);
   }

--- a/docgen/pom.xml
+++ b/docgen/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <name>Documention tool for generating Error Prone bugpattern documentation</name>

--- a/docgen_processor/pom.xml
+++ b/docgen_processor/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <name>JSR-269 annotation processor for @BugPattern annotation</name>

--- a/docs/bugpattern/CheckReturnValue.md
+++ b/docs/bugpattern/CheckReturnValue.md
@@ -3,7 +3,6 @@ Prone][epcrv]) marks methods whose return values should be checked. This error
 is triggered when one of these methods is called but the result is not used.
 
 [^jsr]: Of note, the JSR-305 project was [never fully approved][jsr305], so the
-
 JSR-305 version of the annotation is not actually official and causes issues
 with Java 9 and the [Module System][j9jsr305]. Prefer to use the Error Prone
 version.

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <name>Maven parent POM</name>
   <groupId>com.google.errorprone</groupId>
   <artifactId>error_prone_parent</artifactId>
-  <version>2.3.2-SNAPSHOT</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/refaster/pom.xml
+++ b/refaster/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>error_prone_parent</artifactId>
         <groupId>com.google.errorprone</groupId>
-        <version>2.3.2-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test_helpers/pom.xml
+++ b/test_helpers/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <name>error-prone test helpers</name>

--- a/type_annotations/pom.xml
+++ b/type_annotations/pom.xml
@@ -15,13 +15,15 @@
   limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <name>error-prone type annotations</name>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Check that start <= end in IndexedPosition

RELNOTES: None

7918e0916c88615c6e7b6f3267a67e4e965745da

-------

<p> BadComparable test case with File.

This was a motivating case for BadComparable and so it makes a nice test.

RELNOTES: extra BadComparable test.

a99ab45c00a519e53b05ed020be82f3430387bfa

-------

<p> Generate nicer replacements when having to convert literals.

This avoids waffle like `(double) 1f`.

RELNOTES: N/A

ee6215107e41ae91ee670f9be9359b1d0c14deea

-------

<p> AppliedFix: reject replacement ranges which exceed the source length

RELNOTES: None

7840996af21e32d0cf32d379f84cefb3eb0953fe

-------

<p> BadNestedImport: match on import, report on first occurrence only.

RELNOTES: None

836db1748a9006e5051d33b740c9505c0d3ac4e8

-------

<p> Add a check to catch chained proto builders setting the same field twice.

The most popular occurrence is single fields, but this will also match setting repeated or map fields if the index/key is a compile-time constant.

A suggestion to remove the overwritten set() is only generated if the two contain the same code--this isn't foolproof (they could be set to the result of an impure function), but I haven't seen any obvious false positives.

RELNOTES: [ProtoRedundantSet] Catch occurrences of proto fields being set twice in the same chained expression

eee92ae20eac111c80714b519f21a2dfe1651204

-------

<p> Update NullnessPropagationTransfer to recognize that if equals() returns true, argument in not null

equals() implementation should return false on null arg :
https://docs.oracle.com/javase/9/docs/api/java/lang/Object.html#equals-java.lang.Object-

RELNOTES: N/A

b072f22fdcb1a0776a14ed9e4ee94d092d0befcb

-------

<p> Flags equals() implementation which throw NPE when passed null argument

RELNOTES: Adds a new check which flags equals methods which throw NPE when passed null argument.

0d54d5a1328d7300587714105f8575f4a8a8aedd

-------

<p> Remove extraneous blank line in markdown.

9b3a398436afd4060754702be401cd3c334fcab6

-------

<p> Make the ExpectedException refactoring tool work when we can't determine the expected exception class.

ATM, when the ExpectedException refactoring tool encounters a «thrown.expect(...)» it assumes that it's of the form «thrown.expect(SomeClass.class)» and crashes otherwise.
This is definitely a common pattern, but it's not the case in general.
When refactoring some of our tests that don't follow this pattern, the tool failed on some targets.

RELNOTES: Make the ExpectedException refactoring tool work when we can't determine the expected exception class.

9276d795cfa020bc26a508c041a80b36c6a9a28a