### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/matchers/Description.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/Description.java
@@ -63,7 +63,7 @@ public class Description {
    * A list of fixes to suggest in an error message or use in automated refactoring. Fixes are in
    * order of decreasing preference, from most preferred to least preferred.
    */
-  public final ImmutableList<Fix> fixes;
+  public final List<Fix> fixes;
 
   /** Is this a warning, error, etc.? */
   public final BugPattern.SeverityLevel severity;
@@ -112,13 +112,13 @@ public class Description {
       String checkName,
       String rawMessage,
       String linkUrl,
-      ImmutableList<Fix> fixes,
+      List<Fix> fixes,
       SeverityLevel severity) {
     this.position = position;
     this.checkName = checkName;
     this.rawMessage = rawMessage;
     this.linkUrl = linkUrl;
-    this.fixes = fixes;
+    this.fixes = ImmutableList.copyOf(fixes);
     this.severity = severity;
   }
 

--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -228,6 +228,9 @@ public class ASTHelpers {
     if (tree instanceof ParameterizedTypeTree) {
       return getSymbol(((ParameterizedTypeTree) tree).getType());
     }
+    if (tree instanceof ClassTree) {
+      return getSymbol((ClassTree) tree);
+    }
 
     return getDeclaredSymbol(tree);
   }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StringSplitter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StringSplitter.java
@@ -77,24 +77,7 @@ public class StringSplitter extends BugChecker implements MethodInvocationTreeMa
 
   public Optional<Fix> buildFix(MethodInvocationTree tree, VisitorState state) {
     Tree arg = getOnlyElement(tree.getArguments());
-    String value = ASTHelpers.constValue(arg, String.class);
-    boolean maybeRegex = false;
-    if (value != null) {
-      Optional<String> regexAsLiteral = convertRegexToLiteral(value);
-      if (regexAsLiteral.isPresent()) {
-        value = SourceCodeEscapers.javaCharEscaper().escape(regexAsLiteral.get());
-        if (value.length() == 1) {
-          value = String.format("'%s'", value.charAt(0));
-        } else {
-          value = String.format("\"%s\"", value);
-        }
-      } else {
-        maybeRegex = true;
-        value = state.getSourceForNode(arg);
-      }
-    } else {
-      value = state.getSourceForNode(arg);
-    }
+    String methodAndArgument = getMethodAndArgument(arg, state);
     Tree parent = state.getPath().getParentPath().getLeaf();
     if (parent instanceof EnhancedForLoopTree
         && ((EnhancedForLoopTree) parent).getExpression().equals(tree)) {
@@ -103,10 +86,9 @@ public class StringSplitter extends BugChecker implements MethodInvocationTreeMa
           replaceWithSplitter(
                   SuggestedFix.builder(),
                   tree,
-                  value,
+                  methodAndArgument,
                   state,
                   "split",
-                  maybeRegex,
                   /* mutableList= */ false)
               .build());
     }
@@ -132,7 +114,7 @@ public class StringSplitter extends BugChecker implements MethodInvocationTreeMa
                   ")");
       return Optional.of(
           replaceWithSplitter(
-                  fix, tree, value, state, "split", maybeRegex, /* mutableList= */ false)
+                  fix, tree, methodAndArgument, state, "split", /* mutableList= */ false)
               .build());
     }
     // If the result of split is assigned to a variable, try to fix all uses of the variable in the
@@ -226,21 +208,47 @@ public class StringSplitter extends BugChecker implements MethodInvocationTreeMa
     }
     if (needsList[0]) {
       fix.replace((varTree).getType(), "List<String>").addImport("java.util.List");
-      replaceWithSplitter(fix, tree, value, state, "splitToList", maybeRegex, needsMutableList[0]);
+      replaceWithSplitter(fix, tree, methodAndArgument, state, "splitToList", needsMutableList[0]);
     } else {
       fix.replace((varTree).getType(), "Iterable<String>");
-      replaceWithSplitter(fix, tree, value, state, "split", maybeRegex, needsMutableList[0]);
+      replaceWithSplitter(fix, tree, methodAndArgument, state, "split", needsMutableList[0]);
     }
     return Optional.of(fix.build());
