### PR TITLE
Add a newline between assertThrows and the following assertions:

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/AbstractExpectedExceptionChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AbstractExpectedExceptionChecker.java
@@ -274,7 +274,7 @@ public abstract class AbstractExpectedExceptionChecker extends BugChecker
       fix.prefixWith(throwingStatements.get(0), fixPrefix.toString());
       if (useExpressionLambda) {
         fix.postfixWith(((ExpressionStatementTree) throwingStatements.get(0)).getExpression(), ")");
-        fix.postfixWith(getLast(throwingStatements), Joiner.on('\n').join(newAsserts));
+        fix.postfixWith(getLast(throwingStatements), '\n' + Joiner.on('\n').join(newAsserts));
       } else {
         fix.postfixWith(getLast(throwingStatements), "});\n" + Joiner.on('\n').join(newAsserts));
       }


### PR DESCRIPTION
## Overview
Add a newline after assertThrows with an expression lambda and the following assertions,
so that each statement appears on its own line.

### Note
`com.google.errorprone.BugCheckerRefactoringTestHelper#addOutputLines` does not seem to care about any whitespaces, therefore, I couldn't include a failing test.