### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
@@ -63,7 +63,7 @@ public class BadImport extends BugChecker implements ImportTreeMatcher {
       ImmutableSet.of(
           "Builder");
   private static final ImmutableSet<String> BAD_STATIC_IDENTIFIERS =
-      ImmutableSet.of("of", "from", "INSTANCE", "builder", "newBuilder");
+      ImmutableSet.of("copyOf", "of", "from", "INSTANCE", "builder", "newBuilder");
 
   private static final MultiMatcher<Tree, AnnotationTree> HAS_TYPE_USE_ANNOTATION =
       annotations(AT_LEAST_ONE, (t, state) -> isTypeAnnotation(t));

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpression.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpression.java
@@ -58,7 +58,8 @@ public class StaticQualifiedUsingExpression extends BugChecker implements Member
     }
     switch (sym.getKind()) {
       case FIELD:
-        if (sym.getSimpleName().contentEquals("class")) {
+        if (sym.getSimpleName().contentEquals("class")
+            || sym.getSimpleName().contentEquals("super")) {
           return NO_MATCH;
         }
         // fall through

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UngroupedOverloads.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UngroupedOverloads.java
@@ -26,6 +26,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Streams;
 import com.google.errorprone.BugPattern;
+import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -54,6 +55,13 @@ import javax.lang.model.element.Name;
     link = "https://google.github.io/styleguide/javaguide.html#s3.4.2.1-overloads-never-split"
     )
 public class UngroupedOverloads extends BugChecker implements ClassTreeMatcher {
+
+  private final Boolean showFindingOnFirstOverloadOnly;
+
+  public UngroupedOverloads(ErrorProneFlags flags) {
+    showFindingOnFirstOverloadOnly =
+        flags.getBoolean("UngroupedOverloads:FindingsOnFirstOverload").orElse(false);
+  }
 
   @AutoValue
   abstract static class MemberWithIndex {
@@ -146,6 +154,7 @@ public class UngroupedOverloads extends BugChecker implements ClassTreeMatcher {
     // emit findings for each overload
     overloads
         .stream()
+        .limit(showFindingOnFirstOverloadOnly ? 1 : Long.MAX_VALUE)
         .forEach(
             o ->
                 state.reportMatch(

--- a/core/src/main/java/com/google/errorprone/bugpatterns/apidiff/Java7ApiChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/apidiff/Java7ApiChecker.java
@@ -32,7 +32,10 @@ import java.io.IOException;
         "Code that needs to be compatible with Java 7 cannot use types or members"
             + " that are only present in the JDK 8 class libraries",
     category = JDK,
-    severity = ERROR)
+    severity = ERROR,
+    suppressionAnnotations = {
+      SuppressWarnings.class
+    })
 public class Java7ApiChecker extends ApiDiffChecker {
 
   static final ApiDiff API_DIFF = loadApiDiff();
@@ -70,6 +73,8 @@ public class Java7ApiChecker extends ApiDiffChecker {
   }
 
   public Java7ApiChecker() {
-    super(API_DIFF);
+    super(
+        API_DIFF
+        );
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpressionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpressionTest.java
@@ -111,4 +111,29 @@ public class StaticQualifiedUsingExpressionTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void superAccess() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(new StaticQualifiedUsingExpression(), getClass())
+        .addInputLines(
+            "I.java", //
+            "interface I {",
+            "  interface Builder {",
+            "    default void f() {}",
+            "  }",
+            "}")
+        .expectUnchanged()
+        .addInputLines(
+            "in/Test.java", //
+            "interface J extends I {",
+            "  interface Builder extends I.Builder {",
+            "    default void f() {}",
+            "    default void aI() {",
+            "      I.Builder.super.f();",
+            "    }",
+            "  }",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UngroupedOverloadsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UngroupedOverloadsTest.java
@@ -16,9 +16,11 @@
 
 package com.google.errorprone.bugpatterns;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.ErrorProneFlags;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,7 +34,8 @@ public final class UngroupedOverloadsTest {
       CompilationTestHelper.newInstance(UngroupedOverloads.class, getClass());
 
   private final BugCheckerRefactoringTestHelper refactoringHelper =
-      BugCheckerRefactoringTestHelper.newInstance(new UngroupedOverloads(), getClass());
+      BugCheckerRefactoringTestHelper.newInstance(
+          new UngroupedOverloads(ErrorProneFlags.empty()), getClass());
 
   @Test
   public void ungroupedOverloadsPositiveCasesSingle() throws Exception {
@@ -52,6 +55,14 @@ public final class UngroupedOverloadsTest {
   @Test
   public void ungroupedOverloadsPositiveCasesCovering() throws Exception {
     compilationHelper.addSourceFile("UngroupedOverloadsPositiveCasesCovering.java").doTest();
+  }
+
+  @Test
+  public void ungroupedOverloadsPositiveCasesCoveringOnlyFirstOverload() throws Exception {
+    compilationHelper
+        .addSourceFile("UngroupedOverloadsPositiveCasesCoveringOnlyOnFirst.java")
+        .setArgs(ImmutableList.of("-XepOpt:UngroupedOverloads:FindingsOnFirstOverload"))
+        .doTest();
   }
 
   @Test

--- a/core/src/test/java/com/google/errorprone/bugpatterns/apidiff/AndroidJdkLibsCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/apidiff/AndroidJdkLibsCheckerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.apidiff;
+
+
+import com.google.errorprone.CompilationTestHelper;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** {@link AndroidJdkLibsChecker}Test. */
+
+@RunWith(JUnit4.class)
+public class AndroidJdkLibsCheckerTest extends Java7ApiCheckerTest {
+
+  private final CompilationTestHelper allowJava8Helper =
+      CompilationTestHelper.newInstance(AndroidJdkLibsChecker.class, getClass())
+          .setArgs(Collections.singletonList("-XepOpt:Android:Java8Libs"));
+
+  public AndroidJdkLibsCheckerTest() {
+    super(AndroidJdkLibsChecker.class);
+  }
+
+  @Test
+  public void repeatedAnnotationAllowed() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.lang.annotation.Repeatable;",
+            "@Repeatable(Test.Container.class)",
+            "public @interface Test {",
+            "  public @interface Container {",
+            "    Test[] value();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeAnnotationAllowed() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.lang.annotation.Target;",
+            "import java.lang.annotation.ElementType;",
+            "@Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})",
+            "public @interface Test {",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void defaultMethod() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Map;",
+            "public class Test {",
+            "  abstract static class A implements Map<Object, Object> {}",
+            "  abstract static class B implements Map<Object, Object> {",
+            "    @Override",
+            "    public Object getOrDefault(Object key, Object defaultValue) {",
+            "      return null;",
+            "    }",
+            "  }",
+            "  void f(A a, B b) {",
+            "    // BUG: Diagnostic contains: java.util.Map#getOrDefault(java.lang.Object,V)"
+                + " is not available in Test.A",
+            "    a.getOrDefault(null, null);",
+            "    b.getOrDefault(null, null); // OK: overrides getOrDefault",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeKind() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "public class Test {",
+            "  // BUG: Diagnostic contains:",
+            "  javax.lang.model.type.TypeKind tk;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void allowJava8Flag_packageWhitelist() {
+    allowJava8Helper
+        .addSourceLines(
+            "Test.java",
+            "import java.time.Duration;",
+            "import java.util.stream.Stream;",
+            "import com.google.common.base.Predicates;",
+            "import java.util.Arrays;",
+            "public class Test {",
+            "  Duration d = Duration.ofSeconds(10);",
+            "  public static void test(Stream s) {",
+            "    s.forEach(i -> {});",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void allowJava8Flag_memberWhitelist() {
+    allowJava8Helper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Arrays;",
+            "public class Test {",
+            "  public static void main(String... args) {",
+            "    Arrays.stream(args);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void allowJava8Flag_memberBlacklist() {
+    allowJava8Helper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.stream.Stream;",
+            "public class Test {",
+            "  public static void test(Stream s) {",
+            "    // BUG: Diagnostic contains: parallel",
+            "    s.parallel();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/apidiff/ApiDiffCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/apidiff/ApiDiffCheckerTest.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.apidiff;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.errorprone.BaseErrorProneJavaCompiler;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.bugpatterns.apidiff.ApiDiff.ClassMemberKey;
+import com.google.errorprone.bugpatterns.apidiff.CompilationBuilderHelpers.CompilationBuilder;
+import com.google.errorprone.bugpatterns.apidiff.CompilationBuilderHelpers.CompilationResult;
+import com.google.errorprone.bugpatterns.apidiff.CompilationBuilderHelpers.SourceBuilder;
+import com.google.errorprone.scanner.ErrorProneScanner;
+import com.google.errorprone.scanner.ScannerSupplier;
+import com.sun.tools.javac.api.JavacTool;
+import com.sun.tools.javac.file.JavacFileManager;
+import com.sun.tools.javac.util.Context;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Locale;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** {@link ApiDiffChecker}Test. */
+@RunWith(JUnit4.class)
+public class ApiDiffCheckerTest {
+
+  @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+  private final JavacFileManager fileManager =
+      new JavacFileManager(new Context(), false, StandardCharsets.UTF_8);
+
+  /** An {@link ApiDiffChecker} for testing. */
+  @BugPattern(name = "SampleChecker", severity = SeverityLevel.ERROR, summary = "")
+  private static class SampleApiDiffChecker extends ApiDiffChecker {
+    SampleApiDiffChecker(ApiDiff apiDiff) {
+      super(apiDiff);
+    }
+  }
+
+  @Test
+  public void newDerivedMethod() throws Exception {
+    ApiDiff diff =
+        ApiDiff.fromMembers(
+            Collections.emptySet(),
+            ImmutableSetMultimap.of("lib/Derived", ClassMemberKey.create("g", "()V")));
+
+    Path originalJar =
+        new CompilationBuilder(JavacTool.create(), tempFolder.newFolder(), fileManager)
+            .setSources(
+                new SourceBuilder(tempFolder.newFolder())
+                    .addSourceLines(
+                        "Base.java", //
+                        "package lib;",
+                        "public class Base {",
+                        "  public void f() {}",
+                        "}")
+                    .addSourceLines(
+                        "Derived.java", //
+                        "package lib;",
+                        "public class Derived extends Base {",
+                        "}")
+                    .build())
+            .compileOutputToJarOrDie();
+
+    Path newJar =
+        new CompilationBuilder(JavacTool.create(), tempFolder.newFolder(), fileManager)
+            .setClasspath(Collections.singleton(originalJar))
+            .setSources(
+                new SourceBuilder(tempFolder.newFolder())
+                    .addSourceLines(
+                        "Derived.java", //
+                        "package lib;",
+                        "public class Derived extends Base {",
+                        "  public void f() {}",
+                        "  public void g() {}",
+                        "}")
+                    .build())
+            .compileOutputToJarOrDie();
+
+    BaseErrorProneJavaCompiler errorProneCompiler =
+        new BaseErrorProneJavaCompiler(
+            ScannerSupplier.fromScanner(new ErrorProneScanner(new SampleApiDiffChecker(diff))));
+
+    final CompilationResult result =
+        new CompilationBuilder(errorProneCompiler, tempFolder.newFolder(), fileManager)
+            .setSources(
+                new SourceBuilder(tempFolder.newFolder())
+                    .addSourceLines(
+                        "Test.java",
+                        "import lib.*;", //
+                        "class Test {",
+                        "  void f() {",
+                        "    new Derived().f();",
+                        "    new Derived().g();",
+                        "  }",
+                        "}")
+                    .build())
+            .setClasspath(Arrays.asList(newJar, originalJar))
+            .compile();
+
+    assertThat(getOnlyElement(result.diagnostics()).getMessage(Locale.ENGLISH))
+        .contains("g() is not available in lib.Derived");
+  }
+
+  @Test
+  public void addedSuperAndMethod() throws Exception {
+    ApiDiff diff =
+        ApiDiff.fromMembers(
+            ImmutableSet.of("lib/A"),
+            ImmutableSetMultimap.of("lib/B", ClassMemberKey.create("f", "()V")));
+
+    Path originalJar =
+        new CompilationBuilder(JavacTool.create(), tempFolder.newFolder(), fileManager)
+            .setSources(
+                new SourceBuilder(tempFolder.newFolder())
+                    .addSourceLines(
+                        "B.java", //
+                        "package lib;",
+                        "public class B {",
+                        "}")
+                    .build())
+            .compileOutputToJarOrDie();
+
+    Path newJar =
+        new CompilationBuilder(JavacTool.create(), tempFolder.newFolder(), fileManager)
+            .setSources(
+                new SourceBuilder(tempFolder.newFolder())
+                    .addSourceLines(
+                        "A.java", //
+                        "package lib;",
+                        "interface A {",
+                        "  default void f() {}",
+                        "}")
+                    .addSourceLines(
+                        "B.java", //
+                        "package lib;",
+                        "public class B implements A {",
+                        "}")
+                    .build())
+            .compileOutputToJarOrDie();
+
+    BaseErrorProneJavaCompiler errorProneCompiler =
+        new BaseErrorProneJavaCompiler(
+            ScannerSupplier.fromScanner(new ErrorProneScanner(new SampleApiDiffChecker(diff))));
+
+    final CompilationResult result =
+        new CompilationBuilder(errorProneCompiler, tempFolder.newFolder(), fileManager)
+            .setSources(
+                new SourceBuilder(tempFolder.newFolder())
+                    .addSourceLines(
+                        "Test.java",
+                        "import lib.*;", //
+                        "class Test {",
+                        "  void f(B b) {",
+                        "    b.f();",
+                        "  }",
+                        "}")
+                    .build())
+            .setClasspath(Arrays.asList(newJar, originalJar))
+            .compile();
+
+    // This should be an error (the inherited A.f() is not backwards compatible), but we don't
+    // detect newly added methods in newly added super types.
+    assertThat(result.diagnostics()).isEmpty();
+  }
+
+  @Test
+  public void movedMethodToNewSuper() throws Exception {
+    ApiDiff diff = ApiDiff.fromMembers(ImmutableSet.of("lib/A"), ImmutableSetMultimap.of());
+
+    Path originalJar =
+        new CompilationBuilder(JavacTool.create(), tempFolder.newFolder(), fileManager)
+            .setSources(
+                new SourceBuilder(tempFolder.newFolder())
+                    .addSourceLines(
+                        "B.java", //
+                        "package lib;",
+                        "public class B {",
+                        "  public void f() {}",
+                        "}")
+                    .build())
+            .compileOutputToJarOrDie();
+
+    Path newJar =
+        new CompilationBuilder(JavacTool.create(), tempFolder.newFolder(), fileManager)
+            .setSources(
+                new SourceBuilder(tempFolder.newFolder())
+                    .addSourceLines(
+                        "A.java", //
+                        "package lib;",
+                        "interface A {",
+                        "  default void f() {}",
+                        "}")
+                    .addSourceLines(
+                        "B.java", //
+                        "package lib;",
+                        "public class B implements A {}")
+                    .build())
+            .compileOutputToJarOrDie();
+
+    BaseErrorProneJavaCompiler errorProneCompiler =
+        new BaseErrorProneJavaCompiler(
+            ScannerSupplier.fromScanner(new ErrorProneScanner(new SampleApiDiffChecker(diff))));
+
+    final CompilationResult result =
+        new CompilationBuilder(errorProneCompiler, tempFolder.newFolder(), fileManager)
+            .setSources(
+                new SourceBuilder(tempFolder.newFolder())
+                    .addSourceLines(
+                        "Test.java",
+                        "import lib.*;", //
+                        "class Test {",
+                        "  void f(B b) {",
+                        "    b.f();",
+                        "  }",
+                        "}")
+                    .build())
+            .setClasspath(Arrays.asList(newJar, originalJar))
+            .compile();
+
+    assertThat(result.diagnostics()).isEmpty();
+  }
+
+  @Test
+  public void movedToSuperMethodFromMiddle() throws Exception {
+    ApiDiff diff =
+        ApiDiff.fromMembers(
+            ImmutableSet.of(), ImmutableSetMultimap.of("lib/A", ClassMemberKey.create("f", "()V")));
+
+    Path originalJar =
+        new CompilationBuilder(JavacTool.create(), tempFolder.newFolder(), fileManager)
+            .setSources(
+                new SourceBuilder(tempFolder.newFolder())
+                    .addSourceLines(
+                        "A.java", //
+                        "package lib;",
+                        "public class A {",
+                        "}")
+                    .addSourceLines(
+                        "B.java", //
+                        "package lib;",
+                        "public class B extends A {",
+                        "  public void f() {}",
+                        "}")
+                    .addSourceLines(
+                        "C.java", //
+                        "package lib;",
+                        "public class C extends B {",
+                        "}")
+                    .build())
+            .compileOutputToJarOrDie();
+
+    Path newJar =
+        new CompilationBuilder(JavacTool.create(), tempFolder.newFolder(), fileManager)
+            .setSources(
+                new SourceBuilder(tempFolder.newFolder())
+                    .addSourceLines(
+                        "A.java", //
+                        "package lib;",
+                        "public class A {",
+                        "  public void f() {}",
+                        "}")
+                    .addSourceLines(
+                        "B.java", //
+                        "package lib;",
+                        "public class B extends A {",
+                        "}")
+                    .addSourceLines(
+                        "C.java", //
+                        "package lib;",
+                        "public class C extends B {",
+                        "}")
+                    .build())
+            .compileOutputToJarOrDie();
+
+    BaseErrorProneJavaCompiler errorProneCompiler =
+        new BaseErrorProneJavaCompiler(
+            ScannerSupplier.fromScanner(new ErrorProneScanner(new SampleApiDiffChecker(diff))));
+
+    final CompilationResult result =
+        new CompilationBuilder(errorProneCompiler, tempFolder.newFolder(), fileManager)
+            .setSources(
+                new SourceBuilder(tempFolder.newFolder())
+                    .addSourceLines(
+                        "Test.java",
+                        "import lib.*;", //
+                        "class Test {",
+                        "  void f(C c) {",
+                        "    c.f();",
+                        "  }",
+                        "}")
+                    .build())
+            .setClasspath(Arrays.asList(newJar, originalJar))
+            .compile();
+
+    // This is actually OK, but we see it as a call to the newly-added A.f, and don't consider that
+    // B.f is available in the old version of the API. It's not clear how to avoid this false
+    // positive.
+    assertThat(result.diagnostics()).hasSize(1);
+    assertThat(getOnlyElement(result.diagnostics()).getMessage(Locale.ENGLISH))
+        .contains("lib.A#f() is not available in lib.C");
+  }
+
+  @Test
+  public void subType() throws Exception {
+    ApiDiff diff =
+        ApiDiff.fromMembers(
+            ImmutableSet.of(), ImmutableSetMultimap.of("lib/A", ClassMemberKey.create("f", "()V")));
+
+    Path originalJar =
+        new CompilationBuilder(JavacTool.create(), tempFolder.newFolder(), fileManager)
+            .setSources(
+                new SourceBuilder(tempFolder.newFolder())
+                    .addSourceLines(
+                        "A.java", //
+                        "package lib;",
+                        "public class A {",
+                        "}")
+                    .build())
+            .compileOutputToJarOrDie();
+
+    Path newJar =
+        new CompilationBuilder(JavacTool.create(), tempFolder.newFolder(), fileManager)
+            .setSources(
+                new SourceBuilder(tempFolder.newFolder())
+                    .addSourceLines(
+                        "A.java", //
+                        "package lib;",
+                        "public class A {",
+                        "  public void f() {}",
+                        "}")
+                    .build())
+            .compileOutputToJarOrDie();
+
+    BaseErrorProneJavaCompiler errorProneCompiler =
+        new BaseErrorProneJavaCompiler(
+            ScannerSupplier.fromScanner(new ErrorProneScanner(new SampleApiDiffChecker(diff))));
+
+    final CompilationResult result =
+        new CompilationBuilder(errorProneCompiler, tempFolder.newFolder(), fileManager)
+            .setSources(
+                new SourceBuilder(tempFolder.newFolder())
+                    .addSourceLines(
+                        "Test.java",
+                        "import lib.A;", //
+                        "class Test {",
+                        "  void g() {",
+                        "    new A() {}.f();",
+                        "  }",
+                        "}")
+                    .build())
+            .setClasspath(Arrays.asList(newJar, originalJar))
+            .compile();
+
+    assertThat(result.diagnostics()).hasSize(1);
+    assertThat(getOnlyElement(result.diagnostics()).getMessage(Locale.ENGLISH))
+        .contains("lib.A#f() is not available in <anonymous Test$1>");
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/apidiff/CompilationBuilderHelpers.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/apidiff/CompilationBuilderHelpers.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.apidiff;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.sun.tools.javac.file.JavacFileManager;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+
+/** Compilation test helpers for ApiDiff tools. */
+public class CompilationBuilderHelpers {
+
+  /** A collection of sources to compile. */
+  public static class SourceBuilder {
+    final File tempFolder;
+    final List<Path> sources = new ArrayList<>();
+
+    public SourceBuilder(File tempFolder) {
+      this.tempFolder = tempFolder;
+    }
+
+    public SourceBuilder addSourceLines(String name, String... lines) throws IOException {
+      Path filePath = Paths.get(tempFolder.getAbsolutePath(), name);
+      sources.add(filePath);
+      Files.write(filePath, Arrays.asList(lines), UTF_8, StandardOpenOption.CREATE);
+      return this;
+    }
+
+    public List<Path> build() {
+      return ImmutableList.copyOf(sources);
+    }
+  }
+
+  /** A wrapper around {@link JavaCompiler}. */
+  public static class CompilationBuilder {
+
+    final JavaCompiler compiler;
+    final File tempFolder;
+    final JavacFileManager fileManager;
+
+    private Collection<Path> sources = Collections.emptyList();
+    private Collection<Path> classpath = Collections.emptyList();
+    private Iterable<String> javacopts = Collections.emptyList();
+
+    public CompilationBuilder(
+        JavaCompiler compiler, File tempFolder, JavacFileManager fileManager) {
+      this.compiler = compiler;
+      this.tempFolder = tempFolder;
+      this.fileManager = fileManager;
+    }
+
+    public CompilationBuilder setSources(Collection<Path> sources) {
+      this.sources = sources;
+      return this;
+    }
+
+    public CompilationBuilder setClasspath(Collection<Path> classpath) {
+      this.classpath = classpath;
+      return this;
+    }
+
+    CompilationBuilder setJavacopts(Iterable<String> javacopts) {
+      this.javacopts = javacopts;
+      return this;
+    }
+
+    CompilationResult compile() throws IOException {
+      Path output = tempFolder.toPath();
+      DiagnosticCollector<JavaFileObject> diagnosticCollector = new DiagnosticCollector<>();
+      StringWriter errorOutput = new StringWriter();
+
+      fileManager.setLocationFromPaths(StandardLocation.CLASS_PATH, classpath);
+      fileManager.setLocationFromPaths(StandardLocation.SOURCE_PATH, Collections.<Path>emptyList());
+      fileManager.setLocationFromPaths(
+          StandardLocation.ANNOTATION_PROCESSOR_PATH, Collections.<Path>emptyList());
+
+      fileManager.setLocationFromPaths(
+          StandardLocation.CLASS_OUTPUT, Collections.singleton(output));
+
+      boolean ok =
+          compiler
+              .getTask(
+                  new PrintWriter(errorOutput, true),
+                  fileManager,
+                  diagnosticCollector,
+                  javacopts,
+                  /*classes=*/ Collections.<String>emptyList(),
+                  fileManager.getJavaFileObjectsFromPaths(sources))
+              .call();
+
+      return CompilationResult.create(
+          ok, diagnosticCollector.getDiagnostics(), errorOutput.toString(), output);
+    }
+
+    CompilationResult compileOrDie() throws IOException {
+      CompilationResult result = compile();
+      assertWithMessage("Compilation failed unexpectedly")
+          .that(result.ok())
+          .named(Joiner.on('\n').join(result.diagnostics()))
+          .isTrue();
+      return result;
+    }
+
+    public Path compileOutputToJarOrDie() throws IOException {
+      final Path outputDir = compileOrDie().classOutput();
+      final Path outputJar = outputDir.resolve("output.jar");
+      try (OutputStream os = Files.newOutputStream(outputJar);
+          final JarOutputStream jos = new JarOutputStream(os)) {
+        Files.walkFileTree(
+            outputDir,
+            new SimpleFileVisitor<Path>() {
+              @Override
+              public FileVisitResult visitFile(Path path, BasicFileAttributes attrs)
+                  throws IOException {
+                if (path.toString().endsWith(".class")) {
+                  jos.putNextEntry(new JarEntry(outputDir.relativize(path).toString()));
+                  Files.copy(path, jos);
+                }
+                return FileVisitResult.CONTINUE;
+              }
+            });
+      }
+      return outputJar;
+    }
+  }
+
+  /** The output from a compilation. */
+  @AutoValue
+  abstract static class CompilationResult {
+    abstract boolean ok();
+
+    abstract ImmutableList<Diagnostic<? extends JavaFileObject>> diagnostics();
+
+    abstract String errorOutput();
+
+    abstract Path classOutput();
+
+    static CompilationResult create(
+        boolean ok,
+        Iterable<Diagnostic<? extends JavaFileObject>> diagnostics,
+        String errorOutput,
+        Path classOutput) {
+      return new AutoValue_CompilationBuilderHelpers_CompilationResult(
+          ok, ImmutableList.copyOf(diagnostics), errorOutput, classOutput);
+    }
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/apidiff/Java7ApiCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/apidiff/Java7ApiCheckerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.apidiff;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** {@link Java7ApiChecker}Test */
+
+@RunWith(JUnit4.class)
+public class Java7ApiCheckerTest {
+
+  protected final CompilationTestHelper compilationHelper;
+
+  public Java7ApiCheckerTest() {
+    this(Java7ApiChecker.class);
+  }
+
+  protected Java7ApiCheckerTest(Class<? extends ApiDiffChecker> checker) {
+    compilationHelper = CompilationTestHelper.newInstance(checker, getClass());
+  }
+
+  @Test
+  public void positiveClass() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "class Test {",
+            "  // BUG: Diagnostic contains: java.util.Optional",
+            "  Optional<String> o;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positiveMethod() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.List;",
+            "class Test {",
+            "  void f(List<Integer> xs) {",
+            "    // BUG: Diagnostic contains: stream() is not available in java.util.List",
+            "    xs.stream();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positiveField() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import javax.lang.model.SourceVersion;",
+            "class Test {",
+            "  // BUG: Diagnostic contains: RELEASE_8",
+            "  SourceVersion version8 = SourceVersion.RELEASE_8;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negativeInherited() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.LinkedHashMap;",
+            "import java.util.concurrent.ConcurrentHashMap;",
+            "import java.util.Set;",
+            "class Test {",
+            "  Set<String> getKeySet(LinkedHashMap<String, String> map) {",
+            "    return map.keySet();",
+            "  }",
+            "  Set<String> getKeySet(ConcurrentHashMap<String, String> map) {",
+            "    return map.keySet();",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UngroupedOverloadsPositiveCasesCoveringOnlyOnFirst.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UngroupedOverloadsPositiveCasesCoveringOnlyOnFirst.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+/** @author hanuszczak@google.com (Łukasz Hanuszczak) */
+public class UngroupedOverloadsPositiveCasesCoveringOnlyOnFirst {
+
+  // BUG: Diagnostic contains: Overloads of 'foo' are not grouped together
+  public void foo(int x) {
+    System.out.println(x);
+  }
+
+  // BUG: Diagnostic contains: Overloads of 'bar' are not grouped together
+  public void bar() {
+    foo();
+  }
+
+  public void baz() {
+    bar();
+  }
+
+  public void bar(int x) {
+    foo(x);
+  }
+
+  // BUG: Diagnostic contains: Overloads of 'quux' are not grouped together
+  private void quux() {
+    norf();
+  }
+
+  private void norf() {
+    quux();
+  }
+
+  public void quux(int x) {
+    bar(x);
+  }
+
+  public void foo() {
+    foo(42);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <directory>src/main/java</directory>
         <includes>
           <include>**/*.properties</include>
+          <include>**/*.binarypb</include>
         </includes>
       </resource>
     </resources>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a new option to UngroupedOverloads: FindingsOnFirstOverload

If true, then UngroupedOverloads will only report a finding on the *first*
overload for each method name, as opposed to reporting a finding on each:

void a(); // Always reported
void b(); // Always reported
void a(int a); // Not reported if flag is on
void b(int b); // Not reported if flag is on

RELNOTES: You can use '-XepOpt:UngroupedOverloads:FindingsOnFirstOverload' to
limit UngroupedOverloads' warnings to the first overload of each method name.

GOOGLE: And enable the option on the finding generator flume

1d18cb8eaab091af561951427301c55f7baa5894

-------

<p> In ApiDiffChecker, also recognize APIs that have a given annotation.

GOOGLE:
  And modify Java7ApiCheckerTest to recognize a new @RequiresJava8 annotation.
  Additionally, introduce RequiresJava8MustBeUsedWithMacro to check that @RequiresJava8 is used only with our macro (which doesn't exist yet). And enable it, which is safe because no one uses @RequiresJava8 yet.

RELNOTES: none

6a174ef20f8f7ee1706bf5ff6fba6311dcd3055f

-------

<p> Qualified super accesses are not static

RELNOTES: N/A

bc53d65d674517baba24fa0f079e27b8f2361fbf

-------

<p> Add "copyOf" as a bad import.

If "of" is bad, this is too.

RELNOTES: Add "copyOf" to BadImport

7aeb77d741cc9e56b6c7b78bf5d846ed607183e1