+  }
+
+  private static String getMethodAndArgument(Tree origArg, VisitorState state) {
+    String argSource = state.getSourceForNode(origArg);
+    Tree arg = ASTHelpers.stripParentheses(origArg);
+    if (arg.getKind() != Tree.Kind.STRING_LITERAL) {
+      // Even if the regex is a constant, it still needs to be treated as a regex, since the
+      // value comes from the symbol and/or a concatenation; the values of the subexpressions may be
+      // changed subsequently.
+      return String.format("onPattern(%s)", argSource);
+    }
+    String constValue = ASTHelpers.constValue(arg, String.class);
+    if (constValue == null) {
+      // Not a constant value, so we can't assume anything about pattern: have to treat it as a
+      // regex.
+      return String.format("onPattern(%s)", argSource);
+    }
+    Optional<String> regexAsLiteral = convertRegexToLiteral(constValue);
+    if (!regexAsLiteral.isPresent()) {
+      // Can't convert the regex to a literal string: have to treat it as a regex.
+      return String.format("onPattern(%s)", argSource);
+    }
+    String escaped = SourceCodeEscapers.javaCharEscaper().escape(regexAsLiteral.get());
+    if (regexAsLiteral.get().length() == 1) {
+      return String.format("on('%s')", escaped);
+    }
+    return String.format("on(\"%s\")", escaped);
   }
 
   private SuggestedFix.Builder replaceWithSplitter(
       SuggestedFix.Builder fix,
       MethodInvocationTree tree,
-      String text,
+      String methodAndArgument,
       VisitorState state,
       String splitMethod,
-      boolean maybeRegex,
       boolean mutableList) {
     ExpressionTree receiver = ASTHelpers.getReceiver(tree);
     if (mutableList) {
@@ -250,11 +258,8 @@ public class StringSplitter extends BugChecker implements MethodInvocationTreeMa
         .prefixWith(
             receiver,
             String.format(
-                "%sSplitter.%s(%s).%s(",
-                (mutableList ? "new ArrayList<>(" : ""),
-                (maybeRegex ? "onPattern" : "on"),
-                text,
-                splitMethod))
+                "%sSplitter.%s.%s(",
+                (mutableList ? "new ArrayList<>(" : ""), methodAndArgument, splitMethod))
         .replace(
             state.getEndPosition(receiver),
             state.getEndPosition(tree),

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryDefaultInEnumSwitch.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryDefaultInEnumSwitch.java
@@ -175,7 +175,12 @@ public class UnnecessaryDefaultInEnumSwitch extends BugChecker implements Switch
       // it's OK to to delete the default.
       return buildDescription(defaultCase)
           .setMessage(DESCRIPTION_REMOVED_DEFAULT)
-          .addFix(SuggestedFix.delete(defaultCase))
+          .addFix(
+              unrecognized
+                  ? SuggestedFix.builder()
+                      .replace(defaultCase, "case UNRECOGNIZED:" + initialComments + defaultSource)
+                      .build()
+                  : SuggestedFix.delete(defaultCase))
           .build();
     }
     // case (1) -- If it can complete, we need to merge the default into it.

--- a/core/src/main/java/com/google/errorprone/bugpatterns/Unused.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Unused.java
@@ -171,6 +171,7 @@ public final class Unused extends BugChecker implements CompilationUnitTreeMatch
   private static final ImmutableSet<String> LOGGER_TYPE_NAME = ImmutableSet.of("GoogleLogger");
 
   private static final ImmutableSet<String> LOGGER_VAR_NAME = ImmutableSet.of("logger");
