### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/Fix.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/Fix.java
@@ -30,6 +30,16 @@ public interface Fix {
 
   String toString(JCCompilationUnit compilationUnit);
 
+  /**
+   * A short description which can be attached to the Fix to differentiate multiple fixes provided
+   * to the user.
+   *
+   * <p>Empty string generates the default description.
+   */
+  default String getShortDescription() {
+    return "";
+  }
+
   Set<Replacement> getReplacements(EndPosTable endPositions);
 
   Collection<String> getImportsToAdd();

--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFix.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFix.java
@@ -35,15 +35,16 @@ import javax.annotation.Nullable;
 /** @author alexeagle@google.com (Alex Eagle) */
 public class SuggestedFix implements Fix {
 
+  private final String shortDescription;
   private final ImmutableList<FixOperation> fixes;
   private final ImmutableList<String> importsToAdd;
   private final ImmutableList<String> importsToRemove;
 
-  private SuggestedFix(
-      List<FixOperation> fixes, List<String> importsToAdd, List<String> importsToRemove) {
-    this.fixes = ImmutableList.copyOf(fixes);
-    this.importsToAdd = ImmutableList.copyOf(importsToAdd);
-    this.importsToRemove = ImmutableList.copyOf(importsToRemove);
+  private SuggestedFix(SuggestedFix.Builder builder) {
+    this.shortDescription = builder.shortDescription;
+    this.fixes = ImmutableList.copyOf(builder.fixes);
+    this.importsToAdd = ImmutableList.copyOf(builder.importsToAdd);
+    this.importsToRemove = ImmutableList.copyOf(builder.importsToRemove);
   }
 
   @Override
@@ -71,6 +72,11 @@ public class SuggestedFix implements Fix {
               replacement.startPosition(), replacement.endPosition(), replacement.replaceWith()));
     }
     return result.toString();
+  }
+
+  @Override
+  public String getShortDescription() {
+    return shortDescription;
   }
 
   @Override
