### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/BigDecimalEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BigDecimalEquals.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.Iterables.getLast;
+import static com.google.errorprone.BugPattern.Category.JDK;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.Matchers.equalsMethodDeclaration;
+import static com.google.errorprone.matchers.Matchers.instanceEqualsInvocation;
+import static com.google.errorprone.matchers.Matchers.staticEqualsInvocation;
+import static com.google.errorprone.util.ASTHelpers.getReceiver;
+import static com.google.errorprone.util.ASTHelpers.getType;
+import static com.google.errorprone.util.ASTHelpers.isSameType;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Type;
+import java.util.List;
+
+/**
+ * Matches use of {@code BigDecimal#equals}, which compares scale as well (which is not likely to be
+ * intended).
+ *
+ * @author ghm@google.com (Graeme Morgan)
+ */
+@BugPattern(
+    name = "BigDecimalEquals",
+    summary = "BigDecimal#equals has surprising behavior: it also compares scale.",
+    category = JDK,
+    severity = WARNING,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+public final class BigDecimalEquals extends BugChecker implements MethodInvocationTreeMatcher {
+  private static final String BIG_DECIMAL = "java.math.BigDecimal";
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    Tree receiver;
+    Tree argument;
+    List<? extends ExpressionTree> arguments = tree.getArguments();
+    Type bigDecimal = state.getTypeFromString(BIG_DECIMAL);
+    boolean handleNulls;
+
+    if (staticEqualsInvocation().matches(tree, state)) {
+      handleNulls = true;
+      receiver = arguments.get(arguments.size() - 2);
+      argument = getLast(arguments);
+    } else if (instanceEqualsInvocation().matches(tree, state)) {
+      handleNulls = false;
+      receiver = getReceiver(tree);
+      argument = arguments.get(0);
+    } else {
+      return NO_MATCH;
+    }
+    MethodTree enclosingMethod = state.findEnclosing(MethodTree.class);
+    if (enclosingMethod != null && equalsMethodDeclaration().matches(enclosingMethod, state)) {
+      return NO_MATCH;
+    }
+
+    boolean isReceiverBigDecimal = isSameType(getType(receiver), bigDecimal, state);
+    boolean isTargetBigDecimal = isSameType(getType(argument), bigDecimal, state);
+
+    if (!isReceiverBigDecimal && !isTargetBigDecimal) {
+      return NO_MATCH;
+    }
+
+    // One is BigDecimal but the other isn't: report a finding without a fix.
+    if (isReceiverBigDecimal != isTargetBigDecimal) {
+      return describeMatch(tree);
+    }
+    return describe(tree, state, receiver, argument, handleNulls);
+  }
+
+  private Description describe(
+      MethodInvocationTree tree,
+      VisitorState state,
+      Tree receiver,
+      Tree argument,
+      boolean handleNulls) {
+    return describeMatch(tree);
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UngroupedOverloads.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UngroupedOverloads.java
@@ -20,6 +20,7 @@ import static com.google.common.collect.Multimaps.toMultimap;
 import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
+import static com.google.errorprone.BugPattern.StandardTags.STYLE;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static java.util.stream.Collectors.joining;
 
@@ -56,6 +57,7 @@ import javax.lang.model.element.Name;
     category = JDK,
     severity = SUGGESTION,
     linkType = CUSTOM,
+    tags = STYLE,
     link = "https://google.github.io/styleguide/javaguide.html#s3.4.2.1-overloads-never-split"
     )
 public class UngroupedOverloads extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/Unused.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Unused.java
@@ -659,16 +659,20 @@ public final class Unused extends BugChecker implements CompilationUnitTreeMatch
         VariableTree variableTree = (VariableTree) statement;
         if (hasSideEffect(((VariableTree) statement).getInitializer())) {
           encounteredSideEffects = true;
-          String newContent = "";
           if (varKind == ElementKind.FIELD) {
-            newContent =
+            String newContent =
                 String.format(
                     "%s{ %s; }",
-                    varSymbol.isStatic() ? "static " : "", variableTree.getInitializer());
+                    varSymbol.isStatic() ? "static " : "",
+                    state.getSourceForNode(variableTree.getInitializer()));
+            fix.merge(replaceWithComments(usagePath, newContent, state));
+            removeSideEffectsFix.replace(statement, "");
+          } else {
+            fix.replace(
+                statement,
+                String.format("%s;", state.getSourceForNode(variableTree.getInitializer())));
+            removeSideEffectsFix.replace(statement, "");
           }
-          SuggestedFix replacement = replaceWithComments(usagePath, newContent, state);
-          fix.merge(replacement);
-          removeSideEffectsFix.merge(replacement);
         } else if (isEnhancedForLoopVar(usagePath)) {
           String newContent =
               String.format(

--- a/core/src/main/java/com/google/errorprone/bugpatterns/Unused.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Unused.java
@@ -141,6 +141,7 @@ public final class Unused extends BugChecker implements CompilationUnitTreeMatch
           "javax.persistence.Id",
           "javax.persistence.Version",
           "javax.xml.bind.annotation.XmlElement",
+          "org.junit.Rule",
           "org.mockito.Mock",
           "org.openqa.selenium.support.FindBy",
           "org.openqa.selenium.support.FindBys");
@@ -151,6 +152,10 @@ public final class Unused extends BugChecker implements CompilationUnitTreeMatch
   private static final ImmutableSet<String> EXEMPTING_SUPER_TYPES =
       ImmutableSet.of(
           );
+
+  /** The set of types exempting a field of type extending them. */
+  private static final ImmutableSet<String> EXEMPTING_FIELD_SUPER_TYPES =
+      ImmutableSet.of("org.junit.rules.TestRule");
 
   private static final ImmutableList<String> SPECIAL_FIELDS =
       ImmutableList.of(
@@ -247,11 +252,15 @@ public final class Unused extends BugChecker implements CompilationUnitTreeMatch
         if (isSuppressed(variableTree)) {
           return null;
         }
-        super.visitVariable(variableTree, unused);
         VarSymbol symbol = getSymbol(variableTree);
         if (symbol == null) {
           return null;
         }
+        if (symbol.getKind() == ElementKind.FIELD
+            && exemptedFieldBySuperType(getType(variableTree), state)) {
+          return null;
+        }
+        super.visitVariable(variableTree, null);
         // Return if the element is exempted by an annotation.
         if (exemptedByAnnotation(
             variableTree.getModifiers().getAnnotations(), EXEMPTING_VARIABLE_ANNOTATIONS, state)) {
@@ -282,6 +291,11 @@ public final class Unused extends BugChecker implements CompilationUnitTreeMatch
             break;
         }
         return null;
+      }
+
+      private boolean exemptedFieldBySuperType(Type type, VisitorState state) {
+        return EXEMPTING_FIELD_SUPER_TYPES.stream()
+            .anyMatch(t -> isSubtype(type, state.getTypeFromString(t), state));
       }
 
       private boolean isFieldEligibleForChecking(VariableTree variableTree, VarSymbol symbol) {

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -39,6 +39,7 @@ import com.google.errorprone.bugpatterns.BadComparable;
 import com.google.errorprone.bugpatterns.BadImport;
 import com.google.errorprone.bugpatterns.BadInstanceof;
 import com.google.errorprone.bugpatterns.BadShiftAmount;
+import com.google.errorprone.bugpatterns.BigDecimalEquals;
 import com.google.errorprone.bugpatterns.BigDecimalLiteralDouble;
 import com.google.errorprone.bugpatterns.BooleanParameter;
 import com.google.errorprone.bugpatterns.BoxedPrimitiveConstructor;
@@ -517,6 +518,7 @@ public class BuiltInCheckerSuppliers {
           BadComparable.class,
           BadImport.class,
           BadInstanceof.class,
+          BigDecimalEquals.class,
           BigDecimalLiteralDouble.class,
           BoxedPrimitiveConstructor.class,
           ByteBufferBackingArray.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/BigDecimalEqualsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/BigDecimalEqualsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link BigDecimalEquals}.
+ *
+ * @author ghm@google.com (Graeme Morgan)
+ */
+@RunWith(JUnit4.class)
+public final class BigDecimalEqualsTest {
+  @Test
+  public void positive() {
+    CompilationTestHelper.newInstance(BigDecimalEquals.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.base.Objects;",
+            "import java.math.BigDecimal;",
+            "class Test {",
+            "  void test(BigDecimal a, BigDecimal b) {",
+            "    // BUG: Diagnostic contains:",
+            "    boolean foo = a.equals(b);",
+            "    // BUG: Diagnostic contains:",
+            "    boolean bar = !a.equals(b);",
+            "    // BUG: Diagnostic contains:",
+            "    boolean baz = Objects.equal(a, b);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+
+  @Test
+  public void negative() {
+    CompilationTestHelper.newInstance(BigDecimalEquals.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            "import java.math.BigDecimal;",
+            "class Test {",
+            "  BigDecimal a;",
+            "  BigDecimal b;",
+            "  boolean f(String a, String b) {",
+            "    return a.equals(b);",
+            "  }",
+            "  @Override public boolean equals(Object o) {",
+            "    return a.equals(b);",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/DoubleBraceInitializationTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/DoubleBraceInitializationTest.java
@@ -32,7 +32,7 @@ public class DoubleBraceInitializationTest {
   public void negative() {
     CompilationTestHelper.newInstance(DoubleBraceInitialization.class, getClass())
         .addSourceLines(
-            "Test.java", //
+            "Test.java",
             "import java.util.ArrayList;",
             "import java.util.List;",
             "class Test {",
@@ -61,7 +61,7 @@ public class DoubleBraceInitializationTest {
   public void positiveNoFix() {
     testHelper
         .addInputLines(
-            "in/Test.java", //
+            "in/Test.java",
             "import java.util.ArrayList;",
             "import java.util.List;",
             "// BUG: Diagnostic contains:",
@@ -78,7 +78,7 @@ public class DoubleBraceInitializationTest {
   public void list() {
     testHelper
         .addInputLines(
-            "in/Test.java", //
+            "in/Test.java",
             "import java.util.ArrayList;",
             "import java.util.Collections;",
             "import java.util.List;",
@@ -89,7 +89,7 @@ public class DoubleBraceInitializationTest {
             "  List<Integer> c = new ArrayList<Integer>() {{ add(1); add(2); }};",
             "}")
         .addOutputLines(
-            "out/Test.java", //
+            "out/Test.java",
             "import com.google.common.collect.ImmutableList;",
             "import java.util.ArrayList;",
             "import java.util.Collections;",
@@ -106,7 +106,7 @@ public class DoubleBraceInitializationTest {
   public void set() {
     testHelper
         .addInputLines(
-            "in/Test.java", //
+            "in/Test.java",
             "import java.util.Collections;",
             "import java.util.HashSet;",
             "import java.util.Set;",
@@ -117,7 +117,7 @@ public class DoubleBraceInitializationTest {
             "  Set<Integer> c = new HashSet<Integer>() {{ add(1); add(2); }};",
             "}")
         .addOutputLines(
-            "out/Test.java", //
+            "out/Test.java",
             "import com.google.common.collect.ImmutableSet;",
             "import java.util.Collections;",
             "import java.util.HashSet;",
@@ -134,7 +134,7 @@ public class DoubleBraceInitializationTest {
   public void collection() {
     testHelper
         .addInputLines(
-            "in/Test.java", //
+            "in/Test.java",
             "import java.util.ArrayDeque;",
             "import java.util.Collection;",
             "import java.util.Collections;",
@@ -147,7 +147,7 @@ public class DoubleBraceInitializationTest {
             "  Deque<Integer> c = new ArrayDeque<Integer>() {{ add(1); add(2); }};",
             "}")
         .addOutputLines(
-            "out/Test.java", //
+            "out/Test.java",
             "import com.google.common.collect.ImmutableCollection;",
             "import com.google.common.collect.ImmutableList;",
             "import java.util.ArrayDeque;",
@@ -166,7 +166,7 @@ public class DoubleBraceInitializationTest {
   public void map() {
     testHelper
         .addInputLines(
-            "in/Test.java", //
+            "in/Test.java",
             "import java.util.Collections;",
             "import java.util.HashMap;",
             "import java.util.Map;",
@@ -191,7 +191,7 @@ public class DoubleBraceInitializationTest {
             "  }};",
             "}")
         .addOutputLines(
-            "out/Test.java", //
+            "out/Test.java",
             "import com.google.common.collect.ImmutableMap;",
             "import java.util.Collections;",
             "import java.util.HashMap;",
@@ -220,7 +220,7 @@ public class DoubleBraceInitializationTest {
   public void nulls() {
     testHelper
         .addInputLines(
-            "in/Test.java", //
+            "in/Test.java",
             "import java.util.*;",
             "// BUG: Diagnostic contains:",
             "class Test {",
@@ -230,6 +230,95 @@ public class DoubleBraceInitializationTest {
             "      new HashMap<String, Integer>() {{ put(null, null); }};",
             "}")
         .expectUnchanged()
+        .doTest();
+  }
+
+  @Test
+  public void returned() {
+    testHelper
+        .addInputLines(
+            "Test.java",
+            "import java.util.Collections;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  private Map<String, Object> test() {",
+            "    return Collections.unmodifiableMap(new HashMap<String, Object>() {",
+            "      {}",
+            "    });",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableMap;",
+            "import java.util.Collections;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  private ImmutableMap<String, Object> test() {",
+            "    return ImmutableMap.of();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void lambda() {
+    testHelper
+        .addInputLines(
+            "Test.java",
+            "import java.util.Collections;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "import java.util.function.Supplier;",
+            "class Test {",
+            "  private Supplier<Map<String, Object>> test() {",
+            "    return () -> Collections.unmodifiableMap(new HashMap<String, Object>() {",
+            "      {}",
+            "    });",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableMap;",
+            "import java.util.Collections;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "import java.util.function.Supplier;",
+            "class Test {",
+            "  private Supplier<Map<String, Object>> test() {",
+            "    return () -> ImmutableMap.of();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void statement() {
+    testHelper
+        .addInputLines(
+            "Test.java",
+            "import java.util.Collections;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  private void test() {",
+            "    Collections.unmodifiableMap(new HashMap<String, Object>() {",
+            "      {}",
+            "    });",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableMap;",
+            "import java.util.Collections;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  private void test() {",
+            "    ImmutableMap.of();",
+            "  }",
+            "}")
         .doTest();
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedTest.java
@@ -713,4 +713,16 @@ public class UnusedTest {
         .setFixChooser(FixChoosers.SECOND)
         .doTest();
   }
+
+  @Test
+  public void exemptedFieldsByType() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import org.junit.rules.TestRule;",
+            "class Test {",
+            "  private TestRule rule;",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedTest.java
@@ -16,6 +16,7 @@ package com.google.errorprone.bugpatterns;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.BugCheckerRefactoringTestHelper.FixChoosers;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.ErrorProneFlags;
@@ -662,6 +663,54 @@ public class UnusedTest {
             "  @Inject Object foo;",
             "  @Inject public Object bar;",
             "}")
+        .doTest();
+  }
+
+  @Test
+  public void variableKeepingSideEffects() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableList;",
+            "class Test {",
+            "  private final ImmutableList<Integer> foo = ImmutableList.of();",
+            "  void test() {",
+            "     ImmutableList<Integer> foo = ImmutableList.of();",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableList;",
+            "class Test {",
+            "  { ImmutableList.of(); }",
+            "  void test() {",
+            "     ImmutableList.of();",
+            "  }",
+            "}")
+        .setFixChooser(FixChoosers.FIRST)
+        .doTest();
+  }
+
+  @Test
+  public void variableRemovingSideEffects() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableList;",
+            "class Test {",
+            "  private final ImmutableList<Integer> foo = ImmutableList.of();",
+            "  void test() {",
+            "     ImmutableList<Integer> foo = ImmutableList.of();",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableList;",
+            "class Test {",
+            "  void test() {",
+            "  }",
+            "}")
+        .setFixChooser(FixChoosers.SECOND)
         .doTest();
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/JUnit4TestNotRunNegativeCase3.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/JUnit4TestNotRunNegativeCase3.java
@@ -23,7 +23,7 @@ import org.junit.runners.JUnit4;
 /** @author eaftan@google.com (Eddie Aftandilian) */
 @RunWith(JUnit4.class)
 public class JUnit4TestNotRunNegativeCase3 {
-  // Doesn't begin with "test".
+  // Doesn't begin with "test", and doesn't contain any assertion-like method invocations.
   public void thisIsATest() {}
 
   // Isn't public.

--- a/docs/bugpattern/BigDecimalEquals.md
+++ b/docs/bugpattern/BigDecimalEquals.md
@@ -1,0 +1,9 @@
+`BigDecimal`'s equals method compares the scale of the representation as well as
+the numeric value, which may not be expected.
+
+```java {.bad}
+BigDecimal a = new BigDecimal("1.0");
+BigDecimal b = new BigDecimal("1.00");
+a.equals(b); // false!
+```
+

--- a/docs/bugpattern/GetClassOnEnum.md
+++ b/docs/bugpattern/GetClassOnEnum.md
@@ -3,7 +3,7 @@ calling `getClass()` returns a synthetic subclass of the enum. To retrieve
 the type of the enum, use `getDeclaringClass()`.
 
 In the following example, `Binop.MULT.getClass()` returns the anonymous class
-`Binop$2`, while `Binop.MULTI.getDeclaringClass()` returns the class `Binop`.
+`Binop$2`, while `Binop.MULT.getDeclaringClass()` returns the class `Binop`.
 
 ```java
 enum Binop {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix typo

c90ae10105cef1c31b4178be6ccc5f5cdaf60883

-------

<p> Fix the suggested fix from Unused.

Preservation of side-effects got a bit lost in translation here. Added tests for both sets of fixes.

RELNOTES: N/A

542f9d852f10664bb6964f887c17955a4c7800c8

-------

<p> Exempt fields of type extending org.junit.rules.TestRule in Unused.

RELNOTES: N/A

cea7b69bc49704aebf3d5726bc2335cbb7559727

-------

<p> JUnit4TestNotRunNegativeCase3: Expand on comment a little, because it is misleading to say simply that the method name doesn't start with "test" as the reason for it not triggering the check.

RELNOTES: None

8b7d0fdd1c8f6e5a38555087c506d3776704740f

-------

<p> [ERROR_PRONE] Mark the UngroupedOverload check with the Style tag in the hopes that's the right thing to do to get it to show in the ErrorProne - Style category instead of the ErrorProne - Other category in code search findings layer.

RELNOTES: Recategorized the UngroupedOverload check

53f27965b6c9a46e7dd229adce3f22ab5e9d15d0

-------

<p> Add a bugpattern to point out that BigDecimal's equals method does not
compare for just numeric equality.

I've avoided suggesting a change within #equals implementations, as we're pretty likely to give people an inconsistent hashCode if we replace that.

RELNOTES: [BigDecimalEquals] Suggest using compareTo when comparing BigDecimals, not equals

b501b9aca272a51d88628cf21e003cdda178cfa6

-------

<p> Fix NPE when returning double-brace-initialised things.

The previous code assumes that unmodifiableFoo(new Foo<> {{ }}) must be assigned to a variable, rather than returned by a function (or, who knows, it could just be a statement).

Fixes #1040

RELNOTES: Fix NPE in DoubleBraceInitialization.

3902803a2baff203082f45fa63bdb6d49c6c7686