### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/SwigMemoryLeak.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SwigMemoryLeak.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.Category.JDK;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.LiteralTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.LiteralTree;
+import com.sun.source.tree.MethodTree;
+import javax.lang.model.element.Name;
+
+/** @author irogers@google.com (Ian Rogers) */
+@BugPattern(
+  name = "SwigMemoryLeak",
+  summary = "SWIG generated code that can't call a C++ destructor will leak memory",
+  category = JDK,
+  severity = WARNING
+)
+public class SwigMemoryLeak extends BugChecker implements LiteralTreeMatcher {
+  private static final Matcher<MethodTree> ENCLOSING_CLASS_HAS_FINALIZER =
+      Matchers.enclosingClass(Matchers.hasMethod(Matchers.methodIsNamed("finalize")));
+
+  @Override
+  public Description matchLiteral(LiteralTree tree, VisitorState state) {
+    // Is there a literal matching the message SWIG uses to indicate a
+    // destructor problem?
+    if (tree.getValue() == null
+        || !tree.getValue().equals("C++ destructor does not have public access")) {
+      return NO_MATCH;
+    }
+    // Is it within a delete method?
+    MethodTree enclosingMethodTree =
+        ASTHelpers.findEnclosingNode(state.getPath(), MethodTree.class);
+    Name name = enclosingMethodTree.getName();
+    if (!name.contentEquals("delete")) {
+      return NO_MATCH;
+    }
+    // Does the enclosing class lack a finalizer?
+    if (ENCLOSING_CLASS_HAS_FINALIZER.matches(enclosingMethodTree, state)) {
+      return NO_MATCH;
+    }
+    return buildDescription(tree).build();
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -209,6 +209,7 @@ import com.google.errorprone.bugpatterns.StringBuilderInitWithChar;
 import com.google.errorprone.bugpatterns.StringEquality;
 import com.google.errorprone.bugpatterns.StringSplitter;
 import com.google.errorprone.bugpatterns.SuppressWarningsDeprecated;
+import com.google.errorprone.bugpatterns.SwigMemoryLeak;
 import com.google.errorprone.bugpatterns.SwitchDefault;
 import com.google.errorprone.bugpatterns.TestExceptionChecker;
 import com.google.errorprone.bugpatterns.ThreadJoinLoop;
@@ -546,12 +547,13 @@ public class BuiltInCheckerSuppliers {
           StringSplitter.class,
           StaticGuardedByInstance.class,
           StreamResourceLeak.class,
-          TruthIncompatibleType.class,
+          SwigMemoryLeak.class,
           SynchronizeOnNonFinalField.class,
           ThreadJoinLoop.class,
           ThreadLocalUsage.class,
           ThreeLetterTimeZoneID.class,
           TruthConstantAsserts.class,
+          TruthIncompatibleType.class,
           TypeParameterShadowing.class,
           TypeParameterUnusedInFormals.class,
           UnsafeFinalization.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/SwigMemoryLeakTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/SwigMemoryLeakTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** @author irogers@google.com (Ian Rogers) */
+@RunWith(JUnit4.class)
+public class SwigMemoryLeakTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setUp() {
+    compilationHelper = CompilationTestHelper.newInstance(SwigMemoryLeak.class, getClass());
+  }
+
+  @Test
+  public void testPositiveCase() throws Exception {
+    compilationHelper.addSourceFile("SwigMemoryLeakPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void testNegativeCase() throws Exception {
+    compilationHelper.addSourceFile("SwigMemoryLeakNegativeCases.java").doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/SwigMemoryLeakNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/SwigMemoryLeakNegativeCases.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+/** @author irogers@google.com (Ian Rogers) */
+public class SwigMemoryLeakNegativeCases {
+  private long swigCPtr;
+  protected boolean swigCMemOwn;
+
+  public SwigMemoryLeakNegativeCases(long cPtr, boolean cMemoryOwn) {
+    swigCMemOwn = cMemoryOwn;
+    swigCPtr = cPtr;
+  }
+
+  protected void finalize() {
+    delete();
+  }
+
+  public synchronized void delete() {
+    if (swigCPtr != 0) {
+      if (swigCMemOwn) {
+        swigCMemOwn = false;
+        nativeDelete(swigCPtr);
+      }
+      swigCPtr = 0;
+    }
+  }
+
+  private static native void nativeDelete(long cptr);
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/SwigMemoryLeakPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/SwigMemoryLeakPositiveCases.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+/** @author irogers@google.com (Ian Rogers) */
+public class SwigMemoryLeakPositiveCases {
+  private long swigCPtr;
+  protected boolean swigCMemOwn;
+
+  public SwigMemoryLeakPositiveCases(long cPtr, boolean cMemoryOwn) {
+    swigCMemOwn = cMemoryOwn;
+    swigCPtr = cPtr;
+  }
+
+  public synchronized void delete() {
+    if (swigCPtr != 0) {
+      if (swigCMemOwn) {
+        swigCMemOwn = false;
+        // BUG: Diagnostic contains: SWIG generated code that can't call a C++ destructor will leak
+        // memory
+        throw new UnsupportedOperationException("C++ destructor does not have public access");
+      }
+      swigCPtr = 0;
+    }
+  }
+}

--- a/docs/bugpattern/SwigMemoryLeak.md
+++ b/docs/bugpattern/SwigMemoryLeak.md
@@ -1,0 +1,13 @@
+SWIG is a tool that will automatically generate Java bindings to C++ code. It is
+possible to %ignore in SWIG a C++ object's destructor, this is trivially
+achieved when using %ignoreall and then selectively %unignore-ing an API. SWIG
+cleans up C++ objects using a delete method, which is most commonly called by a
+finalizer. When a SWIG generated delete method can't call a destructor, as it is
+hidden, the delete method throws an exception. However, in the case of a hidden
+C++ destructor SWIG also doesn't generate a finalizer, and so the most common
+call to the delete method is removed. The consequence of this is that the SWIG
+objects leak their C++ counterpart and no warnings or exceptions are thrown.
+
+This check looks for the pattern of a memory leaking SWIG generated object and
+warns about the potential memory leak. The most straightforward fix is to the
+SWIG input code to tell it not to %ignore the C++ code's destructor.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a check for C++ memory leaks in Java code created by SWIG.

SWIG can generate memory leaks of C++ objects. When encountering the leaking Java code create a warning.

RELNOTES: SWIG memory leak checker.

e8f1bf66ba3dc4f4c61ac0e37f5b037bce36eb7b