### PR TITLE
error-prone doesn't work w/ latest javac version

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
+++ b/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
@@ -211,7 +211,7 @@ public class BaseErrorProneJavaCompiler implements JavaCompiler {
     if (!epOptions.patchingOptions().doRefactor()) {
       return ErrorProneAnalyzer.createByScanningForPlugins(scannerSupplier, epOptions, context);
     }
-    refactoringCollection[0] = RefactoringCollection.refactor(epOptions.patchingOptions());
+    refactoringCollection[0] = RefactoringCollection.refactor(epOptions.patchingOptions(), context);
 
     // Refaster refactorer or using builtin checks
     CodeTransformer codeTransformer =

--- a/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java
@@ -62,7 +62,7 @@ public class ErrorProneAnalyzer implements TaskListener {
         scansPlugins(scannerSupplier, errorProneOptions, context),
         errorProneOptions,
         context,
-        JavacErrorDescriptionListener.provider());
+        JavacErrorDescriptionListener.provider(context));
   }
 
   private static Supplier<CodeTransformer> scansPlugins(
@@ -102,7 +102,7 @@ public class ErrorProneAnalyzer implements TaskListener {
         scansPlugins(scannerSupplier, errorProneOptions, context),
         errorProneOptions,
         context,
-        JavacErrorDescriptionListener.provider());
+        JavacErrorDescriptionListener.provider(context));
   }
 
   private ErrorProneAnalyzer(
@@ -152,7 +152,7 @@ public class ErrorProneAnalyzer implements TaskListener {
         transformer.get().apply(new TreePath(compilation), subContext, descriptionListener);
       }
     } catch (ErrorProneError e) {
-      e.logFatalError(log);
+      e.logFatalError(log, context);
       // let the exception propagate to javac's main, where it will cause the compilation to
       // terminate with Result.ABNORMAL
       throw e;

--- a/check_api/src/main/java/com/google/errorprone/ErrorProneError.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneError.java
@@ -18,8 +18,11 @@ package com.google.errorprone;
 
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
+import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.DiagnosticSource;
+import com.sun.tools.javac.util.JCDiagnostic.Factory;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
+import com.sun.tools.javac.util.JCDiagnostic.DiagnosticType;
 import com.sun.tools.javac.util.Log;
 import javax.tools.JavaFileObject;
 
@@ -47,15 +50,14 @@ public class ErrorProneError extends Error {
     this.source = source;
   }
 
-  public void logFatalError(Log log) {
+  public void logFatalError(Log log, Context context) {
     String version = ErrorProneVersion.loadVersionFromPom().or("unknown version");
-    JavaFileObject prev = log.currentSourceFile();
+    JavaFileObject originalSource = log.useSource(source);
+    Factory factory = Factory.instance(context);
     try {
-      log.useSource(source);
-      log.error(
-          pos, "error.prone.crash", Throwables.getStackTraceAsString(cause), version, checkName);
+      log.report(factory.create(DiagnosticType.ERROR, log.currentSource(), pos, "error.prone.crash", Throwables.getStackTraceAsString(cause), version, checkName));
     } finally {
-      log.useSource(prev);
+      log.useSource(originalSource);
     }
   }
 

--- a/check_api/src/main/java/com/google/errorprone/RefactoringCollection.java
+++ b/check_api/src/main/java/com/google/errorprone/RefactoringCollection.java
@@ -35,6 +35,7 @@ import com.google.errorprone.apply.PatchFileDestination;
 import com.google.errorprone.apply.SourceFile;
 import com.google.errorprone.matchers.Description;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
+import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.Log;
 import java.io.IOError;
 import java.io.IOException;
@@ -76,7 +77,7 @@ class RefactoringCollection implements DescriptionListener.Factory {
     CHANGED,
   }
 
-  static RefactoringCollection refactor(PatchingOptions patchingOptions) {
+  static RefactoringCollection refactor(PatchingOptions patchingOptions, Context context) {
     Path rootPath = buildRootPath();
     FileDestination fileDestination;
     Function<URI, RefactoringResult> postProcess;
@@ -119,18 +120,19 @@ class RefactoringCollection implements DescriptionListener.Factory {
     }
 
     ImportOrganizer importOrganizer = patchingOptions.importOrganizer();
-    return new RefactoringCollection(rootPath, fileDestination, postProcess, importOrganizer);
+    return new RefactoringCollection(rootPath, fileDestination, postProcess, importOrganizer, context);
   }
 
   private RefactoringCollection(
       Path rootPath,
       FileDestination fileDestination,
       Function<URI, RefactoringResult> postProcess,
-      ImportOrganizer importOrganizer) {
+      ImportOrganizer importOrganizer,
+      Context context) {
     this.rootPath = rootPath;
     this.fileDestination = fileDestination;
     this.postProcess = postProcess;
-    this.descriptionsFactory = JavacErrorDescriptionListener.providerForRefactoring();
+    this.descriptionsFactory = JavacErrorDescriptionListener.providerForRefactoring(context);
     this.importOrganizer = importOrganizer;
   }
 


### PR DESCRIPTION
running error-prone w/ javac from JDK11+ ea build leads to NoSuchMethodErrors b/c error-prone uses a few methods from which have been removed from com/sun/tools/javac/util/AbstractLog by [JDK-8196403](https://bugs.openjdk.java.net/browse/JDK-8196403).

the fix uses JCDiagnostic.Factory::create to create diagnostic objects and Log::report method. to get JCDiagnostic.Factory, I had to propagate an instance of Context in several places.