### PR TITLE
GuardedByUtils: return empty set instead of null

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByUtils.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByUtils.java
@@ -44,7 +44,7 @@ public class GuardedByUtils {
   static ImmutableSet<String> getGuardValues(Tree tree, VisitorState state) {
     Symbol sym = getSymbol(tree);
     if (sym == null) {
-      return null;
+      return ImmutableSet.of();
     }
     return getAnnotationValueAsStrings(sym);
   }


### PR DESCRIPTION
See https://github.com/google/error-prone/issues/1106#issuecomment-418546231

This fixes an NPE seen with JDK12 (when #1107 is merged):

```
[javac]     public final WaySegment getNearestWaySegment(Point p, Predicate<OsmPrimitive> predicate,
    [javac]                             ^
    [javac]      Please report this at https://github.com/google/error-prone/issues/new and include the following:
    [javac]   
    [javac]      error-prone version: 2.3.2-SNAPSHOT
    [javac]      BugPattern: GuardedBy
    [javac]      Stack Trace:
    [javac]      java.lang.NullPointerException
    [javac]   	at com.google.errorprone.bugpatterns.threadsafety.HeldLockAnalyzer$LockScanner.checkMatch(HeldLockAnalyzer.java:227)
    [javac]   	at com.google.errorprone.bugpatterns.threadsafety.HeldLockAnalyzer$LockScanner.visitIdentifier(HeldLockAnalyzer.java:196)
    [javac]   	at com.google.errorprone.bugpatterns.threadsafety.HeldLockAnalyzer$LockScanner.visitIdentifier(HeldLockAnalyzer.java:116)
    [javac]   	at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCIdent.accept(JCTree.java:2324)
```