### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/scanner/ScannerSupplierImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/scanner/ScannerSupplierImpl.java
@@ -74,7 +74,7 @@ class ScannerSupplierImpl extends ScannerSupplier implements Serializable {
       try {
         return flagsConstructor.get().newInstance(getFlags());
       } catch (ReflectiveOperationException e) {
-        // Invoking flags constructor failed, do nothing and try default constructor.
+        throw new LinkageError("Could not instantiate BugChecker.", e);
       }
     }
     // If no flags constructor, invoke default constructor.

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationFrom.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationFrom.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.matchers.Matchers.isSameType;
+import static com.google.errorprone.matchers.Matchers.staticMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import java.time.Period;
+
+/**
+ * Bans calls to {@code Duration.from(temporalAmount)} where {@code temporalAmount} is a {@link
+ * Period}.
+ *
+ * @author kak@google.com (Kurt Alfred Kluever)
+ */
+@BugPattern(
+    name = "DurationFrom",
+    summary = "Duration.from(Duration) returns itself; from(Period) throws a runtime exception.",
+    explanation =
+        "Duration.from(TemporalAmount) will always throw a UnsupportedTemporalTypeException when "
+            + "passed a Period and return itself when passed a Duration.",
+    severity = ERROR,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+public final class DurationFrom extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private static final Matcher<ExpressionTree> DURATION_FROM =
+      staticMethod().onClass("java.time.Duration").named("from");
+
+  private static final Matcher<Tree> DURATION = isSameType("java.time.Duration");
+
+  private static final Matcher<Tree> PERIOD = isSameType("java.time.Period");
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (DURATION_FROM.matches(tree, state)) {
+      ExpressionTree arg0 = tree.getArguments().get(0);
+      if (PERIOD.matches(arg0, state)) {
+        return describeMatch(tree);
+      }
+      if (DURATION.matches(arg0, state)) {
+        return describeMatch(tree, SuggestedFix.replace(tree, state.getSourceForNode(arg0)));
+      }
+    }
+    return Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PeriodFrom.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PeriodFrom.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.matchers.Matchers.isSameType;
+import static com.google.errorprone.matchers.Matchers.staticMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import java.time.Duration;
+
+/**
+ * Bans calls to {@code Period.from(temporalAmount)} where {@code temporalAmount} is a {@link
+ * Duration}.
+ *
+ * @author kak@google.com (Kurt Alfred Kluever)
+ */
+@BugPattern(
+    name = "PeriodFrom",
+    summary = "Period.from(Period) returns itself; from(Duration) throws a runtime exception.",
+    explanation =
+        "Period.from(TemporalAmount) will always throw a DateTimeException when "
+            + "passed a Duration and return itself when passed a Period.",
+    severity = ERROR,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+public final class PeriodFrom extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private static final Matcher<ExpressionTree> PERIOD_FROM =
+      staticMethod().onClass("java.time.Period").named("from");
+
+  private static final Matcher<Tree> DURATION = isSameType("java.time.Duration");
+
+  private static final Matcher<Tree> PERIOD = isSameType("java.time.Period");
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (PERIOD_FROM.matches(tree, state)) {
+      ExpressionTree arg0 = tree.getArguments().get(0);
+      if (DURATION.matches(arg0, state)) {
+        return describeMatch(tree);
+      }
+      if (PERIOD.matches(arg0, state)) {
+        return describeMatch(tree, SuggestedFix.replace(tree, state.getSourceForNode(arg0)));
+      }
+    }
+    return Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -354,6 +354,7 @@ import com.google.errorprone.bugpatterns.threadsafety.StaticGuardedByInstance;
 import com.google.errorprone.bugpatterns.threadsafety.SynchronizeOnNonFinalField;
 import com.google.errorprone.bugpatterns.threadsafety.ThreadPriorityCheck;
 import com.google.errorprone.bugpatterns.threadsafety.UnlockMethodChecker;
+import com.google.errorprone.bugpatterns.time.DurationFrom;
 import com.google.errorprone.bugpatterns.time.DurationGetTemporalUnit;
 import com.google.errorprone.bugpatterns.time.DurationToLongTimeUnit;
 import com.google.errorprone.bugpatterns.time.JavaDurationGetSecondsGetNano;
@@ -369,6 +370,7 @@ import com.google.errorprone.bugpatterns.time.JodaPlusMinusLong;
 import com.google.errorprone.bugpatterns.time.JodaTimeConverterManager;
 import com.google.errorprone.bugpatterns.time.JodaToSelf;
 import com.google.errorprone.bugpatterns.time.JodaWithDurationAddedLong;
+import com.google.errorprone.bugpatterns.time.PeriodFrom;
 import com.google.errorprone.bugpatterns.time.PeriodGetTemporalUnit;
 import com.google.errorprone.bugpatterns.time.ProtoDurationGetSecondsGetNano;
 import com.google.errorprone.bugpatterns.time.ProtoTimestampGetSecondsGetNano;
@@ -448,6 +450,7 @@ public class BuiltInCheckerSuppliers {
           DeadException.class,
           DeadThread.class,
           DoNotCallChecker.class,
+          DurationFrom.class,
           DurationGetTemporalUnit.class,
           DurationToLongTimeUnit.class,
           EqualsNaN.class,
@@ -506,6 +509,7 @@ public class BuiltInCheckerSuppliers {
           OverridesJavaxInjectableMethod.class,
           PackageInfo.class,
           ParcelableCreator.class,
+          PeriodFrom.class,
           PeriodGetTemporalUnit.class,
           PreconditionsCheckNotNull.class,
           PreconditionsCheckNotNullPrimitive.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UndefinedEqualsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UndefinedEqualsTest.java
@@ -40,7 +40,7 @@ public final class UndefinedEqualsTest {
             "import java.util.Queue;",
             "class Test {",
             "  void f(Queue a, Queue b) {",
-            "  // BUG: Diagnostic contains: java.util.Queue does not have",
+            "  // BUG: Diagnostic contains: Queue does not have",
             "    a.equals(b);",
             "  }",
             "}")
@@ -56,7 +56,7 @@ public final class UndefinedEqualsTest {
             "import java.util.Objects;",
             "class Test {",
             "  void f(Collection a, Collection b) {",
-            "     // BUG: Diagnostic contains: java.util.Collection does not have",
+            "     // BUG: Diagnostic contains: Collection does not have",
             "    Objects.equals(a,b);",
             "  }",
             "}")
@@ -74,11 +74,11 @@ public final class UndefinedEqualsTest {
             "import static org.junit.Assert.assertNotEquals;",
             "class Test {",
             "  void test(List myList, List otherList) {",
-            "    // BUG: Diagnostic contains: java.lang.Iterable does not have",
+            "    // BUG: Diagnostic contains: Iterable does not have",
             "    assertEquals(Iterables.skip(myList, 1), Iterables.skip(myList, 2));",
-            "    // BUG: Diagnostic contains: java.lang.Iterable does not have",
+            "    // BUG: Diagnostic contains: Iterable does not have",
             "    assertNotEquals(Iterables.skip(myList, 1), Iterables.skip(myList, 2));",
-            "    // BUG: Diagnostic contains: java.lang.Iterable does not have",
+            "    // BUG: Diagnostic contains: Iterable does not have",
             "    assertEquals(\"foo\", Iterables.skip(myList, 1), Iterables.skip(myList, 2));",
             "  }",
             "}")
@@ -93,7 +93,7 @@ public final class UndefinedEqualsTest {
             "import java.util.Queue;",
             "class Test {",
             "  <T> void f(Queue<String> a, Queue<T> b) {",
-            "    // BUG: Diagnostic contains: java.util.Queue does not have",
+            "    // BUG: Diagnostic contains: Queue does not have",
             "    a.equals(b);",
             "  }",
             "}")
@@ -109,10 +109,29 @@ public final class UndefinedEqualsTest {
             "import java.util.Queue;",
             "class Test {",
             "  <T> void f(Queue<String> a, Queue<T> b) {",
-            "    // BUG: Diagnostic contains: java.util.Queue does not have",
+            "    // BUG: Diagnostic contains: Queue does not have",
             "    assertThat(a).isEqualTo(b);",
-            "    // BUG: Diagnostic contains: java.util.Queue does not have",
+            "    // BUG: Diagnostic contains: Queue does not have",
             "    assertThat(a).isNotEqualTo(b);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positiveSparseArray() {
+    compilationHelper
+        .addSourceLines(
+            "SparseArray.java", //
+            "package android.util;",
+            "public class SparseArray <T> {}")
+        .addSourceLines(
+            "Test.java",
+            "import android.util.SparseArray;",
+            "class Test {",
+            "  <T> boolean f(SparseArray<T> a, SparseArray<T> b) {",
+            "    // BUG: Diagnostic contains: SparseArray does not have",
+            "    return a.equals(b);",
             "  }",
             "}")
         .doTest();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/DurationFromTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/DurationFromTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static org.junit.Assert.assertThrows;
+
+import com.google.errorprone.CompilationTestHelper;
+import java.time.Duration;
+import java.time.Period;
+import java.time.temporal.TemporalAmount;
+import java.time.temporal.UnsupportedTemporalTypeException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link DurationFrom}. */
+@RunWith(JUnit4.class)
+public class DurationFromTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(DurationFrom.class, getClass());
+
+  @SuppressWarnings("DurationFrom")
+  @Test
+  public void testFailures() {
+    assertThrows(UnsupportedTemporalTypeException.class, () -> Duration.from(Period.ZERO));
+    assertThrows(UnsupportedTemporalTypeException.class, () -> Duration.from(Period.ofDays(1)));
+    assertThrows(UnsupportedTemporalTypeException.class, () -> Duration.from(Period.ofDays(-1)));
+    assertThrows(UnsupportedTemporalTypeException.class, () -> Duration.from(Period.ofWeeks(1)));
+    assertThrows(UnsupportedTemporalTypeException.class, () -> Duration.from(Period.ofWeeks(-1)));
+    assertThrows(UnsupportedTemporalTypeException.class, () -> Duration.from(Period.ofMonths(1)));
+    assertThrows(UnsupportedTemporalTypeException.class, () -> Duration.from(Period.ofMonths(-1)));
+    assertThrows(UnsupportedTemporalTypeException.class, () -> Duration.from(Period.ofYears(1)));
+    assertThrows(UnsupportedTemporalTypeException.class, () -> Duration.from(Period.ofYears(-1)));
+
+    TemporalAmount temporalAmount = Period.ofDays(3);
+    assertThrows(UnsupportedTemporalTypeException.class, () -> Duration.from(temporalAmount));
+  }
+
+  @Test
+  public void durationFrom() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.time.Period;",
+            "import java.time.temporal.TemporalAmount;",
+            "public class TestClass {",
+            "  // BUG: Diagnostic contains: DurationFrom",
+            "  private final Duration oneDay = Duration.from(Period.ofDays(1));",
+            "  // BUG: Diagnostic contains: Duration.ofDays(2)",
+            "  private final Duration twoDays = Duration.from(Duration.ofDays(2));",
+            "  private final TemporalAmount temporalAmount = Duration.ofDays(3);",
+            // don't trigger when it is not statically known to be a Duration/Period
+            "  private final Duration threeDays = Duration.from(temporalAmount);",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PeriodFromTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PeriodFromTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static org.junit.Assert.assertThrows;
+
+import com.google.errorprone.CompilationTestHelper;
+import java.time.DateTimeException;
+import java.time.Duration;
+import java.time.Period;
+import java.time.temporal.TemporalAmount;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link PeriodFrom}. */
+@RunWith(JUnit4.class)
+public class PeriodFromTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(PeriodFrom.class, getClass());
+
+  @SuppressWarnings("PeriodFrom")
+  @Test
+  public void testFailures() {
+    assertThrows(DateTimeException.class, () -> Period.from(Duration.ZERO));
+    assertThrows(DateTimeException.class, () -> Period.from(Duration.ofNanos(1)));
+    assertThrows(DateTimeException.class, () -> Period.from(Duration.ofNanos(-1)));
+    assertThrows(DateTimeException.class, () -> Period.from(Duration.ofMillis(1)));
+    assertThrows(DateTimeException.class, () -> Period.from(Duration.ofMillis(-1)));
+    assertThrows(DateTimeException.class, () -> Period.from(Duration.ofSeconds(1)));
+    assertThrows(DateTimeException.class, () -> Period.from(Duration.ofSeconds(-1)));
+    assertThrows(DateTimeException.class, () -> Period.from(Duration.ofMinutes(1)));
+    assertThrows(DateTimeException.class, () -> Period.from(Duration.ofMinutes(-1)));
+    assertThrows(DateTimeException.class, () -> Period.from(Duration.ofDays(1)));
+    assertThrows(DateTimeException.class, () -> Period.from(Duration.ofDays(-1)));
+
+    TemporalAmount temporalAmount = Duration.ofDays(3);
+    assertThrows(DateTimeException.class, () -> Period.from(temporalAmount));
+  }
+
+  @Test
+  public void periodFrom() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.time.Period;",
+            "import java.time.temporal.TemporalAmount;",
+            "public class TestClass {",
+            "  // BUG: Diagnostic contains: PeriodFrom",
+            "  private final Period oneDay = Period.from(Duration.ofDays(1));",
+            "  // BUG: Diagnostic contains: Period.ofDays(2)",
+            "  private final Period twoDays = Period.from(Period.ofDays(2));",
+            "  private final TemporalAmount temporalAmount = Duration.ofDays(3);",
+            // don't trigger when it is not statically known to be a Duration/Period
+            "  private final Duration threeDays = Duration.from(temporalAmount);",
+            "}")
+        .doTest();
+  }
+}

