### PR TITLE
Create parent directory before writing patch file

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/RefactoringCollection.java
+++ b/check_api/src/main/java/com/google/errorprone/RefactoringCollection.java
@@ -176,6 +176,7 @@ class RefactoringCollection implements DescriptionListener.Factory {
           throw new IOError(e);
         }
       }
+      Files.createDirectories(patchFilePatch.getParent());
       Files.write(patchFilePatch, patchFile.getBytes(UTF_8), APPEND, CREATE);
     }
   }


### PR DESCRIPTION
We may choose to place the generated `error-prone.patch` file in a
subdirectory of the base which might not already exist. For example, we
may wish to place it in target/patches instead of the base directory.