### PR TITLE
Moe Sync

### DIFF
--- a/annotations/src/main/java/com/google/errorprone/annotations/concurrent/LazyInit.java
+++ b/annotations/src/main/java/com/google/errorprone/annotations/concurrent/LazyInit.java
@@ -49,12 +49,14 @@ import java.lang.annotation.Target;
  * http://jeremymanson.blogspot.com/2008/12/benign-data-races-in-java.html (see, particularly, the
  * part after "Now, let's break the code").
  *
- * <p>Also note that {@code LazyInit} must not be used on 64-bit primitives (such as {@code long}s
- * and {@code double}s), because the Java Language Specification does not guarantee that writing to
- * these is made atomically. Furthermore, when using for non-primitives, the non-primitive must be
- * either truly immutable or at least thread safe (in the Java memory model sense). Again, unless
- * you really understand this <b>and</b> you really need the performance benefits of avoiding the
- * data race, do not use this construct.
+ * <p>Also note that {@code LazyInit} must not be used on 64-bit primitives ({@code long}s and
+ * {@code double}s), because the Java Language Specification does not guarantee that writing to
+ * these is atomic. Furthermore, when used for non-primitives, the non-primitive must be either
+ * truly immutable or at least thread safe (in the Java memory model sense). And callers must
+ * accommodate the fact that different calls to something like the above getData() method may return
+ * different (though identically computed) objects, with different identityHashCode() values. Again,
+ * unless you really understand this <b>and</b> you really need the performance benefits of
+ * introducing the data race, do not use this construct.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)

--- a/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/AbstractNullnessPropagationTransfer.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/AbstractNullnessPropagationTransfer.java
@@ -47,6 +47,7 @@ import org.checkerframework.dataflow.cfg.node.BitwiseXorNode;
 import org.checkerframework.dataflow.cfg.node.BooleanLiteralNode;
 import org.checkerframework.dataflow.cfg.node.CaseNode;
 import org.checkerframework.dataflow.cfg.node.CharacterLiteralNode;
+import org.checkerframework.dataflow.cfg.node.ClassDeclarationNode;
 import org.checkerframework.dataflow.cfg.node.ClassNameNode;
 import org.checkerframework.dataflow.cfg.node.ConditionalAndNode;
 import org.checkerframework.dataflow.cfg.node.ConditionalNotNode;
@@ -992,6 +993,14 @@ abstract class AbstractNullnessPropagationTransfer
 
   Nullness visitMarker(MarkerNode node, SubNodeValues inputs, Updates updates) {
     return NULLABLE;
+  }
+
+  // TODO(b/111301865): This is a new API in CF 2.5.3
+  @Override
+  public final TransferResult<Nullness, AccessPathStore<Nullness>> visitClassDeclaration(
+      ClassDeclarationNode classDeclarationNode,
+      TransferInput<Nullness, AccessPathStore<Nullness>> input) {
+    return noStoreChanges(NULLABLE, input);
   }
 
   private static final class ReadableUpdates implements Updates {

--- a/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/AbstractNullnessPropagationTransfer.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/AbstractNullnessPropagationTransfer.java
@@ -995,12 +995,16 @@ abstract class AbstractNullnessPropagationTransfer
     return NULLABLE;
   }
 
-  // TODO(b/111301865): This is a new API in CF 2.5.3
   @Override
   public final TransferResult<Nullness, AccessPathStore<Nullness>> visitClassDeclaration(
       ClassDeclarationNode classDeclarationNode,
       TransferInput<Nullness, AccessPathStore<Nullness>> input) {
-    return noStoreChanges(NULLABLE, input);
+    Nullness result = visitClassDeclaration();
+    return noStoreChanges(result, input);
+  }
+
+  Nullness visitClassDeclaration() {
+    return NULLABLE;
   }
 
   private static final class ReadableUpdates implements Updates {

--- a/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/NullnessPropagationTransfer.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/NullnessPropagationTransfer.java
@@ -533,6 +533,11 @@ class NullnessPropagationTransfer extends AbstractNullnessPropagationTransfer
   }
 
   @Override
+  Nullness visitClassDeclaration() {
+    return NONNULL;
+  }
+
+  @Override
   Nullness visitArrayCreation(ArrayCreationNode node, SubNodeValues inputs, Updates updates) {
     return NONNULL;
   }

--- a/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
@@ -16,6 +16,7 @@
 
 package com.google.errorprone.matchers;
 
+import static com.google.errorprone.suppliers.Suppliers.BOOLEAN_TYPE;
 import static com.google.errorprone.suppliers.Suppliers.typeFromClass;
 import static com.google.errorprone.util.ASTHelpers.stripParentheses;
 
@@ -1491,5 +1492,39 @@ public class Matchers {
   private static String getPackageFullName(VisitorState state) {
     JCCompilationUnit compilationUnit = (JCCompilationUnit) state.getPath().getCompilationUnit();
     return compilationUnit.packge.fullname.toString();
+  }
+
+  /**
+   * Matches an invocation of a recognized static object equality method such as {@link
+   * java.util.Objects#equals}. These are simple facades to {@link Object#equals} that accept null
+   * for either argument.
+   */
+  public static Matcher<MethodInvocationTree> staticEqualsInvocation() {
+    return anyOf(
+        allOf(
+            staticMethod()
+                .onClass("android.support.v4.util.ObjectsCompat")
+                .named("equals")
+                .withParameters("java.lang.Object", "java.lang.Object"),
+            isSameType(BOOLEAN_TYPE)),
+        allOf(
+            staticMethod()
+                .onClass("java.util.Objects")
+                .named("equals")
+                .withParameters("java.lang.Object", "java.lang.Object"),
+            isSameType(BOOLEAN_TYPE)),
+        allOf(
+            staticMethod()
+                .onClass("com.google.common.base.Objects")
+                .named("equal")
+                .withParameters("java.lang.Object", "java.lang.Object"),
+            isSameType(BOOLEAN_TYPE)));
+  }
+
+  /** Matches calls to the method {link Object#equals(Object)} or any override of that method. */
+  public static Matcher<MethodInvocationTree> instanceEqualsInvocation() {
+    return allOf(
+        instanceMethod().anyClass().named("equals").withParameters("java.lang.Object"),
+        isSameType(BOOLEAN_TYPE));
   }
 }

--- a/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
@@ -1527,4 +1527,15 @@ public class Matchers {
         instanceMethod().anyClass().named("equals").withParameters("java.lang.Object"),
         isSameType(BOOLEAN_TYPE));
   }
+
+  /**
+   * Matches calls to the method {link org.junit.Assert#assertEquals} and corresponding methods in
+   * JUnit 3.x.
+   */
+  public static Matcher<ExpressionTree> assertEqualsInvocation() {
+    return anyOf(
+        staticMethod().onClass("org.junit.Assert").named("assertEquals"),
+        staticMethod().onClass("junit.framework.Assert").named("assertEquals"),
+        staticMethod().onClass("junit.framework.TestCase").named("assertEquals"));
+  }
 }

--- a/check_api/src/main/java/com/google/errorprone/suppliers/Suppliers.java
+++ b/check_api/src/main/java/com/google/errorprone/suppliers/Suppliers.java
@@ -208,6 +208,14 @@ public class Suppliers {
         }
       };
 