+  private final boolean reportInjectedFields;
 
   public Unused(ErrorProneFlags flags) {
     ImmutableSet.Builder<String> methodAnnotationsExemptingParameters =
@@ -180,6 +181,7 @@ public final class Unused extends BugChecker implements CompilationUnitTreeMatch
         .getList("Unused:methodAnnotationsExemptingParameters")
         .ifPresent(methodAnnotationsExemptingParameters::addAll);
     this.methodAnnotationsExemptingParameters = methodAnnotationsExemptingParameters.build();
+    this.reportInjectedFields = flags.getBoolean("Unused:ReportInjectedFields").orElse(false);
   }
 
   @Override
@@ -301,7 +303,8 @@ public final class Unused extends BugChecker implements CompilationUnitTreeMatch
       }
 
       private boolean isFieldEligibleForChecking(VariableTree variableTree, VarSymbol symbol) {
-        if (variableTree.getModifiers().getFlags().isEmpty()
+        if (reportInjectedFields
+            && variableTree.getModifiers().getFlags().isEmpty()
             && ASTHelpers.hasDirectAnnotationWithSimpleName(variableTree, "Inject")) {
           return true;
         }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/Unused.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Unused.java
@@ -611,7 +611,7 @@ public final class Unused extends BugChecker implements CompilationUnitTreeMatch
           state.reportMatch(
               buildDescription(unused)
                   .addFix(replaceWithComments(unusedPath, "", state))
-                  .setMessage("Remove unused private method.")
+                  .setMessage("Unused private method.")
                   .build());
           break;
         default:

--- a/core/src/test/java/com/google/errorprone/bugpatterns/StringSplitterTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/StringSplitterTest.java
@@ -52,6 +52,104 @@ public class StringSplitterTest {
   }
 
   @Test
+  public void positive_patternIsSymbol() {
+    testHelper
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  static final String NON_REGEX_PATTERN_STRING = \":\";",
+            "  static final String REGEX_PATTERN_STRING = \".*\";",
+            "  static final String CONVERTIBLE_PATTERN_STRING = \"\\\\Q\\\\E:\";",
+            "  void f() {",
+            "    for (String s : \"\".split(NON_REGEX_PATTERN_STRING)) {}",
+            "    for (String s : \"\".split(REGEX_PATTERN_STRING)) {}",
+            "    for (String s : \"\".split(CONVERTIBLE_PATTERN_STRING)) {}",
+            "    for (String s : \"\".split((CONVERTIBLE_PATTERN_STRING))) {}",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.base.Splitter;",
+            "class Test {",
+            "  static final String NON_REGEX_PATTERN_STRING = \":\";",
+            "  static final String REGEX_PATTERN_STRING = \".*\";",
+            "  static final String CONVERTIBLE_PATTERN_STRING = \"\\\\Q\\\\E:\";",
+            "  void f() {",
+            "    for (String s : Splitter.onPattern(NON_REGEX_PATTERN_STRING).split(\"\")) {}",
+            "    for (String s : Splitter.onPattern(REGEX_PATTERN_STRING).split(\"\")) {}",
+            "    for (String s : Splitter.onPattern(CONVERTIBLE_PATTERN_STRING).split(\"\")) {}",
+            "    for (String s : Splitter.onPattern((CONVERTIBLE_PATTERN_STRING)).split(\"\")) {}",
+            "  }",
+            "}")
+        .doTest(TestMode.TEXT_MATCH);
+  }
+
+  @Test
+  public void positive_patternIsConcatenation() {
+    testHelper
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  void f() {",
+            "    for (String s : \"\".split(\":\" + 0)) {}",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.base.Splitter;",
+            "class Test {",
+            "  void f() {",
+            "    for (String s : Splitter.onPattern(\":\" + 0).split(\"\")) {}",
+            "  }",
+            "}")
+        .doTest(TestMode.TEXT_MATCH);
+  }
+
+  @Test
+  public void positive_patternNotConstant() {
+    testHelper
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  void f() {",
+            "    String pattern = \":\";",
+            "    for (String s : \"\".split(pattern)) {}",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.base.Splitter;",
+            "class Test {",
+            "  void f() {",
+            "    String pattern = \":\";",
+            "    for (String s : Splitter.onPattern(pattern).split(\"\")) {}",
+            "  }",
+            "}")
+        .doTest(TestMode.TEXT_MATCH);
+  }
+
+  @Test
+  public void positive_singleEscapedCharacter() {
+    testHelper
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  void f() {",
+            "    for (String s : \"\".split(\"\\u0000\")) {}",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.base.Splitter;",
+            "class Test {",
+            "  void f() {",
+            "    for (String s : Splitter.on('\\u0000').split(\"\")) {}",
+            "  }",
+            "}")
+        .doTest(TestMode.TEXT_MATCH);
+  }
+
+  @Test
   public void varLoop() {
     testHelper
         .addInputLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryDefaultInEnumSwitchTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryDefaultInEnumSwitchTest.java
@@ -323,6 +323,8 @@ public class UnnecessaryDefaultInEnumSwitchTest {
             "        break;",
             "      case THREE:",
             "        return true;",
+            "      case UNRECOGNIZED:",
+            "        throw new AssertionError(c);",
             "    }",
             "    return false;",
             "  }",
@@ -704,5 +706,47 @@ public class UnnecessaryDefaultInEnumSwitchTest {
             "  }",
             "}")
         .doTest();
+  }
+
+  @Test
+  public void switchCompletesUnrecognized() {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryDefaultInEnumSwitch(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  void m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "        break;",
+            "      case TWO:",
+            "        break;",
+            "      case THREE:",
+            "        break;",
+            "      default:",
+            "        // This is a comment",
+            "        throw new AssertionError(c);",
+            "    }",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO, THREE, UNRECOGNIZED }",
+            "  void m(Case c) {",
+            "    switch (c) {",
+            "      case ONE:",
+            "        break;",
+            "      case TWO:",
+            "        break;",
+            "      case THREE:",
+            "        break;",
+            "      case UNRECOGNIZED:",
+            "        // This is a comment",
+            "        throw new AssertionError(c);",
+            "    }",
+            "  }",
+            "}")
+        .doTest(TEXT_MATCH);
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedExceptionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedExceptionTest.java
@@ -194,6 +194,31 @@ public final class UnusedExceptionTest {
             "    }",
             "  }",
             "}")
-        .doTest(TestMode.AST_MATCH);
+        .doTest();
+  }
+
+  @Test
+  public void replacementNotVisible() {
+    BugCheckerRefactoringTestHelper.newInstance(new UnusedException(), getClass())
+        .addInputLines(
+            "in/MyException.java",
+            "class MyException extends RuntimeException {",
+            "  public MyException(int a) {}",
+            "  protected MyException(int a, Throwable th) {}",
+            "}")
+        .expectUnchanged()
+        .addInputLines(
+            "in/Test.java",
+            "class Test {",
+            "  void test() {",
+            "    try {",
+            "    } catch (Exception e) {",
+            // Not refactored as MyException(int, Throwable) isn't visible.
+            "      throw new MyException(1);",
+            "    }",
+            "  }",
+            "}")
+        .expectUnchanged()
+        .doTest();
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedTest.java
@@ -678,6 +678,21 @@ public class UnusedTest {
             "  @Inject Object foo;",
             "  @Inject public Object bar;",
             "}")
+        .setArgs(ImmutableList.of("-XepOpt:Unused:ReportInjectedFields"))
+        .doTest();
+  }
+
+  @Test
+  public void unusedInject_notByDefault() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "package unusedvars;",
+            "import javax.inject.Inject;",
+            "public class Test {",
+            "  @Inject Object foo;",
+            "  @Inject public Object bar;",
+            "}")
         .doTest();
   }
 

