### PR TITLE
Finally: Replace `.label` by `.getLabel()`

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/Finally.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Finally.java
@@ -163,12 +163,12 @@ public class Finally extends BugChecker
     }
 
     public FinallyJumpMatcher(JCContinue jcContinue) {
-      this.label = jcContinue.label;
+      this.label = jcContinue.getLabel();
       this.jumpType = JumpType.CONTINUE;
     }
 
     public FinallyJumpMatcher(JCBreak jcBreak) {
-      this.label = jcBreak.label;
+      this.label = jcBreak.getLabel();
       this.jumpType = JumpType.BREAK;
     }
 


### PR DESCRIPTION
See #1106 - field removed in JDK12 as per
http://hg.openjdk.java.net/jdk/jdk/rev/de411d537aae#l26.131