@@ -152,6 +158,7 @@ public class SuggestedFix implements Fix {
     private final List<FixOperation> fixes = new ArrayList<>();
     private final List<String> importsToAdd = new ArrayList<>();
     private final List<String> importsToRemove = new ArrayList<>();
+    private String shortDescription = "";
 
     protected Builder() {}
 
@@ -160,11 +167,22 @@ public class SuggestedFix implements Fix {
     }
 
     public SuggestedFix build() {
-      return new SuggestedFix(fixes, importsToAdd, importsToRemove);
+      return new SuggestedFix(this);
     }
 
     private Builder with(FixOperation fix) {
       fixes.add(fix);
+      return this;
+    }
+
+    /**
+     * Sets a custom short description for this fix. This is useful for differentiating multiple
+     * fixes from the same finding.
+     *
+     * <p>Should be limited to one sentence.
+     */
+    public Builder setShortDescription(String shortDescription) {
+      this.shortDescription = shortDescription;
       return this;
     }
 
@@ -277,6 +295,9 @@ public class SuggestedFix implements Fix {
       if (other == null) {
         return this;
       }
+      if (shortDescription.isEmpty()) {
+        shortDescription = other.shortDescription;
+      }
       fixes.addAll(other.fixes);
       importsToAdd.addAll(other.importsToAdd);
       importsToRemove.addAll(other.importsToRemove);
@@ -289,6 +310,9 @@ public class SuggestedFix implements Fix {
     public Builder merge(@Nullable SuggestedFix other) {
       if (other == null) {
         return this;
+      }
+      if (shortDescription.isEmpty()) {
+        shortDescription = other.getShortDescription();
       }
       fixes.addAll(other.fixes);
       importsToAdd.addAll(other.importsToAdd);

--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -1531,4 +1531,11 @@ public class ASTHelpers {
   public static AnnotationMirror getAnnotationMirror(AnnotationTree annotationTree) {
     return ((JCAnnotation) annotationTree).attribute;
   }
+
+  /** Returns whether the given {@code tree} contains any comments in its source. */
+  public static boolean containsComments(Tree tree, VisitorState state) {
+    return ErrorProneTokens.getTokens(state.getSourceForNode(tree), state.context)
+        .stream()
+        .anyMatch(t -> !t.comments().isEmpty());
+  }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/NullableDereference.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/NullableDereference.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.nullness;
+
+import static com.google.errorprone.BugPattern.Category.JDK;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MemberSelectTreeMatcher;
+import com.google.errorprone.dataflow.nullnesspropagation.Nullness;
+import com.google.errorprone.dataflow.nullnesspropagation.TrustingNullnessAnalysis;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.util.TreePath;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
+import com.sun.tools.javac.tree.JCTree.JCIdent;
+import javax.lang.model.type.TypeKind;
+
+/**
+ * Warns when a dereference has a possibly-null receiver.
+ *
+ * <p>Nullability information is drawn from the trusting nullness analysis, which assumes that
+ * fields and method returns are non-null unless otherwise annotated or inferred.
+ *
+ * @author bennostein@google.com (Benno Stein)
+ */
+@BugPattern(
+    name = "NullableDereference",
+    summary = "Dereference of possibly-null value",
+    category = JDK,
+    severity = WARNING,
+    providesFix = ProvidesFix.NO_FIX)
+public class NullableDereference extends BugChecker implements MemberSelectTreeMatcher {
+
+  @Override
+  public Description matchMemberSelect(MemberSelectTree tree, VisitorState state) {
+    JCExpression receiverTree = (JCExpression) tree.getExpression();
+
+    if (receiverTree == null
+        || receiverTree.type == null
+        || receiverTree.type.getKind() == TypeKind.PACKAGE) {
+      return Description.NO_MATCH;
+    }
+
+    if (((tree instanceof JCIdent) && ((JCIdent) tree).sym.isStatic())
+        || ((tree instanceof JCFieldAccess) && ((JCFieldAccess) tree).sym.isStatic())) {
+      return Description.NO_MATCH;
+    }
+
+    Nullness nullness =
+        TrustingNullnessAnalysis.instance(state.context)
+            .getNullness(new TreePath(state.getPath(), receiverTree), state.context);
+
+    Description.Builder descBuilder = buildDescription(tree);
+    switch (nullness) {
+      case NONNULL:
+      case BOTTOM:
+        return Description.NO_MATCH;
+      case NULL:
+        descBuilder.setMessage(
+            String.format(
+                "Dereferencing method/field \"%s\" of definitely null receiver %s",
+                tree.getIdentifier(), receiverTree));
+        break;
+      case NULLABLE:
+        descBuilder.setMessage(
+            String.format(
+                "Dereferencing method/field \"%s\" of possibly null receiver %s",
+                tree.getIdentifier(), receiverTree));
+    }
+    return descBuilder.build();
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ThreadSafety.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ThreadSafety.java
@@ -634,11 +634,10 @@ public final class ThreadSafety {
     if (sym == null) {
       return null;
     }
-    Symbol annosym = state.getSymbolFromString(annotation);
     Optional<Compound> attr =
-        sym.getAnnotationMirrors()
+        sym.getRawAttributes()
             .stream()
-            .filter(a -> a.getAnnotationType().asElement().equals(annosym))
+            .filter(a -> a.type.tsym.getQualifiedName().contentEquals(annotation))
             .findAny();
     if (attr.isPresent()) {
       ImmutableList<String> containerElements = containerOf(state, attr.get());

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -326,6 +326,7 @@ import com.google.errorprone.bugpatterns.inject.guice.OverridesJavaxInjectableMe
 import com.google.errorprone.bugpatterns.inject.guice.ProvidesMethodOutsideOfModule;
 import com.google.errorprone.bugpatterns.nullness.EqualsBrokenForNull;
 import com.google.errorprone.bugpatterns.nullness.FieldMissingNullable;
+import com.google.errorprone.bugpatterns.nullness.NullableDereference;
 import com.google.errorprone.bugpatterns.nullness.ParameterNotNullable;
 import com.google.errorprone.bugpatterns.nullness.ReturnMissingNullable;
 import com.google.errorprone.bugpatterns.overloading.InconsistentOverloads;
@@ -677,6 +678,7 @@ public class BuiltInCheckerSuppliers {
           NoAllocationChecker.class,
           NoFunctionalReturnType.class,
           NonCanonicalStaticMemberImport.class,
+          NullableDereference.class,
           NumericEquality.class,
           PackageLocation.class,
           ParameterComment.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ProtosAsKeyOfSetOrMapTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ProtosAsKeyOfSetOrMapTest.java
@@ -17,6 +17,7 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.Ignore;
 import org.junit.runner.RunWith;

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UndefinedEqualsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UndefinedEqualsTest.java
@@ -16,8 +16,8 @@
 
 package com.google.errorprone.bugpatterns;
 
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,13 +29,8 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public final class UndefinedEqualsTest {
-
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(UndefinedEquals.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(UndefinedEquals.class, getClass());
 
   @Test
   public void positiveInstanceEquals() {
@@ -132,6 +127,30 @@ public final class UndefinedEqualsTest {
             "class Test {",
             "  void f(PriorityQueue a, PriorityQueue b) {",
             "    a.equals(b);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void charSequenceFix() throws Exception {
+    BugCheckerRefactoringTestHelper.newInstance(new UndefinedEquals(), getClass())
+        .addInputLines(
+            "Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "class Test {",
+            "  void f(CharSequence a, String b) {",
+            "    assertThat(a).isEqualTo(b);",
+            "    assertThat(b).isEqualTo(a);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "class Test {",
+            "  void f(CharSequence a, String b) {",
+            "    assertThat(a.toString()).isEqualTo(b);",
+            "    assertThat(b).isEqualTo(a.toString());",
             "  }",
             "}")
         .doTest();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedTest.java
@@ -627,4 +627,21 @@ public class UnusedTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void unusedInject() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "package unusedvars;",
+            "import javax.inject.Inject;",
+            "public class Test {",
+            // Package-private @Inject fields are assumed to be only used within the class, and only
+            // visible for performance.
+            "  // BUG: Diagnostic contains:",
+            "  @Inject Object foo;",
+            "  @Inject public Object bar;",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/NullableDereferenceTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/NullableDereferenceTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.nullness;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** @author bennostein@google.com (Benno Stein) */
+@RunWith(JUnit4.class)
+public class NullableDereferenceTest {
+
+  @Test
+  public void testAnnotatedFormal() throws Exception {
+    createCompilationTestHelper()
+        .addSourceLines(
+            "com/google/errorprone/bugpatterns/nullness/AnnotatedFormalTest.java",
+            "package com.google.errorprone.bugpatterns.nullness;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "import org.checkerframework.checker.nullness.qual.NonNull;",
+            "public class AnnotatedFormalTest {",
+            "  public void testPos(@Nullable Object nullable) {",
+            "    // BUG: Diagnostic contains: possibly null",
+            "    nullable.toString();",
+            "  }",
+            "  public void testNeg(Object unannotated, @NonNull Object nonnull) {",
+            "    unannotated.toString();",
+            "    nonnull.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testDataflow() throws Exception {
+    createCompilationTestHelper()
+        .addSourceLines(
+            "com/google/errorprone/bugpatterns/nullness/DataflowTest.java",
+            "package com.google.errorprone.bugpatterns.nullness;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "import org.checkerframework.checker.nullness.qual.NonNull;",
+            "public class DataflowTest {",
+            "  public void test(@Nullable Object o) {",
+            "    // BUG: Diagnostic contains: possibly null",
+            "    o.toString();",
+            // no error here: successful deref on previous line implies `o` is not null
+            "    o.toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testInference() throws Exception {
+    createCompilationTestHelper()
+        .addSourceLines(
+            "com/google/errorprone/bugpatterns/nullness/InferenceTest.java",
+            "package com.google.errorprone.bugpatterns.nullness;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "import org.checkerframework.checker.nullness.qual.NonNull;",
+            "public class InferenceTest {",
+            "  public void test(@Nullable Object nullable, @NonNull Object nonnull) {",
+            "    // BUG: Diagnostic contains: possibly null",
+            "    nullable.toString();",
+            "    // BUG: Diagnostic contains: possibly null",
+            "    id(nullable).toString();",
+            "    nonnull.toString();",
+            "    id(nonnull).toString();",
+            "  }",
+            "  static <T> T id(T t) { return t; }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testNullLiteral() throws Exception {
+    createCompilationTestHelper()
+        .addSourceLines(
+            "com/google/errorprone/bugpatterns/nullness/NullLiteralTest.java",
+            "package com.google.errorprone.bugpatterns.nullness;",
+            "public class NullLiteralTest {",
+            "  public void test() {",
+            "    // BUG: Diagnostic contains: definitely null",
+            "    ((Object) null).toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testStatics() throws Exception {
+    createCompilationTestHelper()
+        .addSourceLines(
+            "com/google/errorprone/bugpatterns/nullness/StaticsTest.java",
+            "package com.google.errorprone.bugpatterns.nullness;",
+            "public class StaticsTest {",
+            "  static Object staticField;",
+            "  Object instanceField;",
+            "  public void test() {",
+            "    System.out.println();",
+            "    System.out.println(StaticsTest.staticField);",
+            "    System.out.println(staticField);",
+            "    System.out.println(this.instanceField);",
+            "    System.out.println(instanceField);",
+            "    // BUG: Diagnostic contains: definitely null",
+            "    System.out.println(((StaticsTest) null).instanceField);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  private CompilationTestHelper createCompilationTestHelper() {
+    return CompilationTestHelper.newInstance(NullableDereference.class, getClass());
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableCheckerTest.java
@@ -1419,8 +1419,8 @@ public class ImmutableCheckerTest {
         .addSourceLines(
             "Test.java",
             "import " + ClassPathTest.class.getCanonicalName() + ";",
-            "// BUG: Diagnostic contains: not annotated",
             "class Test extends ClassPathTest<String> {",
+            "  // BUG: Diagnostic contains: 'Test' has non-final field 'x'",
             "  int x;",
             "}")
         .setArgs(Arrays.asList("-cp", libJar.toString()))


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Implement new Error Prone checker to warn about possible null dereferences.

RELNOTES: Implement new Error Prone checker to warn about possible null dereferences.

1b4cb3c30df30e7a8340e7b9b36b52bcef7ac0ce

-------

<p> Import from external

RELNOTES: N/A

bbf256fd3278e848a666a822561d5d825a7fdbf5

-------

<p> Create an ErrorProne that removes empty else branches.

This is useful in the nano2lite migration because empty else branches do sometimes get generated, due to AddNullGuards and ClearRemover.

AddNullGuards can lead to code such as:

if (x != null) {
  p.setX(x);
} else {
  p.clearX();
}

ClearRemover can subsequently see that clearX() is unnecessary and leave:

if (x != null) {
  p.setX(x);
} else {
}

A further pass to remove the empty else would make the code cleaner.

This itself is rather generic, so I placed the code in refaster/cleanups. But I can move it to a nano2lite specific location if there's not much desire for such a checker outside of nano2lite.

RELNOTES: N/A

a0a1b1ed21bbcf225b20fd7982913f48188ffc98

-------

<p> Add support for propagating a short description attached to SuggestedFix.

RELNOTES: N/A

1e1f9fe6bc1cc9664f8158fca51f65d4019cb0bb

-------

<p> Treat @Inject-annotated fields as effectively private, as they shouldn't
be used outside the containing class.

(Also split the annotation lists into member and variable ones, to
support this. I cleaned up some that no longer exist...)

RELNOTES: Match @Injected fields in Unused.

9e965948a26baebfd2d2324a3e2e142ef111d45d

-------

<p> Add CharSequence to UndefinedEquals, and provide a suggested fix for it.

RELNOTES: Add CharSequence to UndefinedEquals.

cef800edd1a119ea89f69e72a063a55c8d44aa66

-------

<p> Update annotation handling after 9dca586b31380d6d1acd047e4fc9b0d1e8ed1100

RELNOTES: N/A

64bcfda69e97c5f95ce0c86a477eff39b1bade6b