### PR TITLE
CanBeStatic: Fix NPE

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/CanBeStaticAnalyzer.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CanBeStaticAnalyzer.java
@@ -69,7 +69,7 @@ public class CanBeStaticAnalyzer extends TreeScanner {
   public void visitIdent(JCTree.JCIdent tree) {
     // check for unqualified references to instance members (fields and methods) declared
     // in an enclosing scope
-    if (tree.sym.isStatic()) {
+    if (tree.sym == null || tree.sym.isStatic()) {
       return;
     }
     switch (tree.sym.getKind()) {


### PR DESCRIPTION
See https://github.com/google/error-prone/issues/1106#issuecomment-418871026

Solves NPE (after #1107 and #1110 are merged) with Java 12:

```
[javac]      error-prone version: 2.3.2-SNAPSHOT
    [javac]      BugPattern: ClassCanBeStatic
    [javac]      Stack Trace:
    [javac]      java.lang.NullPointerException
    [javac]   	at com.google.errorprone.bugpatterns.CanBeStaticAnalyzer.visitIdent(CanBeStaticAnalyzer.java:60)
    [javac]   	at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCIdent.accept(JCTree.java:2316)
    [javac]   	at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:49)
    [javac]   	at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.visitBreak(TreeScanner.java:222)
    [javac]   	at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCBreak.accept(JCTree.java:1559)
    [javac]   	at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:49)
    [javac]   	at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:57)
    [javac]   	at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.visitBlock(TreeScanner.java:143)
    [javac]   	at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCBlock.accept(JCTree.java:1026)
    [javac]   	at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:49)
    [javac]   	at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.visitIf(TreeScanner.java:213)
    [javac]   	at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCIf.accept(JCTree.java:1486)
```