--- a/core/src/test/java/com/google/errorprone/util/ASTHelpersTest.java
+++ b/core/src/test/java/com/google/errorprone/util/ASTHelpersTest.java
@@ -1165,4 +1165,26 @@ public class ASTHelpersTest extends CompilerBasedAbstractTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void testDeprecatedClassDeclaration() {
+    writeFile(
+        "A.java", //
+        "@Deprecated",
+        "public class A {",
+        "}");
+    TestScanner scanner =
+        new TestScanner() {
+          @Override
+          public Void visitClass(ClassTree node, VisitorState visitorState) {
+            // we specifically want to test getSymbol(Tree), not getSymbol(ClassTree)
+            Tree tree = node;
+            assertThat(ASTHelpers.getSymbol(tree).isDeprecated()).isTrue();
+            setAssertionsComplete();
+            return super.visitClass(node, visitorState);
+          }
+        };
+    tests.add(scanner);
+    assertCompiles(scanner);
+  }
 }

--- a/docs/bugpattern/ReferenceEquality.md
+++ b/docs/bugpattern/ReferenceEquality.md
@@ -15,12 +15,6 @@ Well, no, because some tricky client can always generate a new instance with
 `new Boolean(true)`. Comparing with `equals` always works; comparing with `==`
 doesn't.
 
