### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/scanner/ErrorProneScanner.java
+++ b/check_api/src/main/java/com/google/errorprone/scanner/ErrorProneScanner.java
@@ -74,6 +74,7 @@ import com.google.errorprone.bugpatterns.BugChecker.UnionTypeTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.WhileLoopTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.WildcardTreeMatcher;
+import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Suppressible;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AnnotatedTypeTree;
@@ -119,6 +120,7 @@ import com.sun.source.tree.ReturnTree;
 import com.sun.source.tree.SwitchTree;
 import com.sun.source.tree.SynchronizedTree;
 import com.sun.source.tree.ThrowTree;
+import com.sun.source.tree.Tree;
 import com.sun.source.tree.TryTree;
 import com.sun.source.tree.TypeCastTree;
 import com.sun.source.tree.TypeParameterTree;
@@ -408,289 +410,186 @@ public class ErrorProneScanner extends Scanner {
     }
   }
 
-  @Override
-  public Void visitAnnotation(AnnotationTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (AnnotationTreeMatcher matcher : annotationMatchers) {
+  @FunctionalInterface
+  private interface TreeProcessor<M extends Suppressible, T extends Tree> {
+    Description process(M matcher, T tree, VisitorState state);
+  }
+
+  private <M extends Suppressible, T extends Tree> VisitorState processMatchers(
+      Iterable<M> matchers, T tree, TreeProcessor<M, T> processingFunction, VisitorState oldState) {
+    VisitorState state = oldState.withPath(getCurrentPath());
+    for (M matcher : matchers) {
       if (!isSuppressed(matcher, state.errorProneOptions())) {
         try {
-          reportMatch(matcher.matchAnnotation(tree, state), state);
+          reportMatch(processingFunction.process(matcher, tree, state), state);
         } catch (Throwable t) {
           handleError(matcher, t);
         }
       }
     }
+    return state;
+  }
+
+  @Override
+  public Void visitAnnotation(AnnotationTree tree, VisitorState visitorState) {
+    VisitorState state =
+        processMatchers(
+            annotationMatchers, tree, AnnotationTreeMatcher::matchAnnotation, visitorState);
     return super.visitAnnotation(tree, state);
   }
 
   @Override
   public Void visitAnnotatedType(AnnotatedTypeTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (AnnotatedTypeTreeMatcher matcher : annotatedTypeMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchAnnotatedType(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            annotatedTypeMatchers,
+            tree,
+            AnnotatedTypeTreeMatcher::matchAnnotatedType,
+            visitorState);
     return super.visitAnnotatedType(tree, state);
   }
 
   @Override
   public Void visitArrayAccess(ArrayAccessTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (ArrayAccessTreeMatcher matcher : arrayAccessMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchArrayAccess(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            arrayAccessMatchers, tree, ArrayAccessTreeMatcher::matchArrayAccess, visitorState);
     return super.visitArrayAccess(tree, state);
   }
 
   @Override
   public Void visitArrayType(ArrayTypeTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (ArrayTypeTreeMatcher matcher : arrayTypeMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchArrayType(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            arrayTypeMatchers, tree, ArrayTypeTreeMatcher::matchArrayType, visitorState);
     return super.visitArrayType(tree, state);
   }
 
   @Override
   public Void visitAssert(AssertTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (AssertTreeMatcher matcher : assertMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchAssert(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(assertMatchers, tree, AssertTreeMatcher::matchAssert, visitorState);
     return super.visitAssert(tree, state);
   }
 
   @Override
   public Void visitAssignment(AssignmentTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (AssignmentTreeMatcher matcher : assignmentMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchAssignment(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            assignmentMatchers, tree, AssignmentTreeMatcher::matchAssignment, visitorState);
     return super.visitAssignment(tree, state);
   }
 
   @Override
   public Void visitBinary(BinaryTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (BinaryTreeMatcher matcher : binaryMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchBinary(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(binaryMatchers, tree, BinaryTreeMatcher::matchBinary, visitorState);
     return super.visitBinary(tree, state);
   }
 
   @Override
   public Void visitBlock(BlockTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (BlockTreeMatcher matcher : blockMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchBlock(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(blockMatchers, tree, BlockTreeMatcher::matchBlock, visitorState);
     return super.visitBlock(tree, state);
   }
 
   @Override
   public Void visitBreak(BreakTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (BreakTreeMatcher matcher : breakMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchBreak(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(breakMatchers, tree, BreakTreeMatcher::matchBreak, visitorState);
     return super.visitBreak(tree, state);
   }
 
   @Override
   public Void visitCase(CaseTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (CaseTreeMatcher matcher : caseMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchCase(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(caseMatchers, tree, CaseTreeMatcher::matchCase, visitorState);
     return super.visitCase(tree, state);
   }
 
   @Override
   public Void visitCatch(CatchTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (CatchTreeMatcher matcher : catchMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchCatch(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(catchMatchers, tree, CatchTreeMatcher::matchCatch, visitorState);
     return super.visitCatch(tree, state);
   }
 
   @Override
   public Void visitClass(ClassTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (ClassTreeMatcher matcher : classMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchClass(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(classMatchers, tree, ClassTreeMatcher::matchClass, visitorState);
     return super.visitClass(tree, state);
   }
 
   @Override
   public Void visitCompilationUnit(CompilationUnitTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (CompilationUnitTreeMatcher matcher : compilationUnitMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchCompilationUnit(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            compilationUnitMatchers,
+            tree,
+            CompilationUnitTreeMatcher::matchCompilationUnit,
+            visitorState);
     return super.visitCompilationUnit(tree, state);
   }
 
   @Override
   public Void visitCompoundAssignment(CompoundAssignmentTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (CompoundAssignmentTreeMatcher matcher : compoundAssignmentMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchCompoundAssignment(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            compoundAssignmentMatchers,
+            tree,
+            CompoundAssignmentTreeMatcher::matchCompoundAssignment,
+            visitorState);
     return super.visitCompoundAssignment(tree, state);
   }
 
   @Override
   public Void visitConditionalExpression(
       ConditionalExpressionTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (ConditionalExpressionTreeMatcher matcher : conditionalExpressionMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchConditionalExpression(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            conditionalExpressionMatchers,
+            tree,
+            ConditionalExpressionTreeMatcher::matchConditionalExpression,
+            visitorState);
     return super.visitConditionalExpression(tree, state);
   }
 
   @Override
   public Void visitContinue(ContinueTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (ContinueTreeMatcher matcher : continueMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchContinue(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(continueMatchers, tree, ContinueTreeMatcher::matchContinue, visitorState);
     return super.visitContinue(tree, state);
   }
 
   @Override
   public Void visitDoWhileLoop(DoWhileLoopTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (DoWhileLoopTreeMatcher matcher : doWhileLoopMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchDoWhileLoop(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            doWhileLoopMatchers, tree, DoWhileLoopTreeMatcher::matchDoWhileLoop, visitorState);
     return super.visitDoWhileLoop(tree, state);
   }
 
   @Override
   public Void visitEmptyStatement(EmptyStatementTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (EmptyStatementTreeMatcher matcher : emptyStatementMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchEmptyStatement(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            emptyStatementMatchers,
+            tree,
+            EmptyStatementTreeMatcher::matchEmptyStatement,
+            visitorState);
     return super.visitEmptyStatement(tree, state);
   }
 
   @Override
   public Void visitEnhancedForLoop(EnhancedForLoopTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (EnhancedForLoopTreeMatcher matcher : enhancedForLoopMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchEnhancedForLoop(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            enhancedForLoopMatchers,
+            tree,
+            EnhancedForLoopTreeMatcher::matchEnhancedForLoop,
+            visitorState);
     return super.visitEnhancedForLoop(tree, state);
   }
 
@@ -698,181 +597,107 @@ public class ErrorProneScanner extends Scanner {
 
   @Override
   public Void visitExpressionStatement(ExpressionStatementTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (ExpressionStatementTreeMatcher matcher : expressionStatementMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchExpressionStatement(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            expressionStatementMatchers,
+            tree,
+            ExpressionStatementTreeMatcher::matchExpressionStatement,
+            visitorState);
     return super.visitExpressionStatement(tree, state);
   }
 
   @Override
   public Void visitForLoop(ForLoopTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (ForLoopTreeMatcher matcher : forLoopMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchForLoop(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(forLoopMatchers, tree, ForLoopTreeMatcher::matchForLoop, visitorState);
     return super.visitForLoop(tree, state);
   }
 
   @Override
   public Void visitIdentifier(IdentifierTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (IdentifierTreeMatcher matcher : identifierMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchIdentifier(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            identifierMatchers, tree, IdentifierTreeMatcher::matchIdentifier, visitorState);
     return super.visitIdentifier(tree, state);
   }
 
   @Override
   public Void visitIf(IfTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (IfTreeMatcher matcher : ifMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchIf(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state = processMatchers(ifMatchers, tree, IfTreeMatcher::matchIf, visitorState);
     return super.visitIf(tree, state);
   }
 
   @Override
   public Void visitImport(ImportTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (ImportTreeMatcher matcher : importMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchImport(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(importMatchers, tree, ImportTreeMatcher::matchImport, visitorState);
     return super.visitImport(tree, state);
   }
 
   @Override
   public Void visitInstanceOf(InstanceOfTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (InstanceOfTreeMatcher matcher : instanceOfMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchInstanceOf(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            instanceOfMatchers, tree, InstanceOfTreeMatcher::matchInstanceOf, visitorState);
     return super.visitInstanceOf(tree, state);
   }
 
   @Override
   public Void visitIntersectionType(IntersectionTypeTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (IntersectionTypeTreeMatcher matcher : intersectionTypeMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchIntersectionType(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            intersectionTypeMatchers,
+            tree,
+            IntersectionTypeTreeMatcher::matchIntersectionType,
+            visitorState);
     return super.visitIntersectionType(tree, state);
   }
 
   @Override
   public Void visitLabeledStatement(LabeledStatementTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (LabeledStatementTreeMatcher matcher : labeledStatementMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchLabeledStatement(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            labeledStatementMatchers,
+            tree,
+            LabeledStatementTreeMatcher::matchLabeledStatement,
+            visitorState);
     return super.visitLabeledStatement(tree, state);
   }
 
   @Override
   public Void visitLambdaExpression(LambdaExpressionTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (LambdaExpressionTreeMatcher matcher : lambdaExpressionMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchLambdaExpression(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            lambdaExpressionMatchers,
+            tree,
+            LambdaExpressionTreeMatcher::matchLambdaExpression,
+            visitorState);
     return super.visitLambdaExpression(tree, state);
   }
 
   @Override
   public Void visitLiteral(LiteralTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (LiteralTreeMatcher matcher : literalMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchLiteral(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(literalMatchers, tree, LiteralTreeMatcher::matchLiteral, visitorState);
     return super.visitLiteral(tree, state);
   }
 
   @Override
   public Void visitMemberReference(MemberReferenceTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (MemberReferenceTreeMatcher matcher : memberReferenceMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchMemberReference(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            memberReferenceMatchers,
+            tree,
+            MemberReferenceTreeMatcher::matchMemberReference,
+            visitorState);
     return super.visitMemberReference(tree, state);
   }
 
   @Override
   public Void visitMemberSelect(MemberSelectTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (MemberSelectTreeMatcher matcher : memberSelectMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchMemberSelect(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            memberSelectMatchers, tree, MemberSelectTreeMatcher::matchMemberSelect, visitorState);
     return super.visitMemberSelect(tree, state);
   }
 
@@ -883,76 +708,42 @@ public class ErrorProneScanner extends Scanner {
       return null;
     }
 
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (MethodTreeMatcher matcher : methodMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchMethod(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(methodMatchers, tree, MethodTreeMatcher::matchMethod, visitorState);
     return super.visitMethod(tree, state);
   }
 
   @Override
   public Void visitMethodInvocation(MethodInvocationTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (MethodInvocationTreeMatcher matcher : methodInvocationMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchMethodInvocation(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            methodInvocationMatchers,
+            tree,
+            MethodInvocationTreeMatcher::matchMethodInvocation,
+            visitorState);
     return super.visitMethodInvocation(tree, state);
   }
 
   @Override
   public Void visitModifiers(ModifiersTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (ModifiersTreeMatcher matcher : modifiersMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchModifiers(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            modifiersMatchers, tree, ModifiersTreeMatcher::matchModifiers, visitorState);
+
     return super.visitModifiers(tree, state);
   }
 
   @Override
   public Void visitNewArray(NewArrayTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (NewArrayTreeMatcher matcher : newArrayMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchNewArray(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(newArrayMatchers, tree, NewArrayTreeMatcher::matchNewArray, visitorState);
     return super.visitNewArray(tree, state);
   }
 
   @Override
   public Void visitNewClass(NewClassTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (NewClassTreeMatcher matcher : newClassMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchNewClass(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(newClassMatchers, tree, NewClassTreeMatcher::matchNewClass, visitorState);
     return super.visitNewClass(tree, state);
   }
 
@@ -961,226 +752,124 @@ public class ErrorProneScanner extends Scanner {
 
   @Override
   public Void visitParameterizedType(ParameterizedTypeTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (ParameterizedTypeTreeMatcher matcher : parameterizedTypeMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchParameterizedType(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            parameterizedTypeMatchers,
+            tree,
+            ParameterizedTypeTreeMatcher::matchParameterizedType,
+            visitorState);
     return super.visitParameterizedType(tree, state);
   }
 
   @Override
   public Void visitParenthesized(ParenthesizedTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (ParenthesizedTreeMatcher matcher : parenthesizedMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchParenthesized(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            parenthesizedMatchers,
+            tree,
+            ParenthesizedTreeMatcher::matchParenthesized,
+            visitorState);
     return super.visitParenthesized(tree, state);
   }
 
   @Override
   public Void visitPrimitiveType(PrimitiveTypeTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (PrimitiveTypeTreeMatcher matcher : primitiveTypeMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchPrimitiveType(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            primitiveTypeMatchers,
+            tree,
+            PrimitiveTypeTreeMatcher::matchPrimitiveType,
+            visitorState);
     return super.visitPrimitiveType(tree, state);
   }
 
   @Override
   public Void visitReturn(ReturnTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (ReturnTreeMatcher matcher : returnMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchReturn(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(returnMatchers, tree, ReturnTreeMatcher::matchReturn, visitorState);
     return super.visitReturn(tree, state);
   }
 
   @Override
   public Void visitSwitch(SwitchTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (SwitchTreeMatcher matcher : switchMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchSwitch(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(switchMatchers, tree, SwitchTreeMatcher::matchSwitch, visitorState);
     return super.visitSwitch(tree, state);
   }
 
   @Override
   public Void visitSynchronized(SynchronizedTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (SynchronizedTreeMatcher matcher : synchronizedMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchSynchronized(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            synchronizedMatchers, tree, SynchronizedTreeMatcher::matchSynchronized, visitorState);
     return super.visitSynchronized(tree, state);
   }
 
   @Override
   public Void visitThrow(ThrowTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (ThrowTreeMatcher matcher : throwMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchThrow(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(throwMatchers, tree, ThrowTreeMatcher::matchThrow, visitorState);
     return super.visitThrow(tree, state);
   }
 
   @Override
   public Void visitTry(TryTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (TryTreeMatcher matcher : tryMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchTry(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state = processMatchers(tryMatchers, tree, TryTreeMatcher::matchTry, visitorState);
     return super.visitTry(tree, state);
   }
 
   @Override
   public Void visitTypeCast(TypeCastTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (TypeCastTreeMatcher matcher : typeCastMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchTypeCast(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(typeCastMatchers, tree, TypeCastTreeMatcher::matchTypeCast, visitorState);
     return super.visitTypeCast(tree, state);
   }
 
   @Override
   public Void visitTypeParameter(TypeParameterTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (TypeParameterTreeMatcher matcher : typeParameterMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchTypeParameter(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            typeParameterMatchers,
+            tree,
+            TypeParameterTreeMatcher::matchTypeParameter,
+            visitorState);
     return super.visitTypeParameter(tree, state);
   }
 
   @Override
   public Void visitUnary(UnaryTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (UnaryTreeMatcher matcher : unaryMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchUnary(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(unaryMatchers, tree, UnaryTreeMatcher::matchUnary, visitorState);
     return super.visitUnary(tree, state);
   }
 
   @Override
   public Void visitUnionType(UnionTypeTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (UnionTypeTreeMatcher matcher : unionTypeMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchUnionType(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            unionTypeMatchers, tree, UnionTypeTreeMatcher::matchUnionType, visitorState);
     return super.visitUnionType(tree, state);
   }
 
   @Override
   public Void visitVariable(VariableTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (VariableTreeMatcher matcher : variableMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchVariable(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(variableMatchers, tree, VariableTreeMatcher::matchVariable, visitorState);
     return super.visitVariable(tree, state);
   }
 
   @Override
   public Void visitWhileLoop(WhileLoopTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (WhileLoopTreeMatcher matcher : whileLoopMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchWhileLoop(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(
+            whileLoopMatchers, tree, WhileLoopTreeMatcher::matchWhileLoop, visitorState);
     return super.visitWhileLoop(tree, state);
   }
 
   @Override
   public Void visitWildcard(WildcardTree tree, VisitorState visitorState) {
-    VisitorState state = visitorState.withPath(getCurrentPath());
-    for (WildcardTreeMatcher matcher : wildcardMatchers) {
-      if (!isSuppressed(matcher, state.errorProneOptions())) {
-        try {
-          reportMatch(matcher.matchWildcard(tree, state), state);
-        } catch (Throwable t) {
-          handleError(matcher, t);
-        }
-      }
-    }
+    VisitorState state =
+        processMatchers(wildcardMatchers, tree, WildcardTreeMatcher::matchWildcard, visitorState);
     return super.visitWildcard(tree, state);
   }
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingTestCall.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingTestCall.java
@@ -83,11 +83,13 @@ public final class MissingTestCall extends BugChecker implements MethodTreeMatch
                   "addInputFile",
                   "addOutput",
                   "addOutputLines",
-                  "addOutputFile"),
+                  "addOutputFile",
+                  "expectUnchanged"),
               REFACTORING_HELPER.named("doTest")),
           MethodPairing.of(
               "CompilationTestHelper",
-              COMPILATION_HELPER.namedAnyOf("addSourceLines", "addSourceFile"),
+              COMPILATION_HELPER.namedAnyOf(
+                  "addSourceLines", "addSourceFile", "expectNoDiagnostics"),
               COMPILATION_HELPER.named("doTest")));
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullRepeated.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullRepeated.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.Category.GUAVA;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.staticMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.List;
+
+/**
+ * Checks that Precondition.checkNotNull is not invoked with same arg twice.
+ *
+ * @author bhagwani@google.com (Sumit Bhagwani)
+ */
+@BugPattern(
+    name = "PreconditionsCheckNotNullRepeated",
+    summary =
+        "Including this argument in the failure message isn't helpful,"
+            + " since its value will always be `null`.",
+    category = GUAVA,
+    severity = WARNING,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+public class PreconditionsCheckNotNullRepeated extends BugChecker
+    implements MethodInvocationTreeMatcher {
+
+  private static final Matcher<MethodInvocationTree> MATCHER =
+      allOf(staticMethod().onClass("com.google.common.base.Preconditions").named("checkNotNull"));
+
+  @Override
+  public Description matchMethodInvocation(
+      MethodInvocationTree methodInvocationTree, VisitorState state) {
+    if (!MATCHER.matches(methodInvocationTree, state)) {
+      return Description.NO_MATCH;
+    }
+    if (methodInvocationTree.getArguments().size() < 2) {
+      return Description.NO_MATCH;
+    }
+    List<? extends ExpressionTree> args = methodInvocationTree.getArguments();
+    int numArgs = args.size();
+    for (int i = 1; i < numArgs; i++) {
+      if (!ASTHelpers.sameVariable(args.get(0), args.get(i))) {
+        continue;
+      }
+      // Special case in case there are only two args and they're same.
+      // checkNotNull(T reference, Object errorMessage)
+      if (numArgs == 2 && i == 1) {
+        return describeMatch(
+            args.get(1),
+            SuggestedFix.replace(
+                args.get(1),
+                String.format("\"%s must not be null\"", state.getSourceForNode(args.get(0)))));
+      }
+      return describeMatch(methodInvocationTree);
+    }
+    return Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UngroupedOverloads.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UngroupedOverloads.java
@@ -145,10 +145,10 @@ public class UngroupedOverloads extends BugChecker implements ClassTreeMatcher {
     if (overloads.stream().anyMatch(m -> isSuppressed(m.tree()))) {
       return;
     }
-    // build a fix that deletes all but the first overload, and adds them back immediately after
-    // the first overload
+    // build a fix that replaces the first overload with all the overloads grouped together
     SuggestedFix.Builder fixBuilder = SuggestedFix.builder();
     StringBuilder sb = new StringBuilder("\n");
+    sb.append(state.getSourceForNode(first.tree()));
     overloads.stream()
         .filter(o -> o != first)
         .forEach(
@@ -158,7 +158,7 @@ public class UngroupedOverloads extends BugChecker implements ClassTreeMatcher {
               sb.append(state.getSourceCode(), start, end).append('\n');
               fixBuilder.replace(start, end, "");
             });
-    fixBuilder.postfixWith(first.tree(), sb.toString());
+    fixBuilder.replace(first.tree(), sb.toString());
     SuggestedFix fix = fixBuilder.build();
     LineMap lineMap = state.getPath().getCompilationUnit().getLineMap();
     // emit findings for each overload

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -200,6 +200,7 @@ import com.google.errorprone.bugpatterns.ParameterComment;
 import com.google.errorprone.bugpatterns.ParameterName;
 import com.google.errorprone.bugpatterns.PreconditionsCheckNotNull;
 import com.google.errorprone.bugpatterns.PreconditionsCheckNotNullPrimitive;
+import com.google.errorprone.bugpatterns.PreconditionsCheckNotNullRepeated;
 import com.google.errorprone.bugpatterns.PreconditionsInvalidPlaceholder;
 import com.google.errorprone.bugpatterns.PredicateIncompatibleType;
 import com.google.errorprone.bugpatterns.PrimitiveArrayPassedToVarargsMethod;
@@ -653,6 +654,7 @@ public class BuiltInCheckerSuppliers {
           OverridesGuiceInjectableMethod.class,
           OverrideThrowableToString.class,
           ParameterName.class,
+          PreconditionsCheckNotNullRepeated.class,
           PreconditionsInvalidPlaceholder.class,
           ProtoRedundantSet.class,
           ProtoDurationGetSecondsGetNano.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/CompileTimeConstantCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/CompileTimeConstantCheckerTest.java
@@ -16,6 +16,7 @@
 
 package com.google.errorprone.bugpatterns;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,7 +49,7 @@ public class CompileTimeConstantCheckerTest {
             "public class CompileTimeConstantTestCase {",
             "  public static void m(@CompileTimeConstant String s) { }",
             "  @SuppressWarnings(\"CompileTimeConstant\")",
-            " // BUG: Diagnostic contains: Non-compile-time constant expression passed",
+            "  // BUG: Diagnostic contains: Non-compile-time constant expression passed",
             "  public static void r(String x) { m(x); }",
             "}")
         .doTest();
@@ -338,6 +339,25 @@ public class CompileTimeConstantCheckerTest {
             "    m(x); ",
             "  }",
             "}")
+        .doTest();
+  }
+
+  @Test
+  public void testMatches_methodReference() {
+    compilationHelper
+        .addSourceLines(
+            "test/CompileTimeConstantTestCase.java",
+            "package test;",
+            "import com.google.errorprone.annotations.CompileTimeConstant;",
+            "import java.util.function.Consumer;",
+            "public class CompileTimeConstantTestCase {",
+            "  public static void m(@CompileTimeConstant String s) { }",
+            "  public static Consumer<String> r(String x) {",
+            "    // BUG: Diagnostic contains: References to methods with @CompileTimeConstant",
+            "    return CompileTimeConstantTestCase::m;",
+            "  }",
+            "}")
+        .setArgs(ImmutableList.of("-XepOpt:CompileTimeConstantChecker:ForbidMethodReferences=true"))
         .doTest();
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullRepeatedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullRepeatedTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link PreconditionsCheckNotNullRepeated} check.
+ *
+ * @author bhagwani@google.com (Sumit Bhagwani)
+ */
+@RunWith(JUnit4.class)
+public class PreconditionsCheckNotNullRepeatedTest {
+
+  private final BugCheckerRefactoringTestHelper testHelper =
+      BugCheckerRefactoringTestHelper.newInstance(
+          new PreconditionsCheckNotNullRepeated(), getClass());
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(PreconditionsCheckNotNullRepeated.class, getClass());
+
+  @Test
+  public void testPositiveMatchesWithReplacement() {
+    testHelper
+        .addInputLines(
+            "in/Test.java",
+            "import static com.google.common.base.Preconditions.checkNotNull;",
+            "import com.google.common.base.Preconditions;",
+            "public class Test {",
+            "  public void error() {",
+            "    Object someObject = new Object();",
+            "    Preconditions.checkNotNull(someObject, someObject);",
+            "    checkNotNull(someObject, someObject);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "import static com.google.common.base.Preconditions.checkNotNull;",
+            "import com.google.common.base.Preconditions;",
+            "public class Test {",
+            "  public void error() {",
+            "    Object someObject = new Object();",
+            "    Preconditions.checkNotNull(someObject, \"someObject must not be null\");",
+            "    checkNotNull(someObject, \"someObject must not be null\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void flagArgInVarargs() {
+    compilationHelper
+        .addSourceLines(
+            "out/Test.java",
+            "import static com.google.common.base.Preconditions.checkNotNull;",
+            "import com.google.common.base.Preconditions;",
+            "public class Test {",
+            "  public void notError() {",
+            "    Object obj = new Object();",
+            "    // BUG: Diagnostic contains: PreconditionsCheckNotNullRepeated",
+            "    Preconditions.checkNotNull(obj, \"%s must not be null\", obj);",
+            "    String s = \"test string\";",
+            "    // BUG: Diagnostic contains: PreconditionsCheckNotNullRepeated",
+            "    Preconditions.checkNotNull(s, s, s);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testNegativeCases() {
+    compilationHelper
+        .addSourceLines(
+            "out/Test.java",
+            "import static com.google.common.base.Preconditions.checkNotNull;",
+            "import com.google.common.base.Preconditions;",
+            "public class Test {",
+            "  public void notError() {",
+            "    Object obj = new Object();",
+            "    Preconditions.checkNotNull(obj);",
+            "    Preconditions.checkNotNull(obj, \"obj\");",
+            "    Preconditions.checkNotNull(obj, \"check with message\");",
+            "    Preconditions.checkNotNull(obj, \"check with msg and an arg %s\", new Object());",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UngroupedOverloadsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UngroupedOverloadsTest.java
@@ -196,10 +196,11 @@ public final class UngroupedOverloadsTest {
         .addOutputLines(
             "out/Test.java",
             "class Test {",
-            "  void foo() {}",
             "",
+            "  void foo() {}",
             "  /** doc */",
             "  void foo(int x) {}",
+            "",
             "  void bar() {}",
             "}")
         .doTest(TestMode.TEXT_MATCH);
@@ -224,5 +225,51 @@ public final class UngroupedOverloadsTest {
             "  private void foo(int a, int b, int c, int d) {}",
             "}")
         .doTest();
+  }
+
+  @Test
+  public void interleavedUngroupedOverloads() {
+    refactoringHelper
+        .addInputLines(
+            "in/Test.java",
+            "class Test {",
+            "  void foo() {",
+            "    System.err.println();",
+            "  }",
+            "",
+            "  void bar() {",
+            "    System.err.println();",
+            "  }",
+            "",
+            "  void foo(int x) {",
+            "    System.err.println();",
+            "  }",
+            "",
+            "  void bar(int x) {",
+            "    System.err.println();",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "class Test {",
+            "",
+            "  void foo() {",
+            "    System.err.println();",
+            "  }",
+            "",
+            "  void foo(int x) {",
+            "    System.err.println();",
+            "  }",
+            "",
+            "  void bar() {",
+            "    System.err.println();",
+            "  }",
+            "",
+            "  void bar(int x) {",
+            "    System.err.println();",
+            "  }",
+            "}")
+        .setArgs("-XepOpt:UngroupedOverloads:FindingsOnFirstOverload")
+        .doTest(TestMode.TEXT_MATCH);
   }
 }

--- a/docs/bugpattern/CompileTimeConstant.md
+++ b/docs/bugpattern/CompileTimeConstant.md
@@ -1,4 +1,9 @@
 A method or constructor with one or more parameters whose declaration is
-annotated with the @CompileTimeConstant type annotation must only be invoked
+annotated with the `@CompileTimeConstant` type annotation must only be invoked
 with corresponding actual parameters that are computed as compile-time constant
 expressions, such as a literal or static final constant.
+
+Getting Java 8 references to methods with `@CompileTimeConstant` parameters is
+disallowed because we couldn't check if the method reference is later applied
+to a compile-time constant. Use the methods directly instead.
+

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <truth.version>0.36</truth.version>
     <javac.version>9+181-r4173-1</javac.version>
     <autovalue.version>1.5.3</autovalue.version>
-    <junit.version>4.13-SNAPSHOT</junit.version>
+    <junit.version>4.13-beta-1</junit.version>
     <dataflow.version>2.5.3</dataflow.version>
     <mockito.version>1.9.5</mockito.version>
   </properties>

--- a/test_helpers/src/main/java/com/google/errorprone/BugCheckerRefactoringTestHelper.java
+++ b/test_helpers/src/main/java/com/google/errorprone/BugCheckerRefactoringTestHelper.java
@@ -222,14 +222,20 @@ public class BugCheckerRefactoringTestHelper {
       throws IOException {
     JavacTool tool = JavacTool.create();
     DiagnosticCollector<JavaFileObject> diagnosticsCollector = new DiagnosticCollector<>();
-    context.put(ErrorProneOptions.class, ErrorProneOptions.empty());
+    ErrorProneOptions errorProneOptions;
+    try {
+      errorProneOptions = ErrorProneOptions.processArgs(options);
+    } catch (InvalidCommandLineOptionException e) {
+      throw new IllegalArgumentException("Exception during argument processing: " + e);
+    }
+    context.put(ErrorProneOptions.class, errorProneOptions);
     JavacTaskImpl task =
         (JavacTaskImpl)
             tool.getTask(
                 CharStreams.nullWriter(),
                 fileManager,
                 diagnosticsCollector,
-                options,
+                ImmutableList.copyOf(errorProneOptions.getRemainingArgs()),
                 /*classes=*/ null,
                 files,
                 context);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a check for repeated arguments in Preconditions.checkNotNull

RELNOTES: Adds a check for repeated arguments in Preconditions.checkNotNull

43b44da2a2ed1611ee4b1a193ffdd286258478de

-------

<p> RELNOTES: Disallow references to methods with @CompileTimeConstant parameters.

We are currently not able to check if the method reference is later applied to a @CompileTimeConstant thus we are banning getting references to methods accepting @CompileTimeConstant.

This is controlled by the CompileTimeConstantChecker:ForbidMethodReferences flag for the time being.

93144c7c67575650e6672477838ca4658db11ca7

-------

<p> Handle -Xep flags in BugCheckerRefactoringTestHelper

RELNOTES: N/A

66dfda3245d44433de586a50fac790362e18def2

-------

<p> Recognize expectNoDiagnostics as a non-terminal method in MissingTestCall

RELNOTES: N/A

500510859b03e0d7050defc8605c5b97cb9a2e0d

-------

<p> Refactor the repetitive bulk of ErrorProneScanner.

This results in no behavioral change now, but will enable later
adjustments to the way that suppressions are handled without a pile
of copy-pasted code.

RELNOTES: n/a

8e271883ff0e3b70f111691f4fe752a43e22c19e

-------

<p> Use JUnit 4.13-beta-1

Instead of 4.13-SNAPSHOT.

See:
- https://github.com/junit-team/junit4/releases/tag/r4.13-beta-1

Fixes #1188

ec0e0764e3bb166dc91832a1e01dcf5021cf1f88

-------

<p> Adjust fix for UngroupedOverloads

Use a replacement instead of a postfix insertion, to better handle
situations where there are multiple interleaved sets of ungrouped
overloads.

RELNOTES: N/A

a59658dce3af24ab6c7c3bb57174a8e8cdbe2d9c