### PR TITLE
[Proposal] new checker for detecting unused variables with Dagger annotations

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/UsageCheckers.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/UsageCheckers.java
@@ -24,22 +24,21 @@ import java.util.HashMap;
 import static com.google.errorprone.BugPattern.Category.DAGGER;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
+/** @authors Murali Krishna Ramanathan, Manu Sridharan */
 /** Class that analyzes the use of variables to determine unused variables. */
 @AutoService(BugChecker.class)
-
-/** @authors Murali Krishna Ramanathan, Manu Sridharan */
 @BugPattern(
   name = "UsageCheckers",
-  altNames = {"UnusedParam", "UnusedInject"},
+  altNames = {"UnusedProviderParam", "UnusedMemberInjection"},
   summary = "Unused field with @Inject annotation.",
   category = DAGGER,
   severity = WARNING
 )
 public class UsageCheckers extends BugChecker implements BugChecker.ClassTreeMatcher {
 
-  private static final String unusedInjectCheckerName = "UnusedInject";
+  private static final String unusedInjectCheckerName = "UnusedMemberInjection";
   private static final String unusedInjectCheckerMessage = "Unused field with @Inject annotation.";
-  private static final String unusedParamCheckerName = "UnusedParam";
+  private static final String unusedParamCheckerName = "UnusedProviderParam";
   private static final String unusedParamCheckerMessage =
       "Unused parameter in method with @Provides annotation.";
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/UsageCheckers.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/UsageCheckers.java
@@ -1,0 +1,127 @@
+package com.google.errorprone.bugpatterns.inject.dagger;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.BugPattern;
+
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.util.TreePathScanner;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.code.Symbol;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.HashMap;
+
+import static com.google.errorprone.BugPattern.Category.DAGGER;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+
+/** Class that analyzes the use of variables to determine unused variables. */
+@AutoService(BugChecker.class)
+
+/** @authors Murali Krishna Ramanathan, Manu Sridharan */
+@BugPattern(
+  name = "UsageCheckers",
+  altNames = {"UnusedParam", "UnusedInject"},
+  summary = "Unused field with @Inject annotation.",
+  category = DAGGER,
+  severity = WARNING
+)
+public class UsageCheckers extends BugChecker implements BugChecker.ClassTreeMatcher {
+
+  private static final String unusedInjectCheckerName = "UnusedInject";
+  private static final String unusedInjectCheckerMessage = "Unused field with @Inject annotation.";
+  private static final String unusedParamCheckerName = "UnusedParam";
+  private static final String unusedParamCheckerMessage =
+      "Unused parameter in method with @Provides annotation.";
+
+  private boolean symbolHasSuppressInitalizationWarningsAnnotation(
+      Symbol symbol, String checkerName) {
+    SuppressWarnings annotation = symbol.getAnnotation(SuppressWarnings.class);
+    if (annotation != null) {
+      for (String s : annotation.value()) {
+        if (s.equals(checkerName)) return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public Description matchClass(ClassTree tree, VisitorState state) {
+    UsageCheckers.CallScanner callScanner = new UsageCheckers.CallScanner(state);
+    callScanner.scan(state.getPath(), null);
+    for (VariableTree decl : callScanner.declaredInjectVars) {
+      Symbol s = ASTHelpers.getSymbol(decl);
+      if (!callScanner.usedVars.contains(s)
+          && !symbolHasSuppressInitalizationWarningsAnnotation(s, unusedInjectCheckerName)) {
+        Description.Builder b = buildDescription(decl).setMessage(unusedInjectCheckerMessage);
+        b.addFix(SuggestedFix.delete(decl));
+        state.reportMatch(b.build());
+      }
+    }
+
+    for (VariableTree decl : callScanner.declaredParamVars.keySet()) {
+      Symbol s = ASTHelpers.getSymbol(decl);
+      Symbol.MethodSymbol mSym = callScanner.declaredParamVars.get(decl);
+      if (!callScanner.usedVars.contains(s)
+          && !symbolHasSuppressInitalizationWarningsAnnotation(mSym, unusedParamCheckerName)) {
+        Description.Builder b = buildDescription(decl).setMessage(unusedParamCheckerMessage);
+        b.addFix(SuggestedFix.delete(decl));
+        state.reportMatch(b.build());
+      }
+    }
+    return Description.NO_MATCH;
+  }
+
+  static class CallScanner extends TreePathScanner<Void, Void> {
+    final Set<VariableTree> declaredInjectVars = new LinkedHashSet<>();
+    final HashMap<VariableTree, Symbol.MethodSymbol> declaredParamVars =
+        new HashMap<VariableTree, Symbol.MethodSymbol>();
+    final Set<Symbol> usedVars = new LinkedHashSet<>();
+    final VisitorState state;
+
+    CallScanner(VisitorState state) {
+      this.state = state;
+    }
+
+    @Override
+    public Void visitMemberSelect(MemberSelectTree tree, Void unused) {
+      usedVars.add(ASTHelpers.getSymbol(tree));
+      return super.visitMemberSelect(tree, null);
+    }
+
+    @Override
+    public Void visitIdentifier(IdentifierTree tree, Void unused) {
+      usedVars.add(ASTHelpers.getSymbol(tree));
+      return super.visitIdentifier(tree, null);
+    }
+
+    @Override
+    public Void visitMethod(MethodTree tree, Void unused) {
+      Symbol.MethodSymbol mSym = ASTHelpers.getSymbol(tree);
+      if (ASTHelpers.hasAnnotation(mSym, "dagger.Provides", state)) {
+        for (VariableTree vt : tree.getParameters()) {
+          declaredParamVars.put(vt, mSym);
+        }
+      }
+      return super.visitMethod(tree, null);
+    }
+
+    @Override
+    public Void visitVariable(VariableTree tree, Void unused) {
+      Symbol.VarSymbol vSym = ASTHelpers.getSymbol(tree);
+      if (ASTHelpers.hasAnnotation(vSym, "javax.inject.Inject", state)) {
+        declaredInjectVars.add(tree);
+      }
+      return super.visitVariable(tree, null);
+    }
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/UsageCheckersTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/UsageCheckersTest.java
@@ -1,0 +1,38 @@
+package com.google.errorprone.bugpatterns.inject.dagger;
+  
+import com.google.errorprone.CompilationTestHelper;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Arrays;
+
+@RunWith(JUnit4.class)
+@SuppressWarnings("CheckTestExtendsBaseClass")
+public class UsageCheckersTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setup() {
+    compilationHelper = CompilationTestHelper.newInstance(UsageCheckers.class, getClass());
+    compilationHelper.setArgs(Arrays.asList("-d", temporaryFolder.getRoot().getAbsolutePath()));
+  }
+  
+
+  @Test
+  public void test_unusedInjectUseCases() {
+    compilationHelper.addSourceFile("UnusedInjectUseCases.java").doTest();
+  }
+  
+  @Test
+  public void test_unusedParamUseCases() {
+    compilationHelper.addSourceFile("UnusedParamUseCases.java").doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/testdata/UnusedInjectUseCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/testdata/UnusedInjectUseCases.java
@@ -19,7 +19,7 @@ public class UnusedInjectUseCases {
   // BUG: Diagnostic contains: Unused field with @Inject annotation.
   @Inject int unusedInt;
 
-  @SuppressWarnings("UnusedInject")
+  @SuppressWarnings("UnusedMemberInjection")
   @Inject int suppressedUnusedInt;
 
   @Inject String usedString1;

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/testdata/UnusedInjectUseCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/testdata/UnusedInjectUseCases.java
@@ -1,0 +1,108 @@
+package com.google.errorprone.bugpatterns.inject.dagger.testdata;
+
+import dagger.Module;
+import dagger.Provides;
+
+import javax.inject.Inject;
+
+import java.util.function.DoubleToIntFunction;
+import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
+
+public class UnusedInjectUseCases {
+
+  @Inject String injectedString;
+
+ // BUG: Diagnostic contains: Unused field with @Inject annotation. 
+  @Inject String unusedString;
+
+  // BUG: Diagnostic contains: Unused field with @Inject annotation.
+  @Inject int unusedInt;
+
+  @SuppressWarnings("UnusedInject")
+  @Inject int suppressedUnusedInt;
+
+  @Inject String usedString1;
+  @Inject String usedString2;
+  @Inject String usedString3;
+  @Inject String usedString4;
+  @Inject String usedString5;
+  @Inject String usedString6;
+
+  @Inject int usedInt1;
+  @Inject int usedInt2;
+  @Inject int usedInt3;
+  @Inject int usedInt4;
+  @Inject int usedInt5;
+
+  @Inject boolean usedBool1;
+  @Inject boolean usedBool2;
+  @Inject boolean usedBool3;
+
+  @Inject String [] usedStringArr;
+
+  @Inject String usedStringLambda;
+
+  @Inject Integer usedInteger;
+
+  @Inject Test usedTest;
+  class Test {
+    public String s;
+  }
+
+  @Inject int usedIntInSwitch;
+
+  @Inject int usedIntInLambda;
+
+  String do_not_report_any_error;
+
+  public String bar() {
+
+    ToIntFunction intFunction = injectedString -> usedIntInLambda;
+
+    System.out.println(injectedString);
+    if (usedString1.equals("abc")) {
+      return usedString2;
+    }
+
+    String x = usedString3;
+    x = (String) usedString4;
+    x = new String(usedString5);
+
+    if(usedBool1) {
+      x = usedBool2 ? "a" : "b";
+    }
+
+    if(!usedBool3) {
+      // do nothing
+    }
+
+    if (usedInt1 > 5) { }
+    int y = usedInt2 < 10 ? usedInt3 : usedInt4;
+
+    for(String s : usedStringArr) {
+       y++;
+    }
+
+    Supplier<String> z = usedStringLambda::toString;
+    x = z.get();
+
+    for (int i = 0; i < usedInt5; i++) { }
+
+    Integer a = new Integer(5);
+    if(a.equals(this.usedInteger)) {
+      // do nothing
+    }
+
+    x = usedTest.s.toString();
+
+    switch(usedIntInSwitch) {
+      case 1: x = "a"; break;
+      case 2: x = "b"; break;
+      default: break;
+    }
+
+    return usedString6.toString();
+  }
+
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/testdata/UnusedParamUseCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/testdata/UnusedParamUseCases.java
@@ -19,7 +19,7 @@ public class UnusedParamUseCases {
      return new Integer(0);
   }
 
-  @SuppressWarnings("UnusedParam")
+  @SuppressWarnings("UnusedProviderParam")
   @Provides static Integer providesMethodWithUnusedParamSuppressed(String unusedSuppressed) {
     return new Integer(0);
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/testdata/UnusedParamUseCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/testdata/UnusedParamUseCases.java
@@ -1,0 +1,113 @@
+package com.google.errorprone.bugpatterns.inject.dagger.testdata;
+
+import dagger.Module;
+import dagger.Provides;
+
+
+import java.util.function.DoubleToIntFunction;
+import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
+
+public class UnusedParamUseCases {
+
+  // no warning
+  private void annotationLessMethod(String unused) {
+  }
+
+  // BUG: Diagnostic contains: Unused parameter in method with @Provides annotation.
+  @Provides static Integer providesMethodWithUnusedParam(String unused) {
+     return new Integer(0);
+  }
+
+  @SuppressWarnings("UnusedParam")
+  @Provides static Integer providesMethodWithUnusedParamSuppressed(String unusedSuppressed) {
+    return new Integer(0);
+  }
+
+  @Provides static void providesMethodWithUsedParam1(String used) {
+    String x = used;
+  }
+
+  @Provides public String bar(
+      String usedString1,
+      String usedString2,
+      String usedString3,
+      String usedString4,
+      String usedString5,
+      String usedString6,
+      int usedInt1,
+      int usedInt2,
+      int usedInt3,
+      int usedInt4,
+      int usedInt5,
+      boolean usedBool1,
+      boolean usedBool2,
+      boolean usedBool3,
+      String [] usedStringArr,
+      String usedStringLambda,
+      Integer usedInteger,
+      UnusedParamUseCases.Test usedTest,
+      UnusedParamUseCases.Test usedTestId,
+      int usedIntInSwitch,
+      int usedIntInLambda) {
+    ToIntFunction intFunction = injectedString -> usedIntInLambda;
+
+    if (usedString1.equals("abc")) {
+      return usedString2;
+    }
+
+    String x = usedString3;
+    x = (String) usedString4;
+    x = new String(usedString5);
+
+    if (usedBool1) {
+      x = usedBool2 ? "a" : "b";
+    }
+
+    if (!usedBool3) {
+      // do nothing
+    }
+
+    if (usedInt1 > 5) {
+    }
+    int y = usedInt2 < 10 ? usedInt3 : usedInt4;
+
+    for (String s : usedStringArr) {
+      y++;
+    }
+
+    Supplier<String> z = usedStringLambda::toString;
+    x = z.get();
+
+    for (int i = 0; i < usedInt5; i++) {
+    }
+
+    Integer a = new Integer(5);
+    if (a.equals(usedInteger)) {
+      // do nothing
+    }
+
+    x = usedTest.s.toString();
+
+    switch (usedIntInSwitch) {
+      case 1:
+        x = "a";
+        break;
+      case 2:
+        x = "b";
+        break;
+      default:
+        break;
+    }
+    Object o = usedTestId.new SubTest();
+
+    return usedString6.toString();
+  }
+
+  class Test {
+    public String s;
+    class SubTest {
+      public Integer i;
+    }
+  }
+}

--- a/docs/bugpattern/UsageCheckers.md
+++ b/docs/bugpattern/UsageCheckers.md
@@ -1,0 +1,5 @@
+###UnusedInject
+Fields that are annotated with @Inject and are not used in the class are reported by this error-prone checker. This is to prevent creation of unnecessary classes/methods by Dagger. In order to avoid this error, remove such unused fields.
+
+###UnusedParam
+Parameters in methods that are annotated with @Provides and that are not used in the method implementation are reported by this error-prone checker. This is to prevent creation of unnecessary classes/methods by Dagger. In order to avoid this error, remove unused parameters appropriately.

--- a/docs/bugpattern/UsageCheckers.md
+++ b/docs/bugpattern/UsageCheckers.md
@@ -1,5 +1,5 @@
-###UnusedInject
+###UnusedMemberInjection
 Fields that are annotated with @Inject and are not used in the class are reported by this error-prone checker. This is to prevent creation of unnecessary classes/methods by Dagger. In order to avoid this error, remove such unused fields.
 
-###UnusedParam
+###UnusedProviderParam
 Parameters in methods that are annotated with @Provides and that are not used in the method implementation are reported by this error-prone checker. This is to prevent creation of unnecessary classes/methods by Dagger. In order to avoid this error, remove unused parameters appropriately.


### PR DESCRIPTION
We have built a checker for detecting unused variables that have dagger annotations. More specifically, when a field with @Inject annotation is declared and unused, unnecessary code is generated. Similarly, when a method with @Provides annotation contains a parameter that is unused in its body, that also results in unnecessary code. The tests provide the necessary example scenarios where this checker can be useful. 

This is a proposal PR and we are happy to update the implementation based on the feedback. Let us know. 

Thanks!