### PR TITLE
Fix errors when suggesting replacements to Lombok generated code

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/JavacErrorDescriptionListener.java
+++ b/check_api/src/main/java/com/google/errorprone/JavacErrorDescriptionListener.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.errorprone.fixes.AppliedFix;
 import com.google.errorprone.fixes.Fix;
+import com.google.errorprone.fixes.Replacement;
 import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.tools.javac.tree.EndPosTable;
@@ -68,7 +69,15 @@ public class JavacErrorDescriptionListener implements DescriptionListener {
     checkNotNull(endPositions);
     try {
       CharSequence sourceFileContent = sourceFile.getCharContent(true);
-      fixToAppliedFix = fix -> AppliedFix.fromSource(sourceFileContent, endPositions).apply(fix);
+      fixToAppliedFix = fix -> {
+        try {
+          return AppliedFix.fromSource(sourceFileContent, endPositions).apply(fix);
+        } catch (Replacement.InvalidReplacementPositionException e) {
+          // Not possible to auto-suggest a fix, for example inside
+          // Lombok auto-generated code
+          return null;
+        }
+      };
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/check_api/src/main/java/com/google/errorprone/fixes/Replacement.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/Replacement.java
@@ -34,12 +34,13 @@ public abstract class Replacement {
    * @param replaceWith the replacement text
    */
   public static Replacement create(int startPosition, int endPosition, String replaceWith) {
-    checkArgument(
-        startPosition >= 0 && startPosition <= endPosition,
-        "invalid replacement: [%s, %s) (%s)",
-        startPosition,
-        endPosition,
-        replaceWith);
+    if (startPosition < 0 || startPosition > endPosition) {
+      throw new InvalidReplacementPositionException(String.format(
+              "invalid replacement: [%s, %s) (%s)",
+              startPosition,
+              endPosition,
+              replaceWith));
+    }
     return new AutoValue_Replacement(Range.closedOpen(startPosition, endPosition), replaceWith);
   }
 
@@ -63,4 +64,10 @@ public abstract class Replacement {
 
   /** The source text to appear in the output. */
   public abstract String replaceWith();
+
+  public static class InvalidReplacementPositionException extends IllegalArgumentException {
+    public InvalidReplacementPositionException(String message) {
+      super(message);
+    }
+  }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AbstractReferenceEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AbstractReferenceEquality.java
@@ -25,6 +25,7 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
 import com.google.errorprone.dataflow.nullnesspropagation.Nullness;
 import com.google.errorprone.fixes.Fix;
+import com.google.errorprone.fixes.Replacement;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
@@ -79,7 +80,12 @@ public abstract class AbstractReferenceEquality extends BugChecker implements Bi
     }
 
     Description.Builder builder = buildDescription(tree);
-    addFixes(builder, tree, state);
+    try {
+      addFixes(builder, tree, state);
+    } catch (Replacement.InvalidReplacementPositionException e) {
+      // Not possible to auto-suggest a fix, for example inside
+      // Lombok auto-generated setters which use "=="
+    }
     return builder.build();
   }
 


### PR DESCRIPTION
I am trying to introduce `error-prone` to a large codebase which uses Lombok (see also #1185).

I have found that a few rules attempt to suggest fixes to code that Lombok has auto-generated, particularly "setters" and "withers" which use reference equality in a way that upsets some rules.

This auto-generated bytecode does not have valid positions in the sourcecode files, so fix suggestion throws an exception.

This change ignores that exception and skips the fixes in question.