### PR TITLE
Fix some Javadoc tags

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
@@ -1533,7 +1533,7 @@ public class Matchers {
           instanceMethod().anyClass().named("equals").withParameters("java.lang.Object"),
           isSameType(BOOLEAN_TYPE));
 
-  /** Matches calls to the method {link Object#equals(Object)} or any override of that method. */
+  /** Matches calls to the method {@link Object#equals(Object)} or any override of that method. */
   public static Matcher<ExpressionTree> instanceEqualsInvocation() {
     return INSTANCE_EQUALS;
   }
@@ -1545,7 +1545,7 @@ public class Matchers {
           staticMethod().onClass("junit.framework.TestCase").named("assertEquals"));
 
   /**
-   * Matches calls to the method {link org.junit.Assert#assertEquals} and corresponding methods in
+   * Matches calls to the method {@link org.junit.Assert#assertEquals} and corresponding methods in
    * JUnit 3.x.
    */
   public static Matcher<ExpressionTree> assertEqualsInvocation() {
@@ -1559,7 +1559,7 @@ public class Matchers {
           staticMethod().onClass("junit.framework.TestCase").named("assertNotEquals"));
 
   /**
-   * Matches calls to the method {link org.junit.Assert#assertNotEquals} and corresponding methods
+   * Matches calls to the method {@link org.junit.Assert#assertNotEquals} and corresponding methods
    * in JUnit 3.x.
    */
   public static Matcher<ExpressionTree> assertNotEqualsInvocation() {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/NamedParameterComment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/NamedParameterComment.java
@@ -165,7 +165,7 @@ public final class NamedParameterComment {
   }
 
   /**
-   * Generate comment text which @{code exactMatch} would consider to match the formal parameter
+   * Generate comment text which {@code exactMatch} would consider to match the formal parameter
    * name.
    */
   static String toCommentText(String formal) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectedConstructorAnnotations.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectedConstructorAnnotations.java
@@ -65,7 +65,7 @@ public class InjectedConstructorAnnotations extends BugChecker implements Method
 
   /**
    * Matches injected constructors annotated with @Inject(optional=true) or binding annotations.
-   * Suggests fixes to remove the argument @code{optional=true} or binding annotations.
+   * Suggests fixes to remove the argument {@code optional=true} or binding annotations.
    */
   @Override
   public Description matchMethod(MethodTree methodTree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByBinder.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByBinder.java
@@ -315,7 +315,7 @@ public class GuardedByBinder {
 
         /**
          * Returns the owner if the given member is declared in a lexically enclosing scope,
-         * and @{code null} otherwise.
+         * and {@code null} otherwise.
          */
         private ClassSymbol isEnclosedIn(ClassSymbol startingClass, Symbol member, Types types) {
           for (ClassSymbol scope = startingClass.owner.enclClass();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/RestrictedApiCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/RestrictedApiCheckerTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit test for @link{RestrictedApiChecker} */
+/** Unit test for {@link RestrictedApiChecker} */
 @RunWith(JUnit4.class)
 public class RestrictedApiCheckerTest {
   private CompilationTestHelper helper;

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/RestrictedApiMethods.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/RestrictedApiMethods.java
@@ -20,7 +20,7 @@ import com.google.errorprone.annotations.RestrictedApi;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
-/** Example for @link{com.google.errorprone.bugpatterns.RestrictedApiCheckerTest}. */
+/** Example for {@link com.google.errorprone.bugpatterns.RestrictedApiCheckerTest}. */
 public class RestrictedApiMethods implements IFaceWithRestriction {
 
   public int normalMethod() {


### PR DESCRIPTION
Noticed a malformed Javadoc tag while reviewing recent Error Prone commits (in 8c9ae015b6b849fab447e766fa57d8e5497a682e). Then used `git grep` to find a few more.