### PR TITLE
Add some sanity checks around source offsets in ParameterName check

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ParameterName.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ParameterName.java
@@ -83,6 +83,11 @@ public class ParameterName extends BugChecker
     }
     int start = ((JCTree) tree).getStartPosition();
     int end = state.getEndPosition(getLast(arguments));
+    // check for obviously invalid locations, which can arise, e.g., when a Javac plugin does AST
+    // mutation but doesn't set source locations
+    if (start < 0 || end < 0 || end <= start) {
+      return;
+    }
     String source = state.getSourceCode().subSequence(start, end).toString();
     if (!source.contains("/*")) {
       // fast path if the arguments don't contain anything that looks like a comment


### PR DESCRIPTION
We've seen a couple of cases where the ParameterName check crashes on method calls that have been inserted into the AST by another tool, e.g., a Javac plugin or Lombok.  These additional sanity checks seem to get rid of the crash.

Not obvious how to write a test for this, but open to suggestions.

Fixes #780 