### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
@@ -67,7 +67,8 @@ public class BadImport extends BugChecker implements ImportTreeMatcher {
       ImmutableSet.of(
           "Builder");
   private static final ImmutableSet<String> BAD_STATIC_IDENTIFIERS =
-      ImmutableSet.of("copyOf", "of", "from", "INSTANCE", "builder", "newBuilder");
+      ImmutableSet.of(
+          "copyOf", "of", "from", "INSTANCE", "builder", "newBuilder", "getDefaultInstance");
 
   private static final MultiMatcher<Tree, AnnotationTree> HAS_TYPE_USE_ANNOTATION =
       annotations(AT_LEAST_ONE, (t, state) -> isTypeAnnotation(t));

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/UnescapedEntity.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/UnescapedEntity.java
@@ -44,6 +44,7 @@ import com.sun.source.doctree.EndElementTree;
 import com.sun.source.doctree.ErroneousTree;
 import com.sun.source.doctree.LinkTree;
 import com.sun.source.doctree.LiteralTree;
+import com.sun.source.doctree.SeeTree;
 import com.sun.source.doctree.StartElementTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
@@ -207,6 +208,12 @@ public final class UnescapedEntity extends BugChecker
     public Void visitLiteral(LiteralTree literalTree, Void unused) {
       excludeFromCodeFixes(literalTree);
       return super.visitLiteral(literalTree, null);
+    }
+
+    @Override
+    public Void visitSee(SeeTree seeTree, Void unused) {
+      excludeFromCodeFixes(seeTree);
+      return super.visitSee(seeTree, null);
     }
 
     private void excludeFromCodeFixes(DocTree tree) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/AnnotationInfo.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/AnnotationInfo.java
@@ -18,6 +18,7 @@ package com.google.errorprone.bugpatterns.threadsafety;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.Immutable;
 import java.util.Set;
 
 /**
@@ -28,6 +29,7 @@ import java.util.Set;
  * the JDK.
  */
 @AutoValue
+@Immutable
 public abstract class AnnotationInfo {
   public abstract String typeName();
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/WellKnownMutability.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/WellKnownMutability.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Sets.SetView;
 import com.google.common.primitives.Primitives;
 import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.annotations.Immutable;
 import com.google.errorprone.bugpatterns.ImmutableCollections;
 import com.google.errorprone.suppliers.Supplier;
 import com.google.errorprone.suppliers.Suppliers;
@@ -37,7 +38,14 @@ import java.util.Map;
 import java.util.Set;
 
 /** A collection of types with known mutability. */
+@Immutable
 public final class WellKnownMutability implements ThreadSafety.KnownTypes {
+
+  /** Types that are known to be immutable. */
+  private final ImmutableMap<String, AnnotationInfo> knownImmutableClasses;
+
+  /** Types that are known to be mutable. */
+  private final ImmutableSet<String> knownUnsafeClasses;
 
 
   private WellKnownMutability(List<String> knownImmutable, List<String> knownUnsafe) {
@@ -64,9 +72,6 @@ public final class WellKnownMutability implements ThreadSafety.KnownTypes {
   public Set<String> getKnownUnsafeClasses() {
     return knownUnsafeClasses;
   }
-
-  /** Types that are known to be immutable. */
-  private final ImmutableMap<String, AnnotationInfo> knownImmutableClasses;
 
   static class Builder {
     final ImmutableMap.Builder<String, AnnotationInfo> mapBuilder = ImmutableMap.builder();
@@ -292,9 +297,6 @@ public final class WellKnownMutability implements ThreadSafety.KnownTypes {
         .add("org.openqa.selenium.ImmutableCapabilities")
         .build();
   }
-
-  /** Types that are known to be mutable. */
-  private final ImmutableSet<String> knownUnsafeClasses;
 
   private static ImmutableSet<String> buildUnsafeClasses(List<String> knownUnsafes) {
     return ImmutableSet.<String>builder()


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Automated rollback of 05560ecc7b509f88c5cf70db229a98ec8775d075.

*** Reason for rollback ***

Retrying without the ImmutableMap change. It somehow seemed to interact with the build system in a weird way, but I'm not quite sure how.

*** Original change description ***

Automated rollback of 6c80a361c7f11f655b96e41c66d133f47e950be1.

*** Original change description ***

Mark WellKnownMutability as @Immutable so that it can be a member of other @Immutable classes

Also a small drive-by cleanup to locate member variables in the same place and make a return type immutable.

RELNOTES: Mark WellKnownMutability as @Immutable.

***

***

8b3f721b817704f886e8d16cd52f572911982a05

-------

<p> Exclude @see tags from UnescapedEntity.

RELNOTES: N/A

8523d3685526089fbf70d2a1bf8e2047f6cb61fc

-------

<p> BadImport: add "getDefaultInstance" as a bad static method to import.

RELNOTES: add "getDefaultInstance" as a bad static method to import

7e0ded9fa8bc853f47560a8801ad3029ea917ce1