### PR TITLE
Update "Command-line flags" page with `-Xplugin` instructions

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -131,4 +131,14 @@ parameter must also be set:
 ```
 
 Be aware that when running on JDK 8 the flags cannot be wrapped across multiple
-lines. JDK 9 and above do allow the flags to be separated by newlines.
+lines. JDK 9 and above do allow the flags to be separated by newlines. That is,
+the second `<arg>` element above can also be formatted as follows on JDK 9+,
+but *not* on JDK 8:
+
+```xml
+<arg>
+  -Xplugin:ErrorProne
+  -Xep:DeadException:WARN
+  -Xep:GuardedBy:OFF
+</arg>
+```

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -107,8 +107,9 @@ public class MyChecker extends BugChecker implements SomeTreeMatcher {
 ## Maven
 
 To pass Error Prone flags to Maven, use the `compilerArgs` parameter in the
-plugin's configuration. To enable warnings, the `showWarnings` parameter must
-also be set:
+plugin's configuration. The flags must be appended to the `arg` entry
+containing `-Xplugin:ErrorProne`. To enable warnings, the `showWarnings`
+parameter must also be set:
 
 ```xml
 <project>
@@ -117,11 +118,10 @@ also be set:
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <compilerId>javac-with-errorprone</compilerId>
           <showWarnings>true</showWarnings>
           <compilerArgs>
-            <arg>-Xep:DeadException:WARN</arg>
-            <arg>-Xep:GuardedBy:OFF</arg>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne -Xep:DeadException:WARN -Xep:GuardedBy:OFF</arg>
           </compilerArgs>
         </configuration>
       </build>
@@ -129,3 +129,6 @@ also be set:
   </plugin>
 </project>
 ```
+
+Be aware that when running on JDK 8 the flags cannot be wrapped across multiple
+lines. JDK 9 and above do allow the flags to be separated by newlines.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,7 +52,7 @@ Edit your `pom.xml` file to add settings to the maven-compiler-plugin:
           <target>8</target>
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>
-            <arg>-Xplugin:ErrorProne</arg>
+            <arg>-Xplugin:ErrorProne -Xep:DeadException:ERROR</arg>
           </compilerArgs>
           <annotationProcessorPaths>
             <path>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,7 +52,7 @@ Edit your `pom.xml` file to add settings to the maven-compiler-plugin:
           <target>8</target>
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>
-            <arg>-Xplugin:ErrorProne -Xep:DeadException:ERROR</arg>
+            <arg>-Xplugin:ErrorProne</arg>
           </compilerArgs>
           <annotationProcessorPaths>
             <path>
@@ -119,6 +119,9 @@ directory for a working example:
 [INFO] BUILD FAILURE
 [INFO] ------------------------------------------------------------------------
 ```
+
+See the [flags documentation](http://errorprone.info/docs/flags#maven) for details on
+how to customize the plugin's behavior.
 
 ## Gradle
 


### PR DESCRIPTION
I migrated a Maven configuration from `javac-with-errorprone` to `-Xplugin:ErrorProne`, as documented in 74726c31eef270acdd15465bc748bec87485a9bf. Not being familiar with javac plugins, it took me quite a while before I realized why I was consistently greeted with errors about Error Prone flags not being recognized:
```
javac: invalid flag: -Xep:FieldMissingNullable:OFF
```

It turns out the following doesn't work anymore (like it did with `javac-with-errorprone`):
```xml
<arg>-Xplugin:ErrorProne</arg>
<arg>-Xep:FieldMissingNullable:OFF</arg>
```

Then based on the [Ant](http://errorprone.info/docs/installation#ant) and [command line](http://errorprone.info/docs/installation#command-line) documentation I tried the following, but this only worked on Java 9+, still failing on Java 8:
```xml
<arg>-Xplugin:ErrorProne
     -Xep:FieldMissingNullable:OFF</arg>
```

The lesson is that for compatibility with Java 8 the flags must either all be on the same line, or in case one wishes to intersperse comments, wrapped like this:
```xml
<arg>-Xplugin:ErrorProne <!--
      See //github.com/google/error-prone/issues/708.
  -->-Xep:FieldMissingNullable:OFF</arg>
```

This PR updates the documentation so that others may find a smoother upgrade path :).
