### PR TITLE
Moe Sync

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <name>@BugPattern annotation</name>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <name>error-prone annotations</name>

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>error_prone_parent</artifactId>
     <groupId>com.google.errorprone</groupId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/check_api/pom.xml
+++ b/check_api/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <name>error-prone check api</name>

--- a/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
@@ -64,7 +64,6 @@ import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 import com.sun.tools.javac.tree.JCTree.JCIdent;
-import com.sun.tools.javac.tree.JCTree.JCNewClass;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -1126,28 +1125,6 @@ public class Matchers {
    */
   public static Matcher<Tree> hasIdentifier(Matcher<IdentifierTree> nodeMatcher) {
     return new HasIdentifier(nodeMatcher);
-  }
-
-  /**
-   * Returns true if the expression is a member access on an instance, rather than a static type.
-   * Supports member method invocations and field accesses.
-   */
-  public static Matcher<ExpressionTree> selectedIsInstance() {
-    return new Matcher<ExpressionTree>() {
-      @Override
-      public boolean matches(ExpressionTree expr, VisitorState state) {
-        if (!(expr instanceof JCFieldAccess)) {
-          // TODO(cushon): throw IllegalArgumentException?
-          return false;
-        }
-        JCExpression selected = ((JCFieldAccess) expr).getExpression();
-        if (selected instanceof JCNewClass) {
-          return true;
-        }
-        Symbol sym = ASTHelpers.getSymbol(selected);
-        return sym instanceof VarSymbol;
-      }
-    };
   }
 
   /** Returns true if the Tree node has the expected {@code Modifier}. */

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,7 +37,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <name>error-prone library</name>

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AbstractToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AbstractToString.java
@@ -64,7 +64,7 @@ public abstract class AbstractToString extends BugChecker
   protected abstract Optional<Fix> implicitToStringFix(ExpressionTree tree, VisitorState state);
 
   /** Adds the description message for match on the type without fixes. */
-  protected Optional<String> descriptionMessageForDefaultMatch(Type type) {
+  protected Optional<String> descriptionMessageForDefaultMatch(Type type, VisitorState state) {
     return Optional.absent();
   }
 
@@ -110,7 +110,7 @@ public abstract class AbstractToString extends BugChecker
     ExpressionTree receiver = ASTHelpers.getReceiver(tree);
     Type receiverType = ASTHelpers.getType(receiver);
     if (TO_STRING.matches(tree, state) && typePredicate().apply(receiverType, state)) {
-      return maybeFix(tree, receiverType, toStringFix(tree, receiver, state));
+      return maybeFix(tree, state, receiverType, toStringFix(tree, receiver, state));
     }
     return checkToString(tree, state);
   }
@@ -147,7 +147,7 @@ public abstract class AbstractToString extends BugChecker
     if (!typePredicate().apply(type, state)) {
       return NO_MATCH;
     }
-    return maybeFix(tree, type, fix);
+    return maybeFix(tree, state, type, fix);
   }
 
   enum ToStringKind {
@@ -183,12 +183,12 @@ public abstract class AbstractToString extends BugChecker
         && state.getTypes().isSameType(ASTHelpers.getType(tree), state.getSymtab().stringType);
   }
 
-  private Description maybeFix(Tree tree, Type matchedType, Optional<Fix> fix) {
+  private Description maybeFix(Tree tree, VisitorState state, Type matchedType, Optional<Fix> fix) {
     Description.Builder description = buildDescription(tree);
     if (fix.isPresent()) {
       description.addFix(fix.get());
     }
-    Optional<String> summary = descriptionMessageForDefaultMatch(matchedType);
+    Optional<String> summary = descriptionMessageForDefaultMatch(matchedType, state);
     if (summary.isPresent()) {
       description.setMessage(summary.get());
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ObjectToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ObjectToString.java
@@ -24,6 +24,7 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.fixes.Fix;
+import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.predicates.TypePredicate;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
@@ -91,11 +92,15 @@ public class ObjectToString extends AbstractToString {
   }
 
   @Override
-  protected Optional<String> descriptionMessageForDefaultMatch(Type type) {
+  protected Optional<String> descriptionMessageForDefaultMatch(Type type, VisitorState state) {
     String format =
-        "%1$s is final and does not override Object.toString, converting it to a string"
-            + " will print its identity (e.g. `%1$s@ 4488aabb`) instead of useful information.";
-    return Optional.of(String.format(format, type.toString()));
+        "%1$s is final and does not override Object.toString, so converting it to a string"
+            + " will print its identity (e.g. `%2$s@ 4488aabb`) instead of useful information.";
+    return Optional.of(
+        String.format(
+            format,
+            SuggestedFixes.prettyType(state, /* fix= */ null, type),
+            type.tsym.getSimpleName()));
   }
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpression.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpression.java
@@ -19,12 +19,8 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.fixes.SuggestedFixes.qualifyType;
-import static com.google.errorprone.matchers.Matchers.allOf;
-import static com.google.errorprone.matchers.Matchers.anyOf;
-import static com.google.errorprone.matchers.Matchers.kindIs;
-import static com.google.errorprone.matchers.Matchers.selectedIsInstance;
-import static com.google.errorprone.matchers.Matchers.staticFieldAccess;
-import static com.google.errorprone.matchers.Matchers.staticMethod;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
 
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.ProvidesFix;
@@ -33,15 +29,14 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MemberSelectTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
-import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
-import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberSelectTree;
-import com.sun.source.tree.Tree.Kind;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.StatementTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import java.util.Objects;
 
 /** @author eaftan@google.com (Eddie Aftandilian) */
 @BugPattern(
@@ -51,53 +46,71 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
     severity = WARNING,
     altNames = {"static", "static-access", "StaticAccessedFromInstance"},
     generateExamplesFromTestCases = false,
-    tags = StandardTags.STYLE,
+    tags = StandardTags.FRAGILE_CODE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class StaticQualifiedUsingExpression extends BugChecker implements MemberSelectTreeMatcher {
 
-  private static final String MESSAGE_TEMPLATE =
-      "Static %s %s should not be accessed from an " + "object instance; instead use %s";
-
-  private static final Matcher<ExpressionTree> staticAccessedFromInstanceMatcher =
-      allOf(
-          anyOf(staticMethod(), staticFieldAccess()),
-          kindIs(Kind.MEMBER_SELECT),
-          selectedIsInstance());
-
   @Override
   public Description matchMemberSelect(MemberSelectTree tree, VisitorState state) {
-    if (!staticAccessedFromInstanceMatcher.matches(tree, state)) {
-      return Description.NO_MATCH;
+    Symbol sym = getSymbol(tree);
+    if (sym == null) {
+      return NO_MATCH;
     }
-
-    // Is the static member being accessed a method or a variable?
-    Symbol staticMemberSym = ASTHelpers.getSymbol(tree);
-    if (staticMemberSym == null) {
-      return Description.NO_MATCH;
+    switch (sym.getKind()) {
+      case FIELD:
+        if (sym.getSimpleName().contentEquals("class")) {
+          return NO_MATCH;
+        }
+        // fall through
+      case METHOD:
+        if (!sym.isStatic()) {
+          return NO_MATCH;
+        }
+        break; // continue below
+      default:
+        return NO_MATCH;
     }
-    boolean isMethod = staticMemberSym instanceof MethodSymbol;
-
-    // Is the static member defined in this class?
-    ClassSymbol ownerSym = staticMemberSym.owner.enclClass();
-    ClassSymbol whereAccessedSym =
-        ASTHelpers.getSymbol(
-            ASTHelpers.findEnclosingNode(state.getPath().getParentPath(), ClassTree.class));
+    ClassSymbol owner = sym.owner.enclClass();
+    switch (tree.getExpression().getKind()) {
+      case MEMBER_SELECT:
+      case IDENTIFIER:
+        // References to static variables should be qualified by the type name of the owning type,
+        // or a sub-type. e.g.: if CONST is declared in Foo, and SubFoo extends Foo,
+        // allow `Foo.CONST` and `SubFoo.CONST` (but not, say, `new Foo().CONST`.
+        Symbol base = getSymbol(tree.getExpression());
+        if (base instanceof ClassSymbol && base.isSubClass(owner, state.getTypes())) {
+          return NO_MATCH;
+        }
+        break;
+      default: // continue below
+    }
     SuggestedFix.Builder fix = SuggestedFix.builder();
-    boolean staticMemberDefinedHere = whereAccessedSym.equals(ownerSym);
     String replacement;
-    if (staticMemberDefinedHere && isMethod) {
-      replacement = staticMemberSym.getSimpleName().toString();
+    boolean isMethod = sym instanceof MethodSymbol;
+    if (isMethod && Objects.equals(getSymbol(state.findEnclosing(ClassTree.class)), owner)) {
+      replacement = sym.getSimpleName().toString();
     } else {
-      replacement = qualifyType(state, fix, staticMemberSym);
+      replacement = qualifyType(state, fix, sym);
     }
     fix.replace(tree, replacement);
 
-    // Compute strings to interpolate into diagnostic message.
-    String memberName = staticMemberSym.getSimpleName().toString();
-    String methodOrVariable = isMethod ? "method" : "variable";
+    // Spill possibly side-effectful qualifier expressions to the top level.
+    // This doesn't preserve order of operations for non-trivial expressions, but we don't have
+    // letexprs and hopefully it'll call attention to the fact that just deleting the qualifier
+    // might not always be the right fix.
+    if (tree.getExpression() instanceof MethodInvocationTree) {
+      StatementTree statement = state.findEnclosing(StatementTree.class);
+      if (statement != null) {
+        fix.prefixWith(statement, state.getSourceForNode(tree.getExpression()) + ";");
+      }
+    }
 
-    String customDiagnosticMessage =
-        String.format(MESSAGE_TEMPLATE, methodOrVariable, memberName, replacement);
-    return buildDescription(tree).setMessage(customDiagnosticMessage).addFix(fix.build()).build();
+    return buildDescription(tree)
+        .setMessage(
+            String.format(
+                "Static %s %s should not be accessed from an object instance; instead use %s",
+                isMethod ? "method" : "variable", sym.getSimpleName().toString(), replacement))
+        .addFix(fix.build())
+        .build();
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpressionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpressionTest.java
@@ -81,4 +81,34 @@ public class StaticQualifiedUsingExpressionTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void expr() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(new StaticQualifiedUsingExpression(), getClass())
+        .addInputLines(
+            "I.java", //
+            "interface I {",
+            "  int CONST = 42;",
+            "  I id();",
+            "}")
+        .expectUnchanged()
+        .addInputLines(
+            "in/Test.java", //
+            "class Test {",
+            "  void f(I i) {",
+            "    System.err.println(((I) null).CONST);",
+            "    System.err.println(i.id().CONST);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java", //
+            "class Test {",
+            "  void f(I i) {",
+            "    System.err.println(I.CONST);",
+            "    i.id();",
+            "    System.err.println(I.CONST);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ObjectToStringPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ObjectToStringPositiveCases.java
@@ -21,10 +21,19 @@ public class ObjectToStringPositiveCases {
 
   public static final class FinalObjectClassWithoutToString {}
 
+  public static final class FinalGenericClassWithoutToString<T> {}
+
   void directToStringCalls() {
     FinalObjectClassWithoutToString finalObjectClassWithoutToString =
         new FinalObjectClassWithoutToString();
     // BUG: Diagnostic contains: ObjectToString
     System.out.println(finalObjectClassWithoutToString.toString());
+  }
+
+  void genericClassShowsErasure() {
+    FinalGenericClassWithoutToString<Object> finalGenericClassWithoutToString =
+        new FinalGenericClassWithoutToString<>();
+    // BUG: Diagnostic contains: `FinalGenericClassWithoutToString@
+    System.out.println(finalGenericClassWithoutToString.toString());
   }
 }

--- a/docgen/pom.xml
+++ b/docgen/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <name>Documention tool for generating Error Prone bugpattern documentation</name>

--- a/docgen_processor/pom.xml
+++ b/docgen_processor/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <name>JSR-269 annotation processor for @BugPattern annotation</name>

--- a/docs/bugpattern/ProtoRedundantSet.md
+++ b/docs/bugpattern/ProtoRedundantSet.md
@@ -1,0 +1,14 @@
+Proto builders provide a pleasant fluent interface for constructing instances.
+Unlike argument lists, however, they do not prevent the user from providing
+multiple values for the same field.
+
+Setting the same field multiple times in the same chained expression is
+pointless (as the intermediate value will be overwritten), and certainly
+unintentional. If the field is set to different values, it may be a bug, e.g.,
+
+```java
+return MyProto.newBuilder()
+    .setFoo(copy.getFoo())
+    .setFoo(copy.getBar())
+    .build();
+```

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <name>Maven parent POM</name>
   <groupId>com.google.errorprone</groupId>
   <artifactId>error_prone_parent</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.3.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/refaster/pom.xml
+++ b/refaster/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>error_prone_parent</artifactId>
         <groupId>com.google.errorprone</groupId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test_helpers/pom.xml
+++ b/test_helpers/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <name>error-prone test helpers</name>

--- a/type_annotations/pom.xml
+++ b/type_annotations/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
   </parent>
 
   <name>error-prone type annotations</name>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Handle more kinds of expression in StaticQualifiedUsingExpression

RELNOTES: Handle more kinds of expression in StaticQualifiedUsingExpression

f19a228f2bcb6ed6df25500a952bb872ee182b60

-------

<p> Show the erased simple type name in the ObjectToString diagnostic message.

Currently it shows stuff like "com.example.MyType<capture#607 of ?>" as the proposed output of toString, which is a bit confusing.

RELNOTES: N/A

87e9cb975736e9dc38b6bd45b791998a8b303047

-------

<p> Add brief documentation for the ProtoRedundantSet bugpattern.

RELNOTES: N/A

88e64c321df7f51e30693153cd920dea7be2b9f9

-------

<p> Refer to 2.3.2-SNAPSHOT internally

cb1d6e0f0e2dc374dd2729212f22c6c20f9a19e1