### PR TITLE
Add support for suppression of FieldCanBeFinal

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeFinal.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeFinal.java
@@ -102,6 +102,14 @@ public class FieldCanBeFinal extends BugChecker implements CompilationUnitTreeMa
   private static final ImmutableSet<String> IMPLICIT_VAR_ANNOTATION_SIMPLE_NAMES =
       ImmutableSet.of("NonFinalForTesting", "NotFinalForTesting");
 
+  /** Unary operator kinds that implicitly assign to their operand. */
+  private static final EnumSet<Kind> UNARY_ASSIGNMENT =
+      EnumSet.of(
+          Kind.PREFIX_DECREMENT,
+          Kind.POSTFIX_DECREMENT,
+          Kind.PREFIX_INCREMENT,
+          Kind.POSTFIX_INCREMENT);
+
   /** The initalization context where an assignment occurred. */
   enum InitializationContext {
     /** A class (static) initializer. */
@@ -243,7 +251,7 @@ public class FieldCanBeFinal extends BugChecker implements CompilationUnitTreeMa
   }
 
   /** Record assignments to possibly-final variables in a compilation unit. */
-  private static class FinalScanner extends TreePathScanner<Void, InitializationContext> {
+  private class FinalScanner extends TreePathScanner<Void, InitializationContext> {
 
     private final VariableAssignmentRecords writes;
     private final Context context;
@@ -256,7 +264,7 @@ public class FieldCanBeFinal extends BugChecker implements CompilationUnitTreeMa
     @Override
     public Void visitVariable(VariableTree node, InitializationContext init) {
       VarSymbol sym = ASTHelpers.getSymbol(node);
-      if (sym.getKind() == ElementKind.FIELD) {
+      if (sym.getKind() == ElementKind.FIELD && !isSuppressed(node)) {
         writes.recordDeclaration(sym, node);
       }
       return super.visitVariable(node, InitializationContext.NONE);
@@ -309,7 +317,10 @@ public class FieldCanBeFinal extends BugChecker implements CompilationUnitTreeMa
     public Void visitClass(ClassTree node, InitializationContext init) {
       VisitorState state = new VisitorState(context).withPath(getCurrentPath());
 
-
+      if (isSuppressed(node))
+      {
+        return null;
+      }
       for (String annotation : IMPLICIT_VAR_CLASS_ANNOTATIONS) {
         if (ASTHelpers.hasAnnotation(getSymbol(node), annotation, state)) {
           return null;
@@ -326,14 +337,6 @@ public class FieldCanBeFinal extends BugChecker implements CompilationUnitTreeMa
       writes.recordAssignment(node.getVariable(), init);
       return super.visitCompoundAssignment(node, init);
     }
-
-    /** Unary operator kinds that implicitly assign to their operand. */
-    private static final EnumSet<Kind> UNARY_ASSIGNMENT =
-        EnumSet.of(
-            Kind.PREFIX_DECREMENT,
-            Kind.POSTFIX_DECREMENT,
-            Kind.PREFIX_INCREMENT,
-            Kind.POSTFIX_INCREMENT);
 
     @Override
     public Void visitUnary(UnaryTree node, InitializationContext init) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/FieldCanBeFinalTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/FieldCanBeFinalTest.java
@@ -104,6 +104,36 @@ public class FieldCanBeFinalTest {
         .doTest();
   }
 
+  @Test
+  public void suppressionOnField() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  @SuppressWarnings(\"FieldCanBeFinal\")",
+            "  private int x;",
+            "  Test() {",
+            "    x = 42;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void suppressionOnClass() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "@SuppressWarnings(\"FieldCanBeFinal\") ",
+            "class Test {",
+            "  private int x;",
+            "  Test() {",
+            "    x = 42;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   // the nullary constructor doesn't set x directly, but that's OK
   @Test
   public void constructorChaining() {


### PR DESCRIPTION
Currently there is no possibility of suppressing `FieldCanBeFinal` check by placing `@SuppressWarnings("FieldCanBeFinal")` annotation, either on field in question, or on whole class. This can be verified by running included tests without appling my proposed fix.