--- a/docs/bugpattern/UndefinedEquals.md
+++ b/docs/bugpattern/UndefinedEquals.md
@@ -1,7 +1,8 @@
 This code uses `Object.equals` (or similar method) with a type that does not
 have well-defined `equals` behavior: [`Collection`], [`Iterable`], [`Multimap`],
 [`Queue`], or [`CharSequence`]. Such a call to `equals` may return `false` in
-cases where equality was expected.
+cases where equality was expected. [`SparseArray`] and [`LongSparseArray`] do
+not implement `equals`, so will fall back to reference equality.
 
 ## For [`Collection`] or [`Iterable`]
 
@@ -44,13 +45,19 @@ When comparing a `String` to a `CharSequence`, prefer `String#contentEquals`.
 When comparing the content of two `CharSequence`s, you may want to compare the
 string representation: `lhs.toString().contentEquals(rhs)`.
 
+## For [`SparseArray`] and [`LongSparseArray`]
+
+These must be iterated over and compared manually, element by element.
+
 [`Collection`]: https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html
 [`Iterable`]: https://docs.oracle.com/javase/8/docs/api/java/lang/Iterable.html
 [`Iterables.elementsEqual`]: https://google.github.io/guava/releases/snapshot/api/docs/com/google/common/collect/Iterables.html#elementsEqual-java.lang.Iterable-java.lang.Iterable-
 [`LinkedList`]: http://docs.oracle.com/javase/8/docs/api/java/util/LinkedList.html
 [`ListMultimap`]: https://google.github.io/guava/releases/snapshot/api/docs/com/google/common/collect/ListMultimap.html
+[`LongSparseArray`]: https://developer.android.com/reference/android/util/LongSparseArray
 [`Multimap`]: https://google.github.io/guava/releases/snapshot/api/docs/com/google/common/collect/Multimap.html
 [`Multiset`]: https://google.github.io/guava/releases/snapshot/api/docs/com/google/common/collect/Multiset.html
 [`SetMultimap`]: https://google.github.io/guava/releases/snapshot/api/docs/com/google/common/collect/SetMultimap.html
+[`SparseArray`]: https://developer.android.com/reference/android/util/SparseArray
 [`Queue`]: http://docs.oracle.com/javase/8/docs/api/java/util/Queue.html
 [`CharSequence`]: http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't silently ignore exceptions thrown by ErrorProneFlags constructors

RELNOTES: N/A

a22a4c108d9448c3de4b1b154fc8ae210c62c049

-------

<p> Ban Duration.from(Period/Duration) and Period.from(Duration/Period) at compile-time.

RELNOTES: Ban Duration.from(Period/Duration) and Period.from(Duration/Period) at compile-time.

d2f6446bb8eef4eb2675b6b1192417078a26359a

-------

<p> Add SparseArray types to UndefinedEquals, as they do not implement equals.

SparseArray is a bit different in that it's a concrete class not an interface, but it's non-final so we can't be *sure* (in general) that someone hasn't overridden it to provide equals/hashCode. But they almost surely won't have, so special-casing it seems reasonable.

RELNOTES: Add SparseArray to UndefinedEquals.

689ebc6d30b7d49c4e825466e6cdde4e545eee5d