### PR TITLE
Moe Sync

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,19 +1,27 @@
-Please answer these questions before submitting your issue. Thanks!
+> ATTENTION! Please read and follow:
+> - if this is a _question_ about Error Prone, send it to error-prone-discuss@googlegroups.com
+> - if this is a _bug_ or _feature request_, fill the form below as best as you can.
 
+### Description of the problem / feature request:
+
+> Replace this line with your answer.
+
+### Feature requests: what underlying problem are you trying to solve with this feature?
+
+> Replace this line with your answer.
+
+### Bugs: what's the simplest, easiest way to reproduce this bug? Please provide a minimal example if possible.
+
+> Replace this line with your answer.
 
 ### What version of Error Prone are you using?
 
+> Replace this line with your answer.
 
-### Does this issue reproduce with the latest release?
+###  Have you found anything relevant by searching the web?
 
-
-### What did you do?
-
-If possible, provide a recipe for reproducing the error.
-A complete small program is good.
-
-
-### What did you expect to see?
-
-
-### What did you see instead?
+> Replace these lines with your answer.
+>
+> Places to look:
+> - GitHub issues: https://github.com/google/error-prone/issues
+> - email threads on https://groups.google.com/forum/#!forum/error-prone-discuss

--- a/check_api/src/main/java/com/google/errorprone/ErrorProneFlags.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneFlags.java
@@ -28,6 +28,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CheckReturnValue;
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -143,12 +144,12 @@ public final class ErrorProneFlags implements Serializable {
   }
 
   /**
-   * Gets the flag value for the given key as a comma-separated {@link ImmutableList} of Strings,
-   * wrapped in an {@link Optional}, which is empty if the flag is unset.
+   * Gets the flag value for the given key as a comma-separated {@link List} of Strings, wrapped in
+   * an {@link Optional}, which is empty if the flag is unset.
    *
    * <p>(note: empty strings included, e.g. {@code "-XepOpt:List=,1,,2," => ["","1","","2",""]})
    */