+  public static final Supplier<Type> THROWABLE_TYPE =
+      new Supplier<Type>() {
+        @Override
+        public Type get(VisitorState state) {
+          return state.getSymtab().throwableType;
+        }
+      };
+
   public static final Supplier<Type> ANNOTATION_TYPE =
       new Supplier<Type>() {
         @Override

--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -90,6 +90,7 @@ import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCAnnotatedType;
 import com.sun.tools.javac.tree.JCTree.JCAnnotation;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
+import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 import com.sun.tools.javac.tree.JCTree.JCIdent;
 import com.sun.tools.javac.tree.JCTree.JCLiteral;
@@ -801,6 +802,17 @@ public class ASTHelpers {
   /** Return the enclosing {@code PackageSymbol} of the given symbol, or {@code null}. */
   public static PackageSymbol enclosingPackage(Symbol sym) {
     return sym.packge();
+  }
+
+  /** Return true if the given symbol is defined in the current package. */
+  public static boolean inSamePackage(Symbol targetSymbol, VisitorState state) {
+    JCCompilationUnit compilationUnit = (JCCompilationUnit) state.getPath().getCompilationUnit();
+    PackageSymbol usePackage = compilationUnit.packge;
+    PackageSymbol targetPackage = targetSymbol.packge();
+
+    return targetPackage != null
+        && usePackage != null
+        && targetPackage.getQualifiedName().equals(usePackage.getQualifiedName());
   }
 
   /**

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AutoValueFinalMethods.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AutoValueFinalMethods.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.isSameType;
+import static com.google.errorprone.matchers.Matchers.methodHasParameters;
+import static com.google.errorprone.matchers.Matchers.methodIsNamed;
+import static com.google.errorprone.matchers.Matchers.methodReturns;
+import static com.google.errorprone.matchers.Matchers.not;
+import static com.google.errorprone.matchers.Matchers.variableType;
+import static com.google.errorprone.suppliers.Suppliers.BOOLEAN_TYPE;
+import static com.google.errorprone.suppliers.Suppliers.INT_TYPE;
+import static com.google.errorprone.suppliers.Suppliers.STRING_TYPE;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import java.util.Optional;
+import javax.lang.model.element.Modifier;
+
+/**
+ * Checks the toString(), hashCode() and equals() methods are final in AutoValue classes.
+ *
+ * @author bhagwani@google.com (Sumit Bhagwani)
+ */
+@BugPattern(
+    name = "AutoValueFinalMethods",
+    summary =
+        "Make toString(), hashCode() and equals() final in AutoValue classes"
+            + ", so it is clear to readers that AutoValue is not overriding them",
+    severity = WARNING,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+public class AutoValueFinalMethods extends BugChecker implements ClassTreeMatcher {
+
+  private static final Matcher<MethodTree> EQUALS_MATCHER =
+      allOf(
+          methodIsNamed("equals"),
+          methodHasParameters(variableType(isSameType("java.lang.Object"))),
+          methodReturns(BOOLEAN_TYPE));
+
+  private static final Matcher<MethodTree> TO_STRING_MATCHER =
+      allOf(methodIsNamed("toString"), methodHasParameters(), methodReturns(STRING_TYPE));
+
+  private static final Matcher<MethodTree> HASH_CODE_MATCHER =
+      allOf(methodIsNamed("hashCode"), methodHasParameters(), methodReturns(INT_TYPE));
+
+  // public non-final eq/ts/hs methods
+  private static final Matcher<MethodTree> METHOD_MATCHER =
+      allOf(
+          Matchers.<MethodTree>hasModifier(Modifier.PUBLIC),
+          not(Matchers.<MethodTree>hasModifier(Modifier.ABSTRACT)),
+          not(Matchers.<MethodTree>hasModifier(Modifier.FINAL)),
+          anyOf(EQUALS_MATCHER, TO_STRING_MATCHER, HASH_CODE_MATCHER));
+
+  @Override
+  public Description matchClass(ClassTree tree, VisitorState state) {
+    if (!ASTHelpers.hasAnnotation(tree, "com.google.auto.value.AutoValue", state)) {
+      return NO_MATCH;
+    }
+    SuggestedFix.Builder fix = SuggestedFix.builder();
+    for (Tree memberTree : tree.getMembers()) {
+      if (!(memberTree instanceof MethodTree)) {
+        continue;
+      }
+      if (METHOD_MATCHER.matches((MethodTree) memberTree, state)) {
+        Optional<SuggestedFix> optionalSuggestedFix =
+            SuggestedFixes.addModifiers(memberTree, state, Modifier.FINAL);
+        if (optionalSuggestedFix.isPresent()) {
+          fix.merge(optionalSuggestedFix.get());
+        }
+      }
+    }
+    if (!fix.isEmpty()) {
+      return describeMatch(tree, fix.build());
+    }
+    return NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CheckReturnValue.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CheckReturnValue.java
@@ -139,9 +139,9 @@ public class CheckReturnValue extends AbstractReturnValueIgnored
 
     String annotationToValidate;
     if (checkReturn) {
-      annotationToValidate = javax.annotation.CheckReturnValue.class.getSimpleName();
+      annotationToValidate = CHECK_RETURN_VALUE;
     } else if (canIgnore) {
-      annotationToValidate = CanIgnoreReturnValue.class.getSimpleName();
+      annotationToValidate = CAN_IGNORE_RETURN_VALUE;
     } else {
       return Description.NO_MATCH;
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DeadException.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DeadException.java
@@ -25,7 +25,7 @@ import static com.google.errorprone.matchers.Matchers.isSubtypeOf;
 import static com.google.errorprone.matchers.Matchers.kindIs;
 import static com.google.errorprone.matchers.Matchers.not;
 import static com.google.errorprone.matchers.Matchers.parentNode;
-import static com.google.errorprone.suppliers.Suppliers.EXCEPTION_TYPE;
+import static com.google.errorprone.suppliers.Suppliers.THROWABLE_TYPE;
 import static com.sun.source.tree.Tree.Kind.EXPRESSION_STATEMENT;
 import static com.sun.source.tree.Tree.Kind.IF;
 
@@ -61,7 +61,7 @@ public class DeadException extends BugChecker implements NewClassTreeMatcher {
   public static final Matcher<Tree> MATCHER =
       allOf(
           parentNode(kindIs(EXPRESSION_STATEMENT)),
-          isSubtypeOf(EXCEPTION_TYPE),
+          isSubtypeOf(THROWABLE_TYPE),
           not(
               anyOf(
                   enclosingClass(JUnitMatchers.isJUnit3TestClass),

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EqualsIncompatibleType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EqualsIncompatibleType.java
@@ -18,13 +18,12 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
-import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.instanceEqualsInvocation;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
-import static com.google.errorprone.matchers.Matchers.isSameType;
+import static com.google.errorprone.matchers.Matchers.staticEqualsInvocation;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
 import static com.google.errorprone.matchers.Matchers.toType;
-import static com.google.errorprone.suppliers.Suppliers.BOOLEAN_TYPE;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Predicate;
@@ -60,31 +59,11 @@ import javax.annotation.Nullable;
     category = JDK,
     severity = WARNING)
 public class EqualsIncompatibleType extends BugChecker implements MethodInvocationTreeMatcher {
-  private static final Matcher<MethodInvocationTree> STATIC_EQUALS_INVOCATION_MATCHER =
-      anyOf(
-          allOf(
-              staticMethod()
-                  .onClass("android.support.v4.util.ObjectsCompat")
-                  .named("equals")
-                  .withParameters("java.lang.Object", "java.lang.Object"),
-              isSameType(BOOLEAN_TYPE)),
-          allOf(
-              staticMethod()
-                  .onClass("java.util.Objects")
-                  .named("equals")
-                  .withParameters("java.lang.Object", "java.lang.Object"),
-              isSameType(BOOLEAN_TYPE)),
-          allOf(
-              staticMethod()
-                  .onClass("com.google.common.base.Objects")
-                  .named("equal")
-                  .withParameters("java.lang.Object", "java.lang.Object"),
-              isSameType(BOOLEAN_TYPE)));
+  private static final Matcher<MethodInvocationTree> STATIC_EQUALS_MATCHER =
+      staticEqualsInvocation();
 
-  private static final Matcher<MethodInvocationTree> INSTANCE_EQUALS_INVOCATION_MATCHER =
-      allOf(
-          instanceMethod().anyClass().named("equals").withParameters("java.lang.Object"),
-          isSameType(BOOLEAN_TYPE));
+  private static final Matcher<MethodInvocationTree> INSTANCE_EQUALS_MATCHER =
+      instanceEqualsInvocation();
 
   private static final Matcher<Tree> ASSERT_FALSE_MATCHER =
       toType(
@@ -96,8 +75,8 @@ public class EqualsIncompatibleType extends BugChecker implements MethodInvocati
   @Override
   public Description matchMethodInvocation(
       MethodInvocationTree invocationTree, final VisitorState state) {
-    if (!STATIC_EQUALS_INVOCATION_MATCHER.matches(invocationTree, state)
-        && !INSTANCE_EQUALS_INVOCATION_MATCHER.matches(invocationTree, state)) {
+    if (!STATIC_EQUALS_MATCHER.matches(invocationTree, state)
+        && !INSTANCE_EQUALS_MATCHER.matches(invocationTree, state)) {
       return Description.NO_MATCH;
     }
 
@@ -110,7 +89,7 @@ public class EqualsIncompatibleType extends BugChecker implements MethodInvocati
     // to this method.
     Type argumentType;
 
-    if (STATIC_EQUALS_INVOCATION_MATCHER.matches(invocationTree, state)) {
+    if (STATIC_EQUALS_MATCHER.matches(invocationTree, state)) {
       receiverType = ASTHelpers.getType(invocationTree.getArguments().get(0));
       argumentType = ASTHelpers.getType(invocationTree.getArguments().get(1));
     } else {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingFail.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingFail.java
@@ -108,11 +108,7 @@ public class MissingFail extends BugChecker implements TryTreeMatcher {
   // assertTrue(thrown);
   // ```
 
-  private static final Matcher<ExpressionTree> ASSERT_EQUALS =
-      Matchers.anyOf(
-          staticMethod().onClass("org.junit.Assert").named("assertEquals"),
-          staticMethod().onClass("junit.framework.Assert").named("assertEquals"),
-          staticMethod().onClass("junit.framework.TestCase").named("assertEquals"));
+  private static final Matcher<ExpressionTree> ASSERT_EQUALS = Matchers.assertEqualsInvocation();
   private static final Matcher<Tree> ASSERT_UNEQUAL =
       toType(MethodInvocationTree.class, new UnequalIntegerLiteralMatcher(ASSERT_EQUALS));
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ModifiedButNotUsed.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ModifiedButNotUsed.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.errorprone.BugPattern.Category.JDK;
+import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.staticMethod;
+import static com.google.errorprone.matchers.method.MethodMatchers.constructor;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+import static com.google.errorprone.util.ASTHelpers.getReceiver;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.IsSubtypeOf;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.predicates.type.DescendantOfAny;
+import com.google.errorprone.suppliers.Suppliers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.AssignmentTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ExpressionStatementTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
+import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * Matches creation of new collections/proto builders which are modified but never used.
+ *
+ * @author ghm@google.com (Graeme Morgan)
+ */
+@BugPattern(
+    name = "ModifiedButNotUsed",
+    summary = "A collection or proto builder was created, but its values were never accessed.",
+    category = JDK,
+    providesFix = REQUIRES_HUMAN_ATTENTION,
+    severity = WARNING)
+public class ModifiedButNotUsed extends BugChecker implements VariableTreeMatcher {
+
+  private static final ImmutableSet<String> GUAVA_IMMUTABLES =
+      ImmutableSet.of(
+          "com.google.common.collect.ImmutableCollection",
+          "com.google.common.collect.ImmutableMap",
+          "com.google.common.collect.ImmutableMultimap");
+
+  private static final ImmutableSet<String> COLLECTIONS =
+      Streams.concat(
+              GUAVA_IMMUTABLES.stream().map(i -> i + ".Builder"),
+              Stream.of(
+                  "java.util.Collection", "java.util.Map", "com.google.common.collect.Multimap"))
+          .collect(toImmutableSet());
+
+  private static final Matcher<ExpressionTree> COLLECTION_SETTER =
+      instanceMethod()
+          .onDescendantOfAny(COLLECTIONS)
+          .withNameMatching(
+              Pattern.compile(
+                  "add|addAll|clear|put|putAll|remove|removeAll|removeIf|replaceAll|"
+                      + "retainAll|set|sort"));
+
+  private static final ImmutableSet<String> PROTO_CLASSES =
+      ImmutableSet.of(
+          "com.google.protobuf.GeneratedMessage", "com.google.protobuf.GeneratedMessageLite");
+
+  private static final Matcher<ExpressionTree> FLUENT_SETTER =
+      anyOf(
+          instanceMethod()
+              .onDescendantOfAny(
+                  PROTO_CLASSES.stream().map(p -> p + ".Builder").collect(toImmutableList()))
+              .withNameMatching(Pattern.compile("(add|set|clear|remove|merge).+")),
+          instanceMethod()
+              .onDescendantOfAny(
+                  GUAVA_IMMUTABLES.stream().map(c -> c + ".Builder").collect(toImmutableSet()))
+              .withNameMatching(Pattern.compile("(add|put)(All)?")));
+
+  private static final Matcher<Tree> COLLECTION_TYPE =
+      anyOf(COLLECTIONS.stream().map(IsSubtypeOf::new).collect(toImmutableList()));
+
+  private static final Matcher<Tree> PROTO_TYPE =
+      anyOf(
+          PROTO_CLASSES
+              .stream()
+              .map(p -> new IsSubtypeOf<>(p + ".Builder"))
+              .collect(toImmutableList()));
+
+  private static final Matcher<ExpressionTree> FLUENT_CONSTRUCTOR =
+      anyOf(
+          constructor()
+              .forClass(
+                  new DescendantOfAny(
+                      GUAVA_IMMUTABLES
+                          .stream()
+                          .map(i -> Suppliers.typeFromString(i + ".Builder"))
+                          .collect(toImmutableList()))),
+          staticMethod()
+              .onClass(
+                  new DescendantOfAny(
+                      GUAVA_IMMUTABLES
+                          .stream()
+                          .map(Suppliers::typeFromString)
+                          .collect(toImmutableList())))
+              .withNameMatching(Pattern.compile("builder(WithExpectedSize)?")),
+          constructor()
+              .forClass(
+                  new DescendantOfAny(
+                      PROTO_CLASSES
+                          .stream()
+                          .map(c -> Suppliers.typeFromString(c + ".Builder"))
+                          .collect(toImmutableList()))),
+          staticMethod()
+              .onClass(
+                  new DescendantOfAny(
+                      PROTO_CLASSES
+                          .stream()
+                          .map(Suppliers::typeFromString)
+                          .collect(toImmutableList())))
+              .named("newBuilder"),
+          instanceMethod()
+              .onClass(
+                  new DescendantOfAny(
+                      PROTO_CLASSES
+                          .stream()
+                          .map(Suppliers::typeFromString)
+                          .collect(toImmutableList())))
+              .withNameMatching(Pattern.compile("toBuilder|newBuilderForType")));
+
+  private static final Matcher<ExpressionTree> NEW_COLLECTION =
+      anyOf(
+          constructor()
+              .forClass(
+                  new DescendantOfAny(
+                      COLLECTIONS
+                          .stream()
+                          .map(Suppliers::typeFromString)
+                          .collect(toImmutableList()))),
+          staticMethod()
+              .onClassAny(
+                  "com.google.common.collect.Lists",
+                  "com.google.common.collect.Maps",
+                  "com.google.common.collect.Sets")
+              .withNameMatching(Pattern.compile("new.+")));
+
+  private static boolean newFluentChain(ExpressionTree tree, VisitorState state) {
+    while (tree instanceof MethodInvocationTree && FLUENT_SETTER.matches(tree, state)) {
+      tree = getReceiver(tree);
+    }
+    return FLUENT_CONSTRUCTOR.matches(tree, state);
+  }
+
+  private static boolean collectionUsed(VisitorState state) {
+    TreePath path = state.getPath();
+    return !(path.getParentPath().getLeaf() instanceof MemberSelectTree)
+        || !(path.getParentPath().getParentPath().getLeaf() instanceof MethodInvocationTree)
+        || !COLLECTION_SETTER.matches(
+            (MethodInvocationTree) path.getParentPath().getParentPath().getLeaf(), state)
+        || ASTHelpers.targetType(state.withPath(path.getParentPath().getParentPath())) != null;
+  }
+
+  private static boolean fluentUsed(VisitorState state) {
+    for (TreePath path = state.getPath();
+        path != null;
+        path = path.getParentPath().getParentPath()) {
+      if (path.getParentPath().getLeaf() instanceof ExpressionStatementTree) {
+        return false;
+      }
+      if (!(path.getParentPath().getLeaf() instanceof MemberSelectTree
+          && path.getParentPath().getParentPath().getLeaf() instanceof MethodInvocationTree
+          && FLUENT_SETTER.matches(
+              (MethodInvocationTree) path.getParentPath().getParentPath().getLeaf(), state))) {
+        break;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public Description matchVariable(VariableTree tree, VisitorState state) {
+    VarSymbol symbol = getSymbol(tree);
+    if (!effectivelyFinal(symbol)) {
+      return NO_MATCH;
+    }
+    if (state.getPath().getParentPath().getLeaf() instanceof ClassTree) {
+      return NO_MATCH;
+    }
+    if (!COLLECTION_TYPE.matches(tree, state) && !PROTO_TYPE.matches(tree, state)) {
+      return NO_MATCH;
+    }
+    List<ExpressionTree> initializers = new ArrayList<>();
+    if (tree.getInitializer() == null) {
+      new TreeScanner<Void, Void>() {
+        @Override
+        public Void visitAssignment(AssignmentTree node, Void aVoid) {
+          if (symbol.equals(getSymbol(node.getVariable()))) {
+            initializers.add(node.getExpression());
+          }
+          return super.visitAssignment(node, aVoid);
+        }
+      }.scan(state.getPath().getParentPath().getLeaf(), null);
+    } else {
+      initializers.add(tree.getInitializer());
+    }
+    initializers.removeIf(i -> !NEW_COLLECTION.matches(i, state) && !newFluentChain(i, state));
+    if (initializers.isEmpty()) {
+      return NO_MATCH;
+    }
+    UnusedScanner isUnusedScanner = new UnusedScanner(symbol, state, getMatcher(tree, state));
+    isUnusedScanner.scan(state.getPath().getParentPath(), null);
+    return isUnusedScanner.isUnused ? describeMatch(initializers.get(0)) : NO_MATCH;
+  }
+
+  private static Matcher<IdentifierTree> getMatcher(Tree tree, VisitorState state) {
+    return COLLECTION_TYPE.matches(tree, state)
+        ? (t, s) -> collectionUsed(s)
+        : (t, s) -> fluentUsed(s);
+  }
+
+  private static class UnusedScanner extends TreePathScanner<Void, Void> {
+    private final Symbol symbol;
+    private final VisitorState state;
+    private final Matcher<IdentifierTree> matcher;
+
+    private boolean isUnused = true;
+
+    private UnusedScanner(Symbol symbol, VisitorState state, Matcher<IdentifierTree> matcher) {
+      this.symbol = symbol;
+      this.state = state;
+      this.matcher = matcher;
+    }
+
+    @Override
+    public Void visitIdentifier(IdentifierTree identifierTree, Void aVoid) {
+      if (!Objects.equals(getSymbol(identifierTree), symbol)) {
+        return null;
+      }
+      if (matcher.matches(identifierTree, state.withPath(getCurrentPath()))) {
+        isUnused = false;
+        return null;
+      }
+      return null;
+    }
+
+    @Override
+    public Void visitVariable(VariableTree variableTree, Void aVoid) {
+      // Don't count the declaration of the variable as a usage.
+      if (Objects.equals(getSymbol(variableTree), symbol)) {
+        return null;
+      }
+      return super.visitVariable(variableTree, aVoid);
+    }
+
+    @Override
+    public Void visitAssignment(AssignmentTree assignmentTree, Void aVoid) {
+      // Don't count the LHS of the assignment to the variable as a usage.
+      if (Objects.equals(getSymbol(assignmentTree.getVariable()), symbol)) {
+        return scan(assignmentTree.getExpression(), aVoid);
+      }
+      return super.visitAssignment(assignmentTree, aVoid);
+    }
+  }
+
+  private static boolean effectivelyFinal(Symbol symbol) {
+    return (symbol.flags() & (Flags.FINAL | Flags.EFFECTIVELY_FINAL)) != 0;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NoFunctionalReturnType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NoFunctionalReturnType.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.methodReturns;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.MethodTree;
+
+/**
+ * Check for functional return types.
+ *
+ * @author seibelsabrina@google.com (Sabrina Seibel)
+ */
+@BugPattern(
+    name = "NoFunctionalReturnType",
+    summary =
+        "Instead of returning a functional type, return the actual type that the returned function"
+            + " would return and use lambdas at use site.",
+    explanation =
+        "Returning the actual type that the returned function would return instead of a functional"
+            + " type creates a more versatile method",
+    severity = WARNING)
+public final class NoFunctionalReturnType extends BugChecker implements MethodTreeMatcher {
+
+  private static final Matcher<MethodTree> FUNCTIONAL_RETURN_TYPE =
+      methodReturns(
+          (tree, state) ->
+              ASTHelpers.getType(tree).tsym.packge().fullname.contentEquals("java.util.function"));
+
+  @Override
+  public Description matchMethod(MethodTree tree, VisitorState state) {
+    return FUNCTIONAL_RETURN_TYPE.matches(tree, state) ? describeMatch(tree) : Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PredicateIncompatibleType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PredicateIncompatibleType.java
@@ -20,7 +20,6 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
-import static com.google.errorprone.util.ASTHelpers.getReceiverType;
 import static com.google.errorprone.util.Signatures.prettyType;
 
 import com.google.errorprone.BugPattern;
@@ -32,31 +31,46 @@ import com.sun.source.tree.MemberReferenceTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/**
+ * @author cushon@google.com (Liam Miller-Cushon)
+ * @author eleanorh@google.com (Eleanor Harris)
+ */
 @BugPattern(
     name = "PredicateIncompatibleType",
     category = JDK,
-    summary = "Using ::equals as an incompatible Predicate; the predicate will always return false",
+    summary =
+        "Using ::equals or ::isInstance as an incompatible Predicate;"
+            + " the predicate will always return false",
     severity = ERROR)
 public class PredicateIncompatibleType extends BugChecker implements MemberReferenceTreeMatcher {
 
   @Override
   public Description matchMemberReference(MemberReferenceTree tree, VisitorState state) {
-    if (!tree.getName().contentEquals("equals")) {
-      return NO_MATCH;
-    }
+
     Type predicateType = predicateType(ASTHelpers.getType(tree), state);
-    Type receiverType = getReceiverType(tree);
-    if (EqualsIncompatibleType.compatibilityOfTypes(receiverType, predicateType, state)
-        .compatible()) {
+    if (predicateType == null) {
       return NO_MATCH;
     }
-    return buildDescription(tree)
-        .setMessage(
-            String.format(
-                "Using %s::equals as Predicate<%s>; the predicate will always return false",
-                prettyType(receiverType), prettyType(predicateType)))
-        .build();
+    Type receiverType = ASTHelpers.getReceiverType(tree);
+
+    if (tree.getName().contentEquals("equals")
+        && !EqualsIncompatibleType.compatibilityOfTypes(receiverType, predicateType, state)
+            .compatible()) {
+      return buildMessage(receiverType, predicateType, tree);
+    }
+
+    if (tree.getName().contentEquals("isInstance")
+        && ASTHelpers.isSameType(receiverType, state.getSymtab().classType, state)
+        && !receiverType.getTypeArguments().isEmpty()) {
+      Type argumentType = receiverType.getTypeArguments().get(0);
+      Type upperBound = ASTHelpers.getUpperBound(predicateType, state.getTypes());
+      if (!EqualsIncompatibleType.compatibilityOfTypes(upperBound, argumentType, state)
+          .compatible()) {
+        return buildMessage(upperBound, argumentType, tree);
+      }
+    }
+
+    return NO_MATCH;
   }
 
   private static Type predicateType(Type type, VisitorState state) {
@@ -69,5 +83,14 @@ public class PredicateIncompatibleType extends BugChecker implements MemberRefer
       return null;
     }
     return getOnlyElement(asPredicate.getTypeArguments(), null);
+  }
+
+  private Description buildMessage(Type type1, Type type2, MemberReferenceTree tree) {
+    return buildDescription(tree)
+        .setMessage(
+            String.format(
+                "Predicate will always evaluate to false because types %s and %s are incompatible",
+                prettyType(type1), prettyType(type2)))
+        .build();
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RestrictedApiChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RestrictedApiChecker.java
@@ -116,8 +116,10 @@ public class RestrictedApiChecker extends BugChecker
       }
     }
     boolean warn =
-        Matchers.enclosingNode(shouldAllowWithWarning(restriction, state)).matches(where, state);
-    boolean allow = Matchers.enclosingNode(shouldAllow(restriction, state)).matches(where, state);
+        Matchers.enclosingNode(shouldAllowWithWarning(restriction))
+                .matches(where, state) ;
+
+    boolean allow = Matchers.enclosingNode(shouldAllow(restriction)).matches(where, state);
     if (warn && allow) {
       // TODO(bangert): Clarify this message if possible.
       return buildDescription(where)
@@ -143,7 +145,7 @@ public class RestrictedApiChecker extends BugChecker
   }
 
   // TODO(bangert): Memoize these if necessary.
-  private static Matcher<Tree> shouldAllow(RestrictedApi api, VisitorState state) {
+  private static Matcher<Tree> shouldAllow(RestrictedApi api) {
     try {
       return Matchers.hasAnyAnnotation(api.whitelistAnnotations());
     } catch (MirroredTypesException e) {
@@ -151,7 +153,7 @@ public class RestrictedApiChecker extends BugChecker
     }
   }
 
-  private static Matcher<Tree> shouldAllowWithWarning(RestrictedApi api, VisitorState state) {
+  private static Matcher<Tree> shouldAllowWithWarning(RestrictedApi api) {
     try {
       return Matchers.hasAnyAnnotation(api.whitelistWithWarningAnnotations());
     } catch (MirroredTypesException e) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/DeprecatedThreadMethods.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/DeprecatedThreadMethods.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.threadsafety;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.regex.Pattern;
+
+/**
+ * Bug checker to detect usage of deprecated Thread methods as detailed in {@link Thread}
+ *
+ * @author siyuanl@google.com (Siyuan Liu)
+ */
+@BugPattern(
+    name = "DeprecatedThreadMethods",
+    summary = "Avoid deprecated Thread methods; read the method's javadoc for details.",
+    severity = WARNING)
+public class DeprecatedThreadMethods extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private static final Pattern METHOD_NAME_REGEX =
+      Pattern.compile("stop|countStackFrames|destroy|resume|suspend");
+
+  // Might be overmatching--Thread subclasses could have additional methods with same names
+  private static final Matcher<ExpressionTree> DEPRACATED =
+      anyOf(
+          Matchers.instanceMethod()
+              .onDescendantOf("java.lang.Thread")
+              .withNameMatching(METHOD_NAME_REGEX));
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    return DEPRACATED.matches(tree, state) ? describeMatch(tree) : Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ThreadPriorityCheck.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ThreadPriorityCheck.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.threadsafety;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+
+/**
+ * Bug checker to detect usage of {@code Thread.stop()}, {@code Thread.yield()}, and changing thread
+ * priorities.
+ */
+@BugPattern(
+    name = "ThreadPriorityCheck",
+    summary =
+        "Relying on the thread scheduler is discouraged; "
+            + "see Effective Java Item 72 (2nd edition) / 84 (3rd edition).",
+    severity = WARNING)
+
+/**
+ * @author siyuanl@google.com (Siyuan Liu)
+ * @author eleanorh@google.com (Eleanor Harris)
+ */
+public class ThreadPriorityCheck extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private static final Matcher<ExpressionTree> THREAD_MATCHERS =
+      anyOf(
+          Matchers.staticMethod().onClass("java.lang.Thread").named("yield"),
+          Matchers.instanceMethod().onDescendantOf("java.lang.Thread").named("setPriority"));
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    return THREAD_MATCHERS.matches(tree, state) ? describeMatch(tree) : Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -312,6 +312,7 @@ import com.google.errorprone.bugpatterns.nullness.FieldMissingNullable;
 import com.google.errorprone.bugpatterns.nullness.ParameterNotNullable;
 import com.google.errorprone.bugpatterns.nullness.ReturnMissingNullable;
 import com.google.errorprone.bugpatterns.overloading.InconsistentOverloads;
+import com.google.errorprone.bugpatterns.threadsafety.DeprecatedThreadMethods;
 import com.google.errorprone.bugpatterns.threadsafety.DoubleCheckedLocking;
 import com.google.errorprone.bugpatterns.threadsafety.GuardedByChecker;
 import com.google.errorprone.bugpatterns.threadsafety.ImmutableAnnotationChecker;
@@ -321,6 +322,7 @@ import com.google.errorprone.bugpatterns.threadsafety.ImmutableRefactoring;
 import com.google.errorprone.bugpatterns.threadsafety.LockMethodChecker;
 import com.google.errorprone.bugpatterns.threadsafety.StaticGuardedByInstance;
 import com.google.errorprone.bugpatterns.threadsafety.SynchronizeOnNonFinalField;
+import com.google.errorprone.bugpatterns.threadsafety.ThreadPriorityCheck;
 import com.google.errorprone.bugpatterns.threadsafety.UnlockMethodChecker;
 import java.util.Arrays;
 
@@ -506,6 +508,7 @@ public class BuiltInCheckerSuppliers {
           ComparableAndComparator.class,
           DateFormatConstant.class,
           DefaultCharset.class,
+          DeprecatedThreadMethods.class,
           DoubleBraceInitialization.class,
           DoubleCheckedLocking.class,
           EqualsHashCode.class,
@@ -573,6 +576,7 @@ public class BuiltInCheckerSuppliers {
           SynchronizeOnNonFinalField.class,
           ThreadJoinLoop.class,
           ThreadLocalUsage.class,
+          ThreadPriorityCheck.class,
           ThreeLetterTimeZoneID.class,
           ToStringReturnsNull.class,
           TruthAssertExpected.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -33,6 +33,7 @@ import com.google.errorprone.bugpatterns.AssertThrowsMultipleStatements;
 import com.google.errorprone.bugpatterns.AssertionFailureIgnored;
 import com.google.errorprone.bugpatterns.AsyncCallableReturnsNull;
 import com.google.errorprone.bugpatterns.AsyncFunctionReturnsNull;
+import com.google.errorprone.bugpatterns.AutoValueFinalMethods;
 import com.google.errorprone.bugpatterns.BadAnnotationImplementation;
 import com.google.errorprone.bugpatterns.BadComparable;
 import com.google.errorprone.bugpatterns.BadImport;
@@ -492,6 +493,7 @@ public class BuiltInCheckerSuppliers {
           AssertEqualsArgumentOrderChecker.class,
           AssertThrowsMultipleStatements.class,
           AssertionFailureIgnored.class,
+          AutoValueFinalMethods.class,
           BadAnnotationImplementation.class,
           BadComparable.class,
           BadImport.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -143,6 +143,7 @@ import com.google.errorprone.bugpatterns.MisusedWeekYear;
 import com.google.errorprone.bugpatterns.MixedArrayDimensions;
 import com.google.errorprone.bugpatterns.MockitoCast;
 import com.google.errorprone.bugpatterns.MockitoUsage;
+import com.google.errorprone.bugpatterns.ModifiedButNotUsed;
 import com.google.errorprone.bugpatterns.ModifyCollectionInEnhancedForLoop;
 import com.google.errorprone.bugpatterns.ModifyingCollectionWithItself;
 import com.google.errorprone.bugpatterns.MultiVariableDeclaration;
@@ -639,6 +640,7 @@ public class BuiltInCheckerSuppliers {
           MethodCanBeStatic.class,
           MissingDefault.class,
           MixedArrayDimensions.class,
+          ModifiedButNotUsed.class,
           MoreThanOneQualifier.class,
           MutableMethodReturnType.class,
           MultiVariableDeclaration.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -157,6 +157,7 @@ import com.google.errorprone.bugpatterns.NCopiesOfChar;
 import com.google.errorprone.bugpatterns.NarrowingCompoundAssignment;
 import com.google.errorprone.bugpatterns.NestedInstanceOfConditions;
 import com.google.errorprone.bugpatterns.NoAllocationChecker;
+import com.google.errorprone.bugpatterns.NoFunctionalReturnType;
 import com.google.errorprone.bugpatterns.NonAtomicVolatileUpdate;
 import com.google.errorprone.bugpatterns.NonCanonicalStaticImport;
 import com.google.errorprone.bugpatterns.NonCanonicalStaticMemberImport;
@@ -647,6 +648,7 @@ public class BuiltInCheckerSuppliers {
           MultipleTopLevelClasses.class,
           MultipleUnaryOperatorsInMethodCall.class,
           NoAllocationChecker.class,
+          NoFunctionalReturnType.class,
           NonCanonicalStaticMemberImport.class,
           NumericEquality.class,
           PackageLocation.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/AutoValueFinalMethodsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/AutoValueFinalMethodsTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link AutoValueFinalMethods} bug pattern.
+ *
+ * @author bhagwani@google.com (Sumit Bhagwani)
+ */
+@RunWith(JUnit4.class)
+public class AutoValueFinalMethodsTest {
+  private final BugCheckerRefactoringTestHelper testHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new AutoValueFinalMethods(), getClass());
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(AutoValueFinalMethods.class, getClass());
+
+  @Test
+  public void testFinalAdditionToEqHcTs() throws Exception {
+    testHelper
+        .addInputLines(
+            "in/Test.java",
+            "import com.google.auto.value.AutoValue;",
+            "@AutoValue",
+            "abstract class Test {",
+            "  abstract String valueOne();",
+            "  abstract String valueTwo();",
+            "  static Test create(String valueOne, String valueTwo) {",
+            "    return null;",
+            "  }",
+            "  @Override",
+            "  public int hashCode() {",
+            "    return 1;",
+            "  }",
+            "  @Override",
+            "  public String toString() {",
+            "    return \"Hakuna Matata\";",
+            "  }",
+            "  @Override",
+            "  public boolean equals(Object obj) {",
+            "    return true;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "import com.google.auto.value.AutoValue;",
+            "@AutoValue",
+            "abstract class Test {",
+            "  abstract String valueOne();",
+            "  abstract String valueTwo();",
+            "  static Test create(String valueOne, String valueTwo) {",
+            "    return null;",
+            "  }",
+            "  @Override",
+            "  public final int hashCode() {",
+            "    return 1;",
+            "  }",
+            "  @Override",
+            "  public final String toString() {",
+            "    return \"Hakuna Matata\";",
+            "  }",
+            "  @Override",
+            "  public final boolean equals(Object obj) {",
+            "    return true;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testNegativeCases() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "out/Test.java",
+            "import com.google.auto.value.AutoValue;",
+            "import com.google.auto.value.extension.memoized.Memoized;",
+            "@AutoValue",
+            "abstract class Test {",
+            "  abstract String valueOne();",
+            "  abstract String valueTwo();",
+            "  static Test create(String valueOne, String valueTwo) {",
+            "    return null;",
+            "  }",
+            "  @Override",
+            "  public abstract int hashCode(); ",
+            "  @Override",
+            "  public final String toString() {",
+            "    return \"Hakuna Matata\";",
+            "  }",
+            "  @Override",
+            "  public final boolean equals(Object obj) {",
+            "    return true;",
+            "  }",
+            "  private int privateNonEqTsHcMethod() {",
+            "    return 2;",
+            "  }",
+            "  public final String publicFinalNonEqTsHcMethod() {",
+            "    return \"Hakuna Matata\";",
+            "  }",
+            "  public boolean publicNonEqTsHcMethod(Object obj) {",
+            "    return true;",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ModifiedButNotUsedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ModifiedButNotUsedTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import org.junit.Ignore;
+
+/**
+ * Tests for {@link ModifiedButNotUsed} bugpattern.
+ *
+ * @author ghm@google.com (Graeme Morgan)
+ */
+@RunWith(JUnit4.class)
+public final class ModifiedButNotUsedTest {
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ModifiedButNotUsed.class, getClass());
+
+  @Test
+  public void positive() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.ArrayList;",
+            "import java.util.List;",
+            "class Test {",
+            "  void test() {",
+            "    // BUG: Diagnostic contains:",
+            "    List<Integer> foo = new ArrayList<>();",
+            "    foo.add(1);",
+            "    List<Integer> bar;",
+            "    // BUG: Diagnostic contains:",
+            "    bar = new ArrayList<>();",
+            "    bar.add(1);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negatives() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.ArrayList;",
+            "import java.util.List;",
+            "abstract class Test {",
+            "  void test() {",
+            "    List<Integer> foo = new ArrayList<>();",
+            "    foo.add(1);",
+            "    if (false) { foo = new ArrayList<>(); }",
+            "    int a = foo.get(0);",
+            "  }",
+            "  void test2() {",
+            "    List<Integer> foo = new ArrayList<>();",
+            "    foo.add(1);",
+            "    incoming(foo);",
+            "  }",
+            "  abstract void incoming(List<Integer> l);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void usedByAssignment() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.ArrayList;",
+            "import java.util.List;",
+            "class Test {",
+            "  private List<Integer> bar;",
+            "  void test() {",
+            "    List<Integer> foo = new ArrayList<>();",
+            "    foo.add(1);",
+            "    bar = foo;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void usedDuringAssignment() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.ArrayList;",
+            "import java.util.List;",
+            "abstract class Test {",
+            "  private List<Integer> bar;",
+            "  void test() {",
+            "    List<Integer> foo = new ArrayList<>();",
+            "    foo.add(1);",
+            "    foo = frobnicate(foo);",
+            "  }",
+            "  abstract List<Integer> frobnicate(List<Integer> a);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negativeAfterReassignment() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.ArrayList;",
+            "import java.util.List;",
+            "class Test {",
+            "  void test() {",
+            "    List<Integer> foo = new ArrayList<>();",
+            "    foo.add(1);",
+            "    foo.get(0);",
+            "    foo = new ArrayList<>();",
+            "    foo.add(1);",
+            "    foo.get(0);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  @Ignore("b/74365407 test proto sources are broken")
+  public void proto() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestFieldProtoMessage;",
+            "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestProtoMessage;",
+            "class Test {",
+            "  static void foo() {",
+            "    // BUG: Diagnostic contains:",
+            "    TestProtoMessage.Builder proto = TestProtoMessage.newBuilder();",
+            "    proto.setMessage(TestFieldProtoMessage.newBuilder());",
+            "    TestProtoMessage.Builder proto2 =",
+            "        // BUG: Diagnostic contains:",
+            "        TestProtoMessage.newBuilder().setMessage(TestFieldProtoMessage.newBuilder());",
+            "    TestProtoMessage.Builder proto3 =",
+            "        // BUG: Diagnostic contains:",
+            "        TestProtoMessage.getDefaultInstance().toBuilder().clearMessage();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  @Ignore("b/74365407 test proto sources are broken")
+  public void protoNegative() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestFieldProtoMessage;",
+            "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestProtoMessage;",
+            "class Test {",
+            "  static TestProtoMessage foo() {",
+            "    TestProtoMessage.Builder proto = TestProtoMessage.newBuilder();",
+            "    return proto.setMessage(TestFieldProtoMessage.newBuilder()).build();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void immutableCollection() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableList;",
+            "class Test {",
+            "  static void foo() {",
+            "    // BUG: Diagnostic contains:",
+            "    ImmutableList.Builder<Integer> a = ImmutableList.builder();",
+            "    a.add(1);",
+            "    // BUG: Diagnostic contains:",
+            "    ImmutableList.Builder<Integer> b = ImmutableList.<Integer>builder().add(1);",
+            "    b.add(1);",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NoFunctionalReturnTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NoFunctionalReturnTypeTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link NoFunctionalReturnType}. */
+@RunWith(JUnit4.class)
+public class NoFunctionalReturnTypeTest {
+
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(NoFunctionalReturnType.class, getClass());
+
+  @Test
+  public void positiveFunctionalReturnTypePredicate() {
+    helper
+        .addSourceLines(
+            "Test.java", //
+            "import java.util.List;",
+            "import java.util.function.Predicate;",
+            "import java.util.regex.Pattern;",
+            "class Test {",
+            "  // BUG: Diagnostic contains: NoFunctionalReturnType",
+            "  private Predicate<String> matchesAnyRegex(List<Pattern> regexes) {",
+            "    return (toMatch) -> regexes.stream().anyMatch(p -> p.matcher(toMatch).matches());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positiveFunctionalReturnTypeDoublePredicate() {
+    helper
+        .addSourceLines(
+            "Test.java", //
+            "import java.util.function.DoublePredicate;",
+            "class Test {",
+            "  // BUG: Diagnostic contains: NoFunctionalReturnType",
+            "  DoublePredicate test(boolean val) { ",
+            "    return (value) -> !true;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positiveFunctionalReturnTypeFunction() {
+    helper
+        .addSourceLines(
+            "Test.java", //
+            "import java.util.function.Function;",
+            "class Test {",
+            "  // BUG: Diagnostic contains: NoFunctionalReturnType",
+            "  Function<String, Boolean> test(String s) { ",
+            "    return (value) -> true;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negativeFunctionalParam() {
+    helper
+        .addSourceLines(
+            "Test.java", //
+            "import java.util.List;",
+            "import java.util.function.Predicate;",
+            "import java.util.regex.Pattern;",
+            "class Test {",
+            "  private boolean matchesAnyRegex(Predicate<String> regexes) {",
+            "     return true;",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/PredicateIncompatibleTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/PredicateIncompatibleTypeTest.java
@@ -37,7 +37,7 @@ public class PredicateIncompatibleTypeTest {
             "import java.util.stream.Stream;",
             "class Test {",
             "  Stream<Integer> f(List<Integer> lx) {",
-            "    // BUG: Diagnostic contains: Using String::equals as Predicate<Integer>;",
+            "    // BUG: Diagnostic contains: types String and Integer are incompatible",
             "    return lx.stream().filter(\"\"::equals);",
             "  }",
             "}")
@@ -84,7 +84,7 @@ public class PredicateIncompatibleTypeTest {
             "import com.google.common.base.Predicate;",
             "class Test {",
             "  void f(Integer x) {",
-            "    // BUG: Diagnostic contains: Using Integer::equals as Predicate<String>;",
+            "    // BUG: Diagnostic contains: types Integer and String are incompatible",
             "    Predicate<String> p = x::equals;",
             "  }",
             "}")
@@ -101,6 +101,114 @@ public class PredicateIncompatibleTypeTest {
             "class Test {",
             "  void f() {",
             "    BiFunction<Object, Object, Boolean> f = Object::equals;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positiveInstanceOf() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "class Test {",
+            "  Optional<String> f(Optional<String> s) {",
+            "    // BUG: Diagnostic contains: types String and Integer are incompatible",
+            "    return s.filter(Integer.class::isInstance);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positiveInstanceOf2() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "import java.util.HashMap;",
+            "class Test {",
+            "  Optional<HashMap<String,Integer>> f(Optional<HashMap<String,Integer>> m) {",
+            "    // BUG: Diagnostic contains: Predicate will always evaluate to false",
+            "    return m.filter(Integer.class::isInstance);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positiveInstanceOfWithGenerics() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "import java.lang.Number;",
+            "class Test {",
+            "  <T extends Number> Optional<T> f(Optional<T> t) {",
+            "    // BUG: Diagnostic contains: types Number and String are incompatible",
+            "    return t.filter(String.class::isInstance);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negativeInstanceOf() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "import java.util.HashMap;",
+            "import java.util.LinkedHashMap;",
+            "class Test {",
+            "  Optional<HashMap> f(Optional<HashMap> m) {",
+            "    return m.filter(LinkedHashMap.class::isInstance);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negativeInstanceOf2() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "import java.util.HashMap;",
+            "import java.util.LinkedHashMap;",
+            "class Test {",
+            "  Optional<HashMap<String, Integer>> f(Optional<HashMap<String,Integer>> m) {",
+            "    return m.filter(LinkedHashMap.class::isInstance);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negativeInstanceOfWithGenerics() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "class Test {",
+            "  <T> Optional<T> f(Optional<T> t) {",
+            "    return t.filter(Object.class::isInstance);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  /* String.class::isInstance is used as a Function<T, Boolean>, not a Predicate<T>. */
+  @Test
+  public void methodReferenceNotPredicate() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "class Test {",
+            "  <T> Optional<Boolean> f(Optional<T> t) {",
+            "    return t.map(String.class::isInstance);",
             "  }",
             "}")
         .doTest();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryDefaultInEnumSwitchTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryDefaultInEnumSwitchTest.java
@@ -70,6 +70,45 @@ public class UnnecessaryDefaultInEnumSwitchTest {
   }
 
   @Test
+  public void switchCannotCompleteUnrecognized() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryDefaultInEnumSwitch(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "      case TWO:",
+            "      case THREE:",
+            "        return true;",
+            "      default:",
+            "        // This is a comment",
+            "        throw new AssertionError(c);",
+            "    }",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "      case TWO:",
+            "      case THREE:",
+            "        return true;",
+            "      case UNRECOGNIZED:",
+            "        break;",
+            "    }",
+            "// This is a comment",
+            "throw new AssertionError(c);",
+            "  }",
+            "}")
+        .doTest(TEXT_MATCH);
+  }
+
+  @Test
   public void emptyDefault() throws Exception {
     BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryDefaultInEnumSwitch(), getClass())
         .addInputLines(
@@ -97,6 +136,43 @@ public class UnnecessaryDefaultInEnumSwitchTest {
             "      case TWO:",
             "      case THREE:",
             "        return true;",
+            "    }",
+            "    return false;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void emptyDefaultUnrecognized() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryDefaultInEnumSwitch(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "      case TWO:",
+            "      case THREE:",
+            "        return true;",
+            "      default:",
+            "    }",
+            "    return false;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "      case TWO:",
+            "      case THREE:",
+            "        return true;",
+            "      case UNRECOGNIZED:",
+            "        // continue below",
             "    }",
             "    return false;",
             "  }",
@@ -133,6 +209,44 @@ public class UnnecessaryDefaultInEnumSwitchTest {
             "      case TWO:",
             "      case THREE:",
             "        return true;",
+            "    }",
+            "    return false;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void defaultBreakUnrecognized() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryDefaultInEnumSwitch(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "      case TWO:",
+            "      case THREE:",
+            "        return true;",
+            "      default:",
+            "        break;",
+            "    }",
+            "    return false;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "      case TWO:",
+            "      case THREE:",
+            "        return true;",
+            "      case UNRECOGNIZED:",
+            "        // continue below",
             "    }",
             "    return false;",
             "  }",
@@ -179,6 +293,44 @@ public class UnnecessaryDefaultInEnumSwitchTest {
   }
 
   @Test
+  public void completes_noUnassignedVars_priorCaseExitsUnrecognized() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryDefaultInEnumSwitch(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "      case TWO:",
+            "        break;",
+            "      case THREE:",
+            "        return true;",
+            "      default:",
+            "        throw new AssertionError(c);",
+            "    }",
+            "    return false;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "      case TWO:",
+            "        break;",
+            "      case THREE:",
+            "        return true;",
+            "    }",
+            "    return false;",
+            "  }",
+            "}")
+        .doTest(TEXT_MATCH);
+  }
+
+  @Test
   public void completes_noUnassignedVars_priorCaseDoesntExit() throws Exception {
     BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryDefaultInEnumSwitch(), getClass())
         .addInputLines(
@@ -218,7 +370,47 @@ public class UnnecessaryDefaultInEnumSwitchTest {
   }
 
   @Test
-  public void completes_unassignedVars() throws Exception {
+  public void completes_noUnassignedVars_priorCaseDoesntExitUnrecognized() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryDefaultInEnumSwitch(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "      case TWO:",
+            "        return true;",
+            "      case THREE:",
+            "      default:",
+            "        // This is a comment",
+            "        System.out.println(\"Test\");",
+            "    }",
+            "    return false;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "      case TWO:",
+            "        return true;",
+            "      case THREE:",
+            "      case UNRECOGNIZED:",
+            "        // This is a comment",
+            "        System.out.println(\"Test\");",
+            "    }",
+            "    return false;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void completes_unassignedVars() {
     compilationHelper
         .addSourceLines(
             "Test.java",
@@ -244,7 +436,33 @@ public class UnnecessaryDefaultInEnumSwitchTest {
   }
 
   @Test
-  public void notExhaustive() throws Exception {
+  public void completes_unassignedVarsUnrecognized() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    int x;",
+            "    switch (c) {",
+            "      case ONE:",
+            "      case TWO:",
+            "        x = 1;",
+            "        break;",
+            "      case THREE:",
+            "        x = 2;",
+            "        break;",
+            "      default:",
+            "        x = 3;",
+            "    }",
+            "    return x == 1;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void notExhaustive() {
     compilationHelper
         .addSourceLines(
             "Test.java",
@@ -261,6 +479,41 @@ public class UnnecessaryDefaultInEnumSwitchTest {
             "  }",
             "}")
         .doTest();
+  }
+
+  @Test
+  public void notExhaustiveUnrecognized() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryDefaultInEnumSwitch(), getClass())
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "      case TWO:",
+            "        return true;",
+            "      default:",
+            "        throw new AssertionError(c);",
+            "    }",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "      case TWO:",
+            "        return true;",
+            "      case UNRECOGNIZED:",
+            "        break;",
+            "    }",
+            "    throw new AssertionError(c);",
+            "  }",
+            "}")
+        .doTest(TEXT_MATCH);
   }
 
   @Test
@@ -301,6 +554,111 @@ public class UnnecessaryDefaultInEnumSwitchTest {
             "    } else {",
             "      return false;",
             "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void notExhaustive2Unrecognized() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryDefaultInEnumSwitch(), getClass())
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  boolean m(boolean f, Case c) {",
+            "    if (f) {",
+            "      switch (c) {",
+            "        case ONE:",
+            "        case TWO:",
+            "        case THREE:",
+            "          return true;",
+            "        default:",
+            "          return false;",
+            "      }",
+            "    } else {",
+            "      return false;",
+            "    }",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  boolean m(boolean f, Case c) {",
+            "    if (f) {",
+            "      switch (c) {",
+            "        case ONE:",
+            "        case TWO:",
+            "        case THREE:",
+            "          return true;",
+            "        case UNRECOGNIZED:",
+            "          break;",
+            "      }",
+            "      return false;",
+            "    } else {",
+            "      return false;",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void unrecognizedIgnore() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryDefaultInEnumSwitch(), getClass())
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "        return true;",
+            "      default:",
+            "        throw new AssertionError(c);",
+            "    }",
+            "  }",
+            "}")
+        .expectUnchanged()
+        .doTest(TEXT_MATCH);
+  }
+
+  @Test
+  public void defaultAboveCaseUnrecognized() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryDefaultInEnumSwitch(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "      case TWO:",
+            "        return true;",
+            "      default:",
+            "      case THREE:",
+            "        // This is a comment",
+            "        System.out.println(\"Test\");",
+            "    }",
+            "    return false;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  boolean m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "      case TWO:",
+            "        return true;",
+            "      case UNRECOGNIZED:",
+            "      case THREE:",
+            "        // This is a comment",
+            "        System.out.println(\"Test\");",
+            "    }",
+            "    return false;",
             "  }",
             "}")
         .doTest();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/VariableNameSameAsTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/VariableNameSameAsTypeTest.java
@@ -43,6 +43,21 @@ public class VariableNameSameAsTypeTest {
   }
 
   @Test
+  public void positiveLambda() throws Exception {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.function.Predicate;",
+            "class Test {",
+            "  void f() {",
+            "    // BUG: Diagnostic contains: Variable named String has the type java.lang.String",
+            "    Predicate<String> p = (String) -> String.isEmpty(); ",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void positiveInitialized() throws Exception {
     helper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/DeadExceptionPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/DeadExceptionPositiveCases.java
@@ -17,9 +17,14 @@
 package com.google.errorprone.bugpatterns.testdata;
 
 public class DeadExceptionPositiveCases {
-  public void error() {
+  public void runtimeException() {
     // BUG: Diagnostic contains: throw new RuntimeException
     new RuntimeException("Not thrown, and reference lost");
+  }
+
+  public void error() {
+    // BUG: Diagnostic contains: throw new AssertionError
+    new AssertionError("Not thrown, and reference lost");
   }
 
   public void fixIsToDeleteTheFirstStatement() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/DeprecatedThreadMethodsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/DeprecatedThreadMethodsTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.threadsafety;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * {@link DeprecatedThreadMethods}Test
+ *
+ * @author siyuanl@google.com (Siyuan Liu)
+ */
+@RunWith(JUnit4.class)
+public final class DeprecatedThreadMethodsTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setUp() {
+    compilationHelper =
+        CompilationTestHelper.newInstance(DeprecatedThreadMethods.class, getClass());
+  }
+
+  @Test
+  public void stopThread() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  public void foo() {",
+            "    Thread thread = new Thread(new Runnable() {",
+            "      @Override",
+            "      public void run() {",
+            "        System.out.println(\"Run, thread, run!\");",
+            "      }",
+            "    });",
+            "    thread.start();",
+            "    // BUG: Diagnostic contains: DeprecatedThreadMethods",
+            "    thread.stop();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void stopThrowableThread() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  public void foo() {",
+            "    Thread thread = new Thread(new Runnable() {",
+            "      @Override",
+            "      public void run() {",
+            "        System.out.println(\"Run, thread, run!\");",
+            "      }",
+            "    });",
+            "    thread.start();",
+            "    // BUG: Diagnostic contains: DeprecatedThreadMethods",
+            "    thread.stop(new Throwable(\"lol pls throw\"));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void countStackFramesThread() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  public void foo() {",
+            "    Thread thread = new Thread(new Runnable() {",
+            "      @Override",
+            "      public void run() {",
+            "        System.out.println(\"Run, thread, run!\");",
+            "      }",
+            "    });",
+            "    thread.start();",
+            "    // BUG: Diagnostic contains: DeprecatedThreadMethods",
+            "    thread.countStackFrames();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void destroyThread() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  public void foo() {",
+            "    Thread thread = new Thread(new Runnable() {",
+            "      @Override",
+            "      public void run() {",
+            "        System.out.println(\"Run, thread, run!\");",
+            "      }",
+            "    });",
+            "    thread.start();",
+            "    // BUG: Diagnostic contains: DeprecatedThreadMethods",
+            "    thread.destroy();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void resumeThread() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  public void foo() {",
+            "    Thread thread = new Thread(new Runnable() {",
+            "      @Override",
+            "      public void run() {",
+            "        System.out.println(\"Run, thread, run!\");",
+            "      }",
+            "    });",
+            "    thread.start();",
+            "    // BUG: Diagnostic contains: DeprecatedThreadMethods",
+            "    thread.resume();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void suspendThread() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  public void foo() {",
+            "    Thread thread = new Thread(new Runnable() {",
+            "      @Override",
+            "      public void run() {",
+            "        System.out.println(\"Run, thread, run!\");",
+            "      }",
+            "    });",
+            "    thread.start();",
+            "    // BUG: Diagnostic contains: DeprecatedThreadMethods",
+            "    thread.suspend();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  public void foo() {",
+            "    Thread thread = new Thread(new Runnable() {",
+            "      @Override",
+            "      public void run() {",
+            "        System.out.println(\"Run, thread, run!\");",
+            "      }",
+            "    });",
+            "    thread.start();",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/ThreadPriorityCheckTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/ThreadPriorityCheckTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.threadsafety;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * {@link ThreadPriorityCheck}Test
+ *
+ * @author siyuanl@google.com (Siyuan Liu)
+ * @author eleanorh@google.com (Eleanor Harris)
+ */
+@RunWith(JUnit4.class)
+public final class ThreadPriorityCheckTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setUp() {
+    compilationHelper = CompilationTestHelper.newInstance(ThreadPriorityCheck.class, getClass());
+  }
+
+  @Test
+  public void yieldThread() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  public void foo() {",
+            "    Thread myThread = new Thread(new Runnable() {",
+            "      @Override",
+            "      public void run() {",
+            "        System.out.println(\"Run, thread, run!\");",
+            "      }",
+            "    });",
+            "    myThread.start();",
+            "    // BUG: Diagnostic contains: ThreadPriorityCheck",
+            "    Thread.yield();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void setPriority() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  public void foo() {",
+            "    Thread thread = new Thread(new Runnable() {",
+            "      @Override",
+            "      public void run() {",
+            "        System.out.println(\"Run, thread, run!\");",
+            "      }",
+            "    });",
+            "    thread.start();",
+            "    // BUG: Diagnostic contains: ThreadPriorityCheck",
+            "    thread.setPriority(Thread.MAX_PRIORITY);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  public void foo() {",
+            "    Thread thread = new Thread(new Runnable() {",
+            "      @Override",
+            "      public void run() {",
+            "        System.out.println(\"Run, thread, run!\");",
+            "      }",
+            "    });",
+            "    thread.start();",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/docs/bugpattern/AutoValueFinalMethods.md
+++ b/docs/bugpattern/AutoValueFinalMethods.md
@@ -1,0 +1,7 @@
+Consider that other developers will try to read and understand your value class
+while looking only at your hand-written class, not the actual (generated)
+implementation class. If you mark your concrete methods final, they won't have
+to wonder whether the generated subclass might be overriding them. This is
+especially helpful if you are underriding equals, hashCode or toString!
+
+Reference: https://github.com/google/auto/blob/master/value/userguide/practices.md#mark-all-concrete-methods-final

--- a/docs/bugpattern/CheckReturnValue.md
+++ b/docs/bugpattern/CheckReturnValue.md
@@ -42,7 +42,7 @@ from having to use either an `unused` variable or `@SuppressWarnings`):
     annotated with `@CheckReturnValue`). Here, the method calls are just used to
     program the mock object, not to be consumed directly.
 
-2.  Code that doing exception-testing with JUnit, where the intent is that the
+2.  Code that does exception testing with JUnit, where the intent is that the
     method call should throw an exception:
 
     *   Uses of JUnit 4.13 or JUnit5's `assertThrows` methods:

--- a/docs/bugpattern/ModifiedButNotUsed.md
+++ b/docs/bugpattern/ModifiedButNotUsed.md
@@ -1,0 +1,12 @@
+Collections and proto builders which are created and mutated but never used may
+be a sign of a bug, for example:
+
+```java {.bad}
+  MyProto.Builder builder = MyProto.newBuilder();
+  if (field != null) {
+    MyProto.NestedField.Builder nestedBuilder = MyProto.NestedField.newBuilder();
+    nestedBuilder.setValue(field);
+    // Oops--forgot to do anything with nestedBuilder.
+  }
+  return builder.build();
+```

--- a/docs/bugpattern/RestrictedApiChecker.md
+++ b/docs/bugpattern/RestrictedApiChecker.md
@@ -1,2 +1,3 @@
 Calls to APIs marked @RestrictedApi are prohibited without a corresponding
 whitelist annotation.
+

--- a/docs/bugpattern/VariableNameSameAsType.md
+++ b/docs/bugpattern/VariableNameSameAsType.md
@@ -1,0 +1,20 @@
+When a field/variable name is the same as the field/variable type, it is
+difficult to determine which to use at which time.
+
+For example,
+
+```java
+private static String String;
+```
+
+This would cause future use of String.something within this class to refer to
+the static field String, instead of the class String.
+
+This is worth calling out to avoid confusion and is a violation of
+[Google Java style naming conventions](https://google.github.io/styleguide/javaguide.html#s5.2.7-local-variable-names)
+
+Instead of this naming style, the correct way would be:
+
+```java
+private static String string;
+```

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <javac.version>9+181-r4173-1</javac.version>
     <autovalue.version>1.5.3</autovalue.version>
     <junit.version>4.13-SNAPSHOT</junit.version>
-    <dataflow.version>2.5.2</dataflow.version>
+    <dataflow.version>2.5.3</dataflow.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fixed grammar in CheckReturnValue.md: "Code that doing exception-testing" -> "Code that does exception testing".

279418d472766fbbab09dc2062acba6c9436dbd3

-------

<p> Checks that a clazz::isInstance call is operating on supertypes of clazz.

RELNOTES: n/a

588ced9e366bf608b5e6d61065f4fa3beda514a1

-------

<p> Moved static equals & instance equals matchers to Matchers.java to enable code reuse.

RELNOTES: n/a

e1213387a44e4240f39166e59aecea5b90e223ef

-------

<p> Modified VariableNameSameAsType check

RELNOTES: Added a custom message for all variable declarations to specify the current issue and why it needs to be changed.

c07f387fe03c6a28ea77416514dcb12eb742d776

-------

<p> GOOGLE: Document RestrictedApiChecker and add an internal-only flag to demote it to a
warning.

GOOGLE: JSFlume requires that the @RestrictedApi annotation is already checked in; the
warningOnlyForRefactoring internal flag accomodates this restriction.
Blaze_error_prone.sh similarly requires that the target always compiles.

TESTED=in a separate CL; tested instructions with samueltan@
RELNOTES:N/A

9d04f1ecdb58c04d0e68d6fb60d9786a95b0db74

-------

<p> Created ThreadPriorityCheck, DeprecatedThreadMethods, and tests.

RELNOTES: n/a

299b184ca98dc08b98e94097ca3b9e7b1d85b831

-------

<p> Moved JUnit assertEquals method to Matchers to allow for code reuse.

RELNOTES: n/a

1f32931b0b64a592834e4051ab8b1203ea62a74d

-------

<p> Add a ModifiedButNotUsed bugpattern, which matches collections and immutable collection/proto builders which are modified but never used.

RELNOTES: [ModifiedButNotUsed] Match collections/builders which are modified but never used.

934e91b10903ab78ad77edd609899759669e33a8

-------

<p> Avoid class literals in CheckReturnValue

RELNOTES: N/A

78cd344cd00ffb2b9fe12b4ba533f0577df398d7

-------

<p> Added NoFunctionalReturnType check

RELNOTES: Added check that looks for methods returning functional types

18c88160bbaafef8922ec0abfda8f52110806efa

-------

<p> Expand DeadException to cover all Throwables rather than just subtypes of Exception

Based on the comments and the altName this appears to have been the intention all along.

RELNOTES: DeadException now applies to all Throwable subtypes instead of just Exception subtypes.

0048f04db356ce75376d30ab3dae467f3ccec845

-------

<p> Add RestrictedInheritance checker.

This checker allows restricting subtyping to whitelisted classes; this is analogous to the existing @RestrictedApi checker, which has been pretty useful.

TESTED=Adds tests.
RELNOTES:
Don't suggest whitelist annotations on anonymous class definitions.

3170fca79afe8742ba62e21440307eb7649bdf53

-------

<p> Suggest AutoValue classes to mark manually written equals, hashCode and toString to be final

RELNOTES: Suggest AutoValue classes to mark manually written equals, hashCode and toString to be final

e6cd1eb3df0b55dfe15b834e72f072220e261456

-------

<p> Update checker framework version 2.5.3

./third_party/java/checker_framework/update-checker \
    --old_version 2.5.2  \
    --checker_release 2.5.3 \
    --annotation_file_utilities_new_version 3.6.55 \
    --annotation_file_utilities_old_version 3.6.54

RELNOTES: upgrade checker framework to 2.5.3

2085f3d50bf67a9fb6176a961432a8128bb15117

-------

<p> Markdown for VariableNameSameAsType

0081eef615cd985f51ac6bbc57e33408e7d2324d

-------

<p> Moved inSamePackage helper method from checker to ASTHelpers.

RELNOTES: n/a

233ad7041ad3d41d798d46546cc85576b239ee07

-------

<p> Addition to UnnecessaryDefaultInEnumSwitch

RELNOTES: Added functionality to UnnecessaryDefaultInEnumSwitch that explicitly handles UNRECOGNIZED

8627c57bcfaf86851272cdffc32057837f4a233c

-------

<p> Improve warning comment.

RELNOTES: n/a

Fix some grammatical errors and imprecisions in the comment. Explicitly warn against the fact that getData() may not consistently return the same object.

3431577845361d4098995f170e5d777592740762

-------

<p> Add transfer for new dataflow node introduced by CF 2.5.3.

The node (ClassDeclarationNode) represents an anonymous inner class, which always returns a non-null value.

RELNOTES: n/a

79d210a92676bdb55801b293adecc50ed17e5539