-### But `enum` values are always unique, so can't I compare _them_ with `==`?
-
-Yes, _but_ that might confuse the reader, who must understand that your type has
-special properties because it's an `enum`. Using `equals` everywhere can work
-the same everywhere; special-casing for enums isn't worth it.
-
 ### How about a reference equality comparison before a more expensive content equality comparison?
 
 The check allows implementations of `Object#equals()` to perform reference


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> More work-arounds for b/33815144
RELNOTES: N/A

58d1b77e8714b4a5710d86f0bcae7b7ec15dcc22

-------

<p> Put checking of @Injected fields behind a flag in Unused.

(I don't want to remove it entirely, because I want to experiment a bit and see if we can come up with a good heuristic, but clearly it's false positiving for people at the moment.)

RELNOTES: N/A

41d9a12372222e89c6f61676fe1e2122a485731b

-------

<p> Make UnusedException not generate a fix if the proposed constructor is not visible.

(Fiddly to do this for anonymous classes without descending into the class body to find the generated super() call, but that seems like edge case upon edge case.)

RELNOTES: Fix for bad replacements from UnusedException

c3eb632704229dfb52bc28aec0a25738a7a34ff1

-------

<p> Remove text about enums from ReferenceEquality check, as it doesn't check them.

I considered rephrasing it to say that using #equals is preferred but not enforced by this check, but mentioning them at all seems confusing.

Fixes #783

RELNOTES: Tweak documentation for ReferenceEquality

88e24cb7611316c89789eeed37f182cee2991df6

-------

<p> StringSplitter: only replace pattern with literal if it is already a literal; and don't use Splitter.on if the pattern is not a constant.

RELNOTES: Fixes for fixes in StringSplitter

913a676c8600d8d43cb5a2c2550f3c36fc3015bb

-------

<p> Fix ASTHelpers#getSymbol(Tree) handling of ClassTree

previously only the ASTHelpers#getSymbol(ClassTree) overload worked.

RELNOTES: N/A

836edd7e058f53c01b279ba700ddf3a1889a2aaf

-------

<p> Fix handling of UNRECOGNIZED in UnnecessaryDefaultInEnumSwitch

For switches that have a default and explicitly handle all cases except
`UNRECOGNIZED`, replace `default:` with `case UNRECOGNIZED:` instead of
deleting the default.

RELNOTES: N/A

d4fd29c1d44bfe1a11a7903174406a18145fd7d1

-------

<p> Make the private method summary consistent with the general case
RELNOTES: N/A

cc4010535616f78ecc7ce1ee8420dd6f5d132095