-  public Optional<ImmutableList<String>> getList(String key) {
+  public Optional<List<String>> getList(String key) {
     return this.get(key).map(v -> ImmutableList.copyOf(Splitter.on(',').split(v)));
   }
 

--- a/check_api/src/main/java/com/google/errorprone/matchers/FieldMatchers.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/FieldMatchers.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.matchers;
+
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.ImportTree;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import javax.annotation.Nullable;
+
+// TODO(glorioso): this likely wants to be a fluent interface like MethodMatchers.
+// Ex: [staticField()|instanceField()]
+//         .[onClass(String)|onAnyClass|onClassMatching]
+//         .[named(String)|withAnyName|withNameMatching]
+/** Static utility methods for creating {@link Matcher}s for detecting references to fields. */
+public final class FieldMatchers {
+  private FieldMatchers() {}
+
+  public static Matcher<ExpressionTree> anyFieldInClass(String className) {
+    return new FieldReferenceMatcher() {
+      @Override
+      boolean classIsAppropriate(ClassSymbol classSymbol) {
+        return classSymbol.getQualifiedName().contentEquals(className);
+      }
+
+      @Override
+      boolean fieldSymbolIsAppropriate(Symbol symbol) {
+        return true;
+      }
+    };
+  }
+
+  public static Matcher<ExpressionTree> staticField(String className, String fieldName) {
+    return new FieldReferenceMatcher() {
+      @Override
+      boolean classIsAppropriate(ClassSymbol classSymbol) {
+        return classSymbol.getQualifiedName().contentEquals(className);
+      }
+
+      @Override
+      boolean fieldSymbolIsAppropriate(Symbol symbol) {
+        return symbol.isStatic() && symbol.getSimpleName().contentEquals(fieldName);
+      }
+    };
+  }
+
+  public static Matcher<ExpressionTree> instanceField(String className, String fieldName) {
+    return new FieldReferenceMatcher() {
+      @Override
+      boolean classIsAppropriate(ClassSymbol classSymbol) {
+        return classSymbol.getQualifiedName().contentEquals(className);
+      }
+
+      @Override
+      boolean fieldSymbolIsAppropriate(Symbol symbol) {
+        return !symbol.isStatic() && symbol.getSimpleName().contentEquals(fieldName);
+      }
+    };
+  }
+
+  private abstract static class FieldReferenceMatcher implements Matcher<ExpressionTree> {
+    @Override
+    public boolean matches(ExpressionTree expressionTree, VisitorState state) {
+      return isSymbolFieldInAppropriateClass(ASTHelpers.getSymbol(expressionTree))
+          // Don't match if this is part of a static import tree, since they will get the finding
+          // on any usage of the field in their source.
+          && ASTHelpers.findEnclosingNode(state.getPath(), ImportTree.class) == null;
+    }
+
+    private boolean isSymbolFieldInAppropriateClass(@Nullable Symbol symbol) {
+      if (symbol == null) {
+        return false;
+      }
+      return symbol.getKind().isField()
+          && fieldSymbolIsAppropriate(symbol)
+          && classIsAppropriate(symbol.owner.enclClass());
+    }
+
+    abstract boolean fieldSymbolIsAppropriate(Symbol symbol);
+
+    abstract boolean classIsAppropriate(ClassSymbol classSymbol);
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CanonicalDuration.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CanonicalDuration.java
@@ -131,11 +131,12 @@ public class CanonicalDuration extends BugChecker implements MethodInvocationTre
       // don't inline constants
       return NO_MATCH;
     }
-    Number value = constValue(arg, Number.class);
-    if (value == null) {
+    Number constValue = constValue(arg, Number.class);
+    if (constValue == null) {
       return NO_MATCH;
     }
-    if (value.intValue() == 0) {
+    long value = constValue.longValue();
+    if (value == 0) {
       switch (api) {
         case JODA:
           ExpressionTree receiver = getReceiver(tree);
@@ -166,10 +167,10 @@ public class CanonicalDuration extends BugChecker implements MethodInvocationTre
       return NO_MATCH;
     }
     TemporalUnit unit = METHOD_NAME_TO_UNIT.get(sym.getSimpleName().toString());
-    if (Objects.equals(BANLIST.get(unit), value.longValue())) {
+    if (Objects.equals(BANLIST.get(unit), value)) {
       return NO_MATCH;
     }
-    Duration duration = Duration.of(value.longValue(), unit);
+    Duration duration = Duration.of(value, unit);
     // Iterate over all possible units from largest to smallest (days to nanos) until we find the
     // largest unit that can be used to exactly express the duration.
     for (Map.Entry<ChronoUnit, Converter<Duration, Long>> entry : CONVERTERS.entrySet()) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CanonicalDuration.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CanonicalDuration.java
@@ -106,7 +106,7 @@ public class CanonicalDuration extends BugChecker implements MethodInvocationTre
 
   // Represent a single day/hour/minute as hours/minutes/seconds is sometimes used to allow a block
   // of durations to have consistent units.
-  private static final ImmutableMap<TemporalUnit, Long> BLACKLIST =
+  private static final ImmutableMap<TemporalUnit, Long> BANLIST =
       ImmutableMap.of(
           ChronoUnit.HOURS, 24L,
           ChronoUnit.MINUTES, 60L,
@@ -166,7 +166,7 @@ public class CanonicalDuration extends BugChecker implements MethodInvocationTre
       return NO_MATCH;
     }
     TemporalUnit unit = METHOD_NAME_TO_UNIT.get(sym.getSimpleName().toString());
-    if (Objects.equals(BLACKLIST.get(unit), value.longValue())) {
+    if (Objects.equals(BANLIST.get(unit), value.longValue())) {
       return NO_MATCH;
     }
     Duration duration = Duration.of(value.longValue(), unit);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DeduplicateConstants.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DeduplicateConstants.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.BlockTree;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.LiteralTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.util.Name;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A checker that suggests deduplicating literals with existing constant variables.
+ *
+ * @author cushon@google.com (Liam Miller-Cushon)
+ */
+@BugPattern(
+    name = "DeduplicateConstants",
+    summary =
+        "This expression was previously declared as a constant;"
+            + " consider replacing this occurrence.",
+    severity = ERROR,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+public class DeduplicateConstants extends BugChecker implements CompilationUnitTreeMatcher {
+
+  /** A lexical scope for constant declarations. */
+  static class Scope {
+
+    /** A map from string literals to constant declarations. */
+    private final HashMap<String, VarSymbol> values = new HashMap<>();
+    /** Declarations that are hidden in the current scope. */
+    private final Set<Name> hidden = new HashSet<>();
+
+    /** The parent of the current scope. */
+    private final Scope parent;
+
+    Scope(Scope parent) {
+      this.parent = parent;
+    }
+
+    /** Enters a new sub-scope. */
+    Scope enter() {
+      return new Scope(this);
+    }
+
+    /** Returns an in-scope constant variable with the given value. */
+    public VarSymbol get(String value) {
+      VarSymbol sym = getInternal(value);
+      if (sym == null) {
+        return null;
+      }
+      if (hidden.contains(sym.getSimpleName())) {
+        return null;
+      }
+      return sym;
+    }
+
+    private VarSymbol getInternal(String value) {
+      VarSymbol sym = values.get(value);
+      if (sym != null) {
+        return sym;
+      }
+      if (parent != null) {
+        sym = parent.get(value);
+        if (sym != null) {
+          return sym;
+        }
+      }
+      return null;
+    }
+
+    /** Adds a constant declaration with the given value to the current scope. */
+    public void put(String value, VarSymbol sym) {
+      hidden.remove(sym.getSimpleName());
+      values.put(value, sym);
+    }
+
+    /**
+     * Records a non-constant variable declaration that hides any previously declared constants of
+     * the same name.
+     */
+    public void remove(VarSymbol sym) {
+      hidden.add(sym.getSimpleName());
+    }
+  }
+
+  @Override
+  public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {
+    Table<VarSymbol, Tree, SuggestedFix> fixes = HashBasedTable.create();
+    new TreeScanner<Void, Scope>() {
+
+      @Override
+      public Void visitBlock(BlockTree tree, Scope scope) {
+        // enter a new block scope (includes block trees for method and class bodies)
+        return super.visitBlock(tree, scope.enter());
+      }
+
+      @Override
+      public Void visitVariable(VariableTree tree, Scope scope) {
+        // record that this variables hides previous declarations before entering its initializer
+        scope.remove(ASTHelpers.getSymbol(tree));
+        scan(tree.getInitializer(), scope);
+        saveConstValue(tree, scope);
+        return null;
+      }
+
+      @Override
+      public Void visitLiteral(LiteralTree tree, Scope scope) {
+        replaceLiteral(tree, scope, state);
+        return super.visitLiteral(tree, scope);
+      }
+
+      private void replaceLiteral(LiteralTree tree, Scope scope, VisitorState state) {
+        Object value = ASTHelpers.constValue(tree);
+        if (value == null) {
+          return;
+        }
+        VarSymbol sym = scope.get(state.getSourceForNode(tree));
+        if (sym == null) {
+          return;
+        }
+        SuggestedFix fix = SuggestedFix.replace(tree, sym.getSimpleName().toString());
+        fixes.put(sym, tree, fix);
+      }
+
+      private void saveConstValue(VariableTree tree, Scope scope) {
+        VarSymbol sym = ASTHelpers.getSymbol(tree);
+        if (sym == null) {
+          return;
+        }
+        if ((sym.flags() & (Flags.EFFECTIVELY_FINAL | Flags.FINAL)) == 0) {
+          return;
+        }
+        // heuristic: long string constants are generally more interesting than short ones, or
+        // than non-string constants (e.g. `""`, `0`, or `false`).
+        String constValue = ASTHelpers.constValue(tree.getInitializer(), String.class);
+        if (constValue == null || constValue.length() <= 1) {
+          return;
+        }
+        scope.put(state.getSourceForNode(tree.getInitializer()), sym);
+      }
+    }.scan(tree, new Scope(null));
+    for (Map.Entry<VarSymbol, Map<Tree, SuggestedFix>> entries : fixes.rowMap().entrySet()) {
+      Map<Tree, SuggestedFix> occurrences = entries.getValue();
+      if (occurrences.size() < 2) {
+        // heuristic: only de-duplicate when there are two or more occurrences
+        continue;
+      }
+      // report the finding on each occurrence, but provide a fix for all related occurrences,
+      // so it works better on changed-lines only
+      SuggestedFix fix = mergeFix(occurrences.values());
+      occurrences.keySet().forEach(t -> state.reportMatch(describeMatch(t, fix)));
+    }
+    return Description.NO_MATCH;
+  }
+
+  private static SuggestedFix mergeFix(Collection<SuggestedFix> fixes) {
+    SuggestedFix.Builder fix = SuggestedFix.builder();
+    fixes.forEach(fix::merge);
+    return fix.build();
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/WellKnownMutability.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/WellKnownMutability.java
@@ -45,10 +45,8 @@ public final class WellKnownMutability implements ThreadSafety.KnownTypes {
   }
 
   public static WellKnownMutability fromFlags(ErrorProneFlags flags) {
-    ImmutableList<String> immutable =
-        flags.getList("Immutable:KnownImmutable").orElse(ImmutableList.of());
-    ImmutableList<String> unsafe =
-        flags.getList("Immutable:KnownUnsafe").orElse(ImmutableList.of());
+    List<String> immutable = flags.getList("Immutable:KnownImmutable").orElse(ImmutableList.of());
+    List<String> unsafe = flags.getList("Immutable:KnownUnsafe").orElse(ImmutableList.of());
     return new WellKnownMutability(immutable, unsafe);
   }
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/WellKnownMutability.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/WellKnownMutability.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Sets.SetView;
 import com.google.common.primitives.Primitives;
 import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.ImmutableCollections;
 import com.google.errorprone.suppliers.Supplier;
 import com.google.errorprone.suppliers.Suppliers;
 import com.sun.tools.javac.code.Type;
@@ -296,22 +297,30 @@ public final class WellKnownMutability implements ThreadSafety.KnownTypes {
   private final ImmutableSet<String> knownUnsafeClasses;
 
   private static ImmutableSet<String> buildUnsafeClasses(List<String> knownUnsafes) {
-    ImmutableSet.Builder<String> result = ImmutableSet.<String>builder();
-    result.addAll(knownUnsafes);
-    for (Class<?> clazz :
-        ImmutableSet.<Class<?>>of(
-            java.lang.Iterable.class,
-            java.lang.Object.class,
-            java.util.ArrayList.class,
-            java.util.Collection.class,
-            java.util.List.class,
-            java.util.Map.class,
-            java.util.Set.class,
-            java.util.EnumSet.class,
-            java.util.EnumMap.class)) {
-      result.add(clazz.getName());
-    }
-    return result.build();
+    return ImmutableSet.<String>builder()
+        .addAll(knownUnsafes)
+        .addAll(ImmutableCollections.MUTABLE_TO_IMMUTABLE_CLASS_NAME_MAP.keySet())
+        .add("com.google.protobuf.util.FieldMaskUtil.MergeOptions")
+        .add(java.util.BitSet.class.getName())
+        .add(java.util.Calendar.class.getName())
+        .add(java.lang.Iterable.class.getName())
+        .add(java.lang.Object.class.getName())
+        .add("java.text.DateFormat")
+        .add(java.util.ArrayList.class.getName())
+        .add(java.util.Collection.class.getName())
+        .add(java.util.EnumMap.class.getName())
+        .add(java.util.EnumSet.class.getName())
+        .add(java.util.List.class.getName())
+        .add(java.util.Map.class.getName())
+        .add(java.util.HashMap.class.getName())
+        .add(java.util.HashSet.class.getName())
+        .add(java.util.NavigableMap.class.getName())
+        .add(java.util.NavigableSet.class.getName())
+        .add(java.util.TreeMap.class.getName())
+        .add(java.util.TreeSet.class.getName())
+        .add(java.util.Vector.class.getName())
+        .add(java.util.Set.class.getName())
+        .build();
   }
 
   // ProtocolSupport matches Message (not MessageLite) for legacy reasons

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaDurationWithNanos.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaDurationWithNanos.java
@@ -12,7 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */ package com.google.errorprone.bugpatterns.time;
+ */
+package com.google.errorprone.bugpatterns.time;
 
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaDurationWithSeconds.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaDurationWithSeconds.java
@@ -12,7 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */ package com.google.errorprone.bugpatterns.time;
+ */
+package com.google.errorprone.bugpatterns.time;
 
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PeriodTimeMath.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PeriodTimeMath.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.argument;
+import static com.google.errorprone.matchers.Matchers.instanceMethod;
+import static com.google.errorprone.matchers.Matchers.isSameType;
+import static com.google.errorprone.matchers.Matchers.not;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.ErrorProneFlags;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+
+/** Bans calls to {@code Period#plus/minus(TemporalAmount)} where the argument is a Duration. */
+@BugPattern(
+    name = "PeriodTimeMath",
+    summary = "When adding or subtracting from a Period, Duration is incompatible.",
+    explanation =
+        "Period.(plus|minus)(TemporalAmount) will always throw a DateTimeException when passed a "
+            + "Duration.",
+    severity = ERROR,
+    providesFix = ProvidesFix.NO_FIX)
+public final class PeriodTimeMath extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private final Matcher<MethodInvocationTree> matcherToCheck;
+
+  private static final Matcher<ExpressionTree> PERIOD_MATH =
+      instanceMethod().onExactClass("java.time.Period").namedAnyOf("plus", "minus");
+
+  private static final Matcher<ExpressionTree> DURATION = isSameType("java.time.Duration");
+  private static final Matcher<ExpressionTree> PERIOD = isSameType("java.time.Period");
+
+  public PeriodTimeMath(ErrorProneFlags flags) {
+    boolean requireStrictCompatibility =
+        flags.getBoolean("PeriodTimeMath:RequireStaticPeriodArgument").orElse(false);
+    matcherToCheck =
+        allOf(PERIOD_MATH, argument(0, requireStrictCompatibility ? not(PERIOD) : DURATION));
+  }
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    return matcherToCheck.matches(tree, state) ? describeMatch(tree) : Description.NO_MATCH;
+  }
+}
+

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -73,6 +73,7 @@ import com.google.errorprone.bugpatterns.ConstructorLeaksThis;
 import com.google.errorprone.bugpatterns.DateFormatConstant;
 import com.google.errorprone.bugpatterns.DeadException;
 import com.google.errorprone.bugpatterns.DeadThread;
+import com.google.errorprone.bugpatterns.DeduplicateConstants;
 import com.google.errorprone.bugpatterns.DefaultCharset;
 import com.google.errorprone.bugpatterns.DepAnn;
 import com.google.errorprone.bugpatterns.DivZero;
@@ -706,6 +707,7 @@ public class BuiltInCheckerSuppliers {
           ConstantField.class,
           ConstructorInvokesOverridable.class,
           ConstructorLeaksThis.class,
+          DeduplicateConstants.class,
           DepAnn.class,
           DivZero.class,
           EmptyIfStatement.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -372,6 +372,7 @@ import com.google.errorprone.bugpatterns.time.JodaToSelf;
 import com.google.errorprone.bugpatterns.time.JodaWithDurationAddedLong;
 import com.google.errorprone.bugpatterns.time.PeriodFrom;
 import com.google.errorprone.bugpatterns.time.PeriodGetTemporalUnit;
+import com.google.errorprone.bugpatterns.time.PeriodTimeMath;
 import com.google.errorprone.bugpatterns.time.ProtoDurationGetSecondsGetNano;
 import com.google.errorprone.bugpatterns.time.ProtoTimestampGetSecondsGetNano;
 import com.google.errorprone.bugpatterns.time.TemporalAccessorGetChronoField;
@@ -510,6 +511,7 @@ public class BuiltInCheckerSuppliers {
           PackageInfo.class,
           ParcelableCreator.class,
           PeriodFrom.class,
+          PeriodTimeMath.class,
           PeriodGetTemporalUnit.class,
           PreconditionsCheckNotNull.class,
           PreconditionsCheckNotNullPrimitive.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/CanonicalDurationTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/CanonicalDurationTest.java
@@ -42,6 +42,7 @@ public class CanonicalDurationTest {
             "    java.time.Duration.ofSeconds(86400);",
             "    Duration.ofSeconds(CONST);",
             "    Duration.ofMillis(0);",
+            "    Duration.ofMillis(4611686018427387904L);",
             "    Duration.ofDays(1);",
             "  }",
             "}")
@@ -56,6 +57,7 @@ public class CanonicalDurationTest {
             "    java.time.Duration.ofDays(1);",
             "    Duration.ofSeconds(CONST);",
             "    Duration.ofMillis(0);",
+            "    Duration.ofMillis(4611686018427387904L);",
             "    Duration.ofDays(1);",
             "  }",
             "}")

--- a/core/src/test/java/com/google/errorprone/bugpatterns/DeduplicateConstantsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/DeduplicateConstantsTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** {@link DeduplicateConstants}Test */
+@RunWith(JUnit4.class)
+public class DeduplicateConstantsTest {
+
+  @Test
+  public void positive() {
+    BugCheckerRefactoringTestHelper.newInstance(new DeduplicateConstants(), getClass())
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  static final String C = \"hello world\";",
+            "  void f() {",
+            "    System.err.println(\"hello world\");",
+            "    System.err.println(\"hello world\");",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "class Test {",
+            "  static final String C = \"hello world\";",
+            "  void f() {",
+            "    System.err.println(C);",
+            "    System.err.println(C);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void effectivelyFinal() {
+    BugCheckerRefactoringTestHelper.newInstance(new DeduplicateConstants(), getClass())
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  void f() {",
+            "    String C = \"hello world\";",
+            "    System.err.println(\"hello world\");",
+            "    System.err.println(\"hello world\");",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "class Test {",
+            "  void f() {",
+            "    String C = \"hello world\";",
+            "    System.err.println(C);",
+            "    System.err.println(C);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negativeRecursiveInitializers() {
+    BugCheckerRefactoringTestHelper.newInstance(new DeduplicateConstants(), getClass())
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  static final String C = \"hello\";",
+            "  class One {",
+            "    static final String C = \"hello\";",
+            "  }",
+            "  class Two {",
+            "    static final String C = \"hello\";",
+            "  }",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
+
+  @Test
+  public void negativeOnlyOneUse() {
+    BugCheckerRefactoringTestHelper.newInstance(new DeduplicateConstants(), getClass())
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  static final String C = \"hello world\";",
+            "  void f() {",
+            "    System.err.println(\"hello world\");",
+            "  }",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
+
+  @Test
+  public void negativeTooShort() {
+    BugCheckerRefactoringTestHelper.newInstance(new DeduplicateConstants(), getClass())
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  static final String C = \".\";",
+            "  void f() {",
+            "    System.err.println(\".\");",
+            "    System.err.println(\".\");",
+            "    System.err.println(\".\");",
+            "  }",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedTest.java
@@ -613,6 +613,23 @@ public class UnusedTest {
   }
 
   @Test
+  public void removal_rogueBraces() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "@SuppressWarnings(\"foo\" /* { */)",
+            "public class Test {",
+            "  private static final int A = 1;",
+            "}")
+        .addOutputLines(
+            "Test.java", //
+            "@SuppressWarnings(\"foo\" /* { */)",
+            "public class Test {",
+            "}")
+        .doTest(TestMode.TEXT_MATCH);
+  }
+
+  @Test
   public void unusedWithComment_interspersedComments() {
     helper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/JodaPlusMinusLongTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/JodaPlusMinusLongTest.java
@@ -12,7 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */ package com.google.errorprone.bugpatterns.time;
+ */
+package com.google.errorprone.bugpatterns.time;
 
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.Test;

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PeriodTimeMathTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PeriodTimeMathTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.CompilationTestHelper;
+import java.time.DateTimeException;
+import java.time.Duration;
+import java.time.Period;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link PeriodTimeMath} */
+@RunWith(JUnit4.class)
+public class PeriodTimeMathTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(PeriodTimeMath.class, getClass());
+
+  @SuppressWarnings("PeriodTimeMath")
+  @Test
+  public void testFailures() {
+    Period p = Period.ZERO;
+    assertThrows(DateTimeException.class, () -> p.plus(Duration.ZERO));
+    assertThrows(DateTimeException.class, () -> p.minus(Duration.ZERO));
+    assertThrows(DateTimeException.class, () -> p.plus(Duration.ofHours(48)));
+    assertThrows(DateTimeException.class, () -> p.minus(Duration.ofHours(48)));
+    assertThrows(DateTimeException.class, () -> p.plus(Duration.ofDays(2)));
+  }
+
+  @Test
+  public void periodMath() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.time.Period;",
+            "import java.time.temporal.TemporalAmount;",
+            "public class TestClass {",
+            "  // BUG: Diagnostic contains: PeriodTimeMath",
+            "  private final Period zero = Period.ZERO.plus(Duration.ZERO);",
+            "  private final Period oneDay = Period.ZERO.plus(Period.ofDays(1));",
+            "  // BUG: Diagnostic contains: PeriodTimeMath",
+            "  private final Period twoDays = Period.ZERO.minus(Duration.ZERO);",
+            "  private final TemporalAmount temporalAmount = Duration.ofDays(3);",
+            // don't trigger when it is not statically known to be a Duration/Period
+            "  private final Period threeDays = Period.ZERO.plus(temporalAmount);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void strictPeriodMath() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.time.Period;",
+            "import java.time.temporal.TemporalAmount;",
+            "public class TestClass {",
+            "  // BUG: Diagnostic contains: PeriodTimeMath",
+            "  private final Period zero = Period.ZERO.plus(Duration.ZERO);",
+            "  private final Period oneDay = Period.ZERO.plus(Period.ofDays(1));",
+            "  // BUG: Diagnostic contains: PeriodTimeMath",
+            "  private final Period twoDays = Period.ZERO.minus(Duration.ZERO);",
+            "  private final TemporalAmount temporalAmount = Duration.ofDays(3);",
+            // In strict mode, trigger when it's not known to be a Period
+            "  // BUG: Diagnostic contains: PeriodTimeMath",
+            "  private final Period threeDays = Period.ZERO.plus(temporalAmount);",
+            "}")
+        .setArgs(ImmutableList.of("-XepOpt:PeriodTimeMath:RequireStaticPeriodArgument"))
+        .doTest();
+  }
+}

--- a/docs/bugpattern/CollectionIncompatibleType.md
+++ b/docs/bugpattern/CollectionIncompatibleType.md
@@ -9,7 +9,7 @@ element type are "incompatible." A typical example:
 
 ```java
 Set<Long> values = ...
-if (values.contains(1)) { ... }
+if (values.contains(42)) { ... }
 ```
 
 This code looks reasonable, but there's a problem: The `Set` contains `Long`
@@ -24,7 +24,7 @@ be strictly *assignable to* the collection's element type. For example:
 
 ```java
 void addIntegerOne(Set<? extends Number> numbers) {
-  numbers.add(1); // won't compile
+  numbers.add(42); // won't compile
 }
 ```
 
@@ -36,11 +36,11 @@ that only query or remove elements cannot corrupt the collection:
 
 ```java
 void removeIntegerOne(Set<? extends Number> numbers) {
-  numbers.remove(1); // should compile (and does)
+  numbers.remove(42); // should compile (and does)
 }
 ```
 
-In this case, the `Integer` `1` might be contained in `numbers`, and should be
+In this case, the `Integer` `42` might be contained in `numbers`, and should be
 removed if it is, but if `numbers` is a `Set<Long>`, no harm is done.
 
 We'd like to define `contains` in a way that rejects the bad call but permits

--- a/docs/bugpattern/MathAbsoluteRandom.md
+++ b/docs/bugpattern/MathAbsoluteRandom.md
@@ -19,3 +19,10 @@ to generate positive numbers:
 Random r = new Random();
 int positiveNumber = r.nextInt(Integer.MAX_VALUE);
 ```
+
+or map negative numbers onto the non-negative range:
+
+```java
+long lng = r.nextLong();
+lng = (lng == Long.MIN_VALUE) ? 0 : Math.abs(lng);
+```


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Change signature of an ErrorProneFlags method to avoid Guava types, to avoid
classloader conflicts in plugin checks that use flags.

RELNOTES: none

d1bccec9d717f97b148e4016c6da532a0ac1b282

-------

<p> Fix the suggested fix for the first element in a class where the modifiers
contain an opening brace.

RELNOTES: N/A

91081d3e7976d39d063e11e4fcd1fd288fbc399d

-------

<p> Use a better integer in CollectionIncompatibleType docs

Fixes #1170

RELNOTES: N/A

225e26cee05080ce66ea2fd0c883f0ef33992b3b

-------

<p> Move package declarations back to their own line, as opposed to being part of
the license header comment.

RELNOTES: n/a

1a97740eeec93511d5af85d759b9e3509cde5cd6

-------

<p> MathAbsoluteRandom: suggest method to generate non-negative long.

86d519da7af0e918d4d1bd17ca7dfee30215c586

-------

<p> s/BLACKLIST/BANLIST/

RELNOTES: n/a

5c079c6f3c6b4462261f1e3eba5765bcf8eab574

-------

<p> Improve MoreAnnotations' handling of constructors
RELNOTES: N/A

d9f746343defdbcb680c81d351b2ff2f84e0a108

-------

<p> Add a new check for Period.plus/minus passing a Duration: this will always
throw an exception at runtime.

RELNOTES: New Error-level check: PeriodTimeMath, catches known-unsafe calls to
Period.plus/minus(TemporalAmount)

23f1dd8db859756dfd447211b0e5fd09e25a5885

-------

<p> ISSUE_TEMPLATE v2

RELNOTES: N/A

ae17055a57ca3ffbc4a371a17b2caffa9d1ce82b

-------

<p> Suggest replacing occurrences of string literals with existing constants

RELNOTES: N/A

e83c26f4aee3ba68191f916a48facdc5103bbdf3

-------

<p> Don't assume duration constants fit into an int
RELNOTES: N/A

a218374007e983a562ca9e46d467e45ecf35d6c1

-------

<p> Add a local FieldMatchers class to help match references to instance or static fields.


GOOGLE:
Update JavaTimeChecker to explore field references in addition to method invocations:
  * Explicitly allow a number of enum constants/static fields
  * Explicitly ban ChronoUnit.MICRO_OF_SECOND
  * Refactor ApiElement a bit
  * Create a FieldMatchers local utility class

29e94d7b7a1af367ba908665bc9d894ad5744097

-------

<p> Move some well known mutable classes from ConstantCaseForConstants to WellKnownMutability

RELNOTES: Move some well known mutable classes from ConstantCaseForConstants to WellKnownMutability.

2340b3b115e2f08da59bde403f20afbbd2fff0c6