### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/BaseErrorProneCompiler.java
+++ b/check_api/src/main/java/com/google/errorprone/BaseErrorProneCompiler.java
@@ -39,7 +39,13 @@ import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 
-/** An Error Prone compiler that matches the interface of {@link com.sun.tools.javac.Main}. */
+/**
+ * An Error Prone compiler that matches the interface of {@link com.sun.tools.javac.Main}.
+ *
+ * @deprecated prefer {@link BaseErrorProneJavaCompiler}, which implements the standard {@code
+ *     javax.tools.JavacCompiler} interface.
+ */
+@Deprecated
 public class BaseErrorProneCompiler {
 
   private final DiagnosticListener<? super JavaFileObject> diagnosticListener;

--- a/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
@@ -343,7 +343,6 @@ public class Matchers {
     return new ConstructorOfClass(matchType, constructorMatcher);
   }
 
-  // TODO(cushon): expunge
   public static Matcher<MethodInvocationTree> methodSelect(
       Matcher<ExpressionTree> methodSelectMatcher) {
     return new MethodInvocationMethodSelect(methodSelectMatcher);
@@ -911,7 +910,6 @@ public class Matchers {
    *
    * @param methodName The name of the method to match, e.g., "equals"
    */
-  // TODO(cushon): expunge
   public static Matcher<MethodTree> methodIsNamed(final String methodName) {
     return new Matcher<MethodTree>() {
       @Override
@@ -1126,7 +1124,9 @@ public class Matchers {
    *     "java.util.Map"
    * @param methodName The name of the method to match, including arguments, e.g.,
    *     "get(java.lang.Object)"
+   * @deprecated prefer {@link MethodMatchers#instanceMethod}
    */
+  @Deprecated
   // TODO(cushon): expunge
   public static Matcher<ExpressionTree> isDescendantOfMethod(
       String fullClassName, String methodName) {

--- a/core/src/main/java/com/google/errorprone/ErrorProneCompiler.java
+++ b/core/src/main/java/com/google/errorprone/ErrorProneCompiler.java
@@ -31,7 +31,10 @@ import javax.tools.JavaFileObject;
  * <p>Used by plexus-java-compiler-errorprone.
  *
  * @author alexeagle@google.com (Alex Eagle)
+ * @deprecated prefer {@link ErrorProneJavaCompiler}, which implements the standard {@code
+ *     javax.tools.JavacCompiler} interface.
  */
+@Deprecated
 public class ErrorProneCompiler {
 
   /**

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AssertThrowsMultipleStatements.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AssertThrowsMultipleStatements.java
@@ -41,7 +41,7 @@ import java.util.List;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "AssertThrowsMultipleStatements",
-    summary = "The lambda passed to assertThows should contain exactly one statement",
+    summary = "The lambda passed to assertThrows should contain exactly one statement",
     severity = SeverityLevel.WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class AssertThrowsMultipleStatements extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/Unused.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Unused.java
@@ -166,7 +166,9 @@ public final class Unused extends BugChecker implements CompilationUnitTreeMatch
   private static final ImmutableSet<String> LOGGER_VAR_NAME = ImmutableSet.of("logger");
 
   public Unused(ErrorProneFlags flags) {
-    ImmutableSet.Builder<String> methodAnnotationsExemptingParameters = ImmutableSet.builder();
+    ImmutableSet.Builder<String> methodAnnotationsExemptingParameters =
+        ImmutableSet.<String>builder()
+            .add("org.robolectric.annotation.Implementation");
     flags
         .getList("Unused:methodAnnotationsExemptingParameters")
         .ifPresent(methodAnnotationsExemptingParameters::addAll);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ThreadSafety.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ThreadSafety.java
@@ -178,6 +178,11 @@ public final class ThreadSafety {
      * Annotations that will cause a class to be tested with this {@link ThreadSafety} instance; for
      * example, when testing a class for immutability, this should be @Immutable.
      */
+    public Builder markerAnnotations(Set<String> markerAnnotations) {
+      return markerAnnotations(ImmutableSet.copyOf(markerAnnotations));
+    }
+
+    // TODO(ringwalt): Remove this constructor. We need it for binary compatibility.
     public Builder markerAnnotations(ImmutableSet<String> markerAnnotations) {
       checkNotNull(markerAnnotations);
       this.markerAnnotations = markerAnnotations;
@@ -190,6 +195,11 @@ public final class ThreadSafety {
      * annotation, @Immutable would be included in this list, as an immutable class is by definition
      * thread-safe.
      */
+    public Builder acceptedAnnotations(Set<String> acceptedAnnotations) {
+      return acceptedAnnotations(ImmutableSet.copyOf(acceptedAnnotations));
+    }
+
+    // TODO(ringwalt): Remove this constructor. We need it for binary compatibility.
     public Builder acceptedAnnotations(ImmutableSet<String> acceptedAnnotations) {
       checkNotNull(acceptedAnnotations);
       this.acceptedAnnotations = acceptedAnnotations;

--- a/core/src/test/java/com/google/errorprone/CommandLineFlagTest.java
+++ b/core/src/test/java/com/google/errorprone/CommandLineFlagTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.errorprone.BugPattern.Category.ONE_OFF;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static org.junit.Assert.assertThrows;
 
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.ReturnTreeMatcher;
@@ -126,11 +127,13 @@ public class CommandLineFlagTest {
             "-Xep:", // no check name
             "-Xep:Foo:FJDKFJSD"); // nonexistent severity level
 
-    Result exitCode;
     for (String badArg : badArgs) {
-      exitCode = compiler.compile(new String[] {badArg}, Collections.<JavaFileObject>emptyList());
-      assertThat(exitCode).isEqualTo(Result.CMDERR);
-      assertThat(output.toString()).contains("invalid flag");
+      InvalidCommandLineOptionException expected =
+          assertThrows(
+              InvalidCommandLineOptionException.class,
+              () ->
+                  compiler.compile(new String[] {badArg}, Collections.<JavaFileObject>emptyList()));
+      assertThat(expected).hasMessageThat().contains("invalid flag");
     }
   }
 
@@ -225,9 +228,11 @@ public class CommandLineFlagTest {
     List<JavaFileObject> sources =
         compiler.fileManager().forResources(getClass(), "CommandLineFlagTestFile.java");
 
-    Result exitCode = compiler.compile(new String[] {"-Xep:NondisableableChecker:OFF"}, sources);
-    assertThat(output.toString()).contains("NondisableableChecker may not be disabled");
-    assertThat(exitCode).isEqualTo(Result.CMDERR);
+    InvalidCommandLineOptionException expected =
+        assertThrows(
+            InvalidCommandLineOptionException.class,
+            () -> compiler.compile(new String[] {"-Xep:NondisableableChecker:OFF"}, sources));
+    assertThat(expected).hasMessageThat().contains("NondisableableChecker may not be disabled");
   }
 
   @Test
@@ -243,9 +248,11 @@ public class CommandLineFlagTest {
             "-Xep:BogusChecker");
 
     for (String badOption : badOptions) {
-      Result exitCode = compiler.compile(new String[] {badOption}, sources);
-      assertThat(exitCode).isEqualTo(Result.CMDERR);
-      assertThat(output.toString()).contains("BogusChecker is not a valid checker name");
+      InvalidCommandLineOptionException expected =
+          assertThrows(
+              InvalidCommandLineOptionException.class,
+              () -> compiler.compile(new String[] {badOption}, sources));
+      assertThat(expected).hasMessageThat().contains("BogusChecker is not a valid checker name");
     }
   }
 
@@ -256,9 +263,11 @@ public class CommandLineFlagTest {
     List<JavaFileObject> sources =
         compiler.fileManager().forResources(getClass(), "CommandLineFlagTestFile.java");
 
-    Result exitCode = compiler.compile(new String[] {"-Xep:foo:OFF"}, sources);
-    assertThat(exitCode).isEqualTo(Result.CMDERR);
-    assertThat(output.toString()).contains("foo is not a valid checker name");
+    InvalidCommandLineOptionException expected =
+        assertThrows(
+            InvalidCommandLineOptionException.class,
+            () -> compiler.compile(new String[] {"-Xep:foo:OFF"}, sources));
+    assertThat(expected).hasMessageThat().contains("foo is not a valid checker name");
   }
 
   @Test

--- a/docs/bugpattern/JdkObsolete.md
+++ b/docs/bugpattern/JdkObsolete.md
@@ -37,8 +37,8 @@ If a synchronized collection is necessary, use a data structure from
 `java.util.concurrent`.
 
 When migrating from `Stack` to `Deque`, note that the `Stack` methods
-`push`/`pop`/`peek` correspond to the `Deque` methods
-`addFirst`/`removeFirst`/`peekFirst`.
+`push`/`pop`/`peek`/`add`/`iterator` correspond to the `Deque` methods
+`addFirst`/`removeFirst`/`peekFirst`/`addFirst`/`descendingIterator`.
 
 ## `StringBuffer`
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add //third_party/java/error_prone/...:all to TAP presubmit.

f8b91b6e1040a6690665c5ae1f0320742e17068e

-------

<p> Remove uses of ErrorProneCompiler and BaseErrorProneCompiler

prefer ErrorProneJavacPlugin and ErrorProneJavaCompiler, which implement
the standard compiler API and compiler plugin interfaces, instead of the
javac's internal compiler API.

eb80b08dbc94b62258588843cf9d2af13ac204a2

-------

<p> Update migration guide from Stack to Deque.

Fixes #1101

05cb483e985e7b6db53ebad0be1c12aeed231a7c

-------

<p> Add methods with Set in their signature to address binary compatibility issues in ThreadSafety.Builder.

Equivalent to [] for the new builder.

RELNOTES: N/A

aff92dce77f73f90927b94252dd27c405c5582c7

-------

<p> Deprecate {Base,}ErrorProneCompiler

RELNOTES: BaseErrorProneCompiler and ErrorProneCompiler are deprecated and will be removed in a future release of Error Prone; prefer BaseErrorProneJavaCompiler and ErrorProneJavaCompiler which implement the standard javax.tools.JavaCompiler interface

d7981b7450b5dc152943efedcd9d1ac823f69e29

-------

<p> Add a suggested fix to ModifiedButNotUsed.

We can follow the pattern of Unused here: suggest first a fix which preserves side-effects (if necessary), and then one which removes them. Obviously the third option of "don't apply a fix, and actually use the collection/proto" should be considered by the user, but that goes for Unused too.

RELNOTES: Add suggested fix to ModifiedButNotUsed.

c619bc3272d5a3b7206abb8f43622d8080bd4002

-------

<p> Fix typo "assertThows" in AssertThrowsMultipleStatements

RELNOTES: Fix typo "assertThows" in AssertThrowsMultipleStatements

b991407af1cefdf1034d6c1d5ef35a77991a43ae

-------

<p> Add org.robolectric.annotation.Implementation to method annotations which exempt parameters from Unused checking.

These are used to define Robolectric shadows, whose signatures have to match.

RELNOTES: N/A

f73ab0ba5e90db5717ef3ec2dc673601dd45e41f