### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/VisitorState.java
+++ b/check_api/src/main/java/com/google/errorprone/VisitorState.java
@@ -104,7 +104,7 @@ public class VisitorState {
         typeCache != null
             ? typeCache
             : CacheBuilder.newBuilder()
-                .concurrencyLevel(1) // resolving symbols in javac is not is not thread-safe
+                .concurrencyLevel(1) // resolving symbols in javac is not thread-safe
                 .build(
                     new CacheLoader<String, Optional<Type>>() {
                       @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DiscardedPostfixExpression.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DiscardedPostfixExpression.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.UnaryTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
+import com.sun.source.tree.UnaryTree;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.tree.JCTree.JCLambda;
+
+/** @author cushon@google.com (Liam Miller-Cushon) */
+@BugPattern(
+    name = "DiscardedPostfixExpression",
+    summary = "The result of this unary operation on a lambda parameter is discarded",
+    severity = SeverityLevel.ERROR,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+public class DiscardedPostfixExpression extends BugChecker implements UnaryTreeMatcher {
+
+  @Override
+  public Description matchUnary(UnaryTree tree, VisitorState state) {
+    switch (tree.getKind()) {
+      case POSTFIX_INCREMENT:
+      case POSTFIX_DECREMENT:
+        break;
+      default:
+        return NO_MATCH;
+    }
+    Tree parent = state.getPath().getParentPath().getLeaf();
+    if (parent.getKind() != Kind.LAMBDA_EXPRESSION) {
+      return NO_MATCH;
+    }
+    JCLambda lambda = (JCLambda) parent;
+    Symbol sym = ASTHelpers.getSymbol(tree.getExpression());
+    if (lambda.getParameters().stream().noneMatch(p -> ASTHelpers.getSymbol(p) == sym)) {
+      return NO_MATCH;
+    }
+    return describeMatch(
+        tree,
+        SuggestedFix.replace(
+            tree,
+            String.format(
+                "%s %s 1",
+                state.getSourceForNode(tree.getExpression()),
+                tree.getKind() == Kind.POSTFIX_INCREMENT ? "+" : "-")));
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/WildcardImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/WildcardImport.java
@@ -205,7 +205,8 @@ public class WildcardImport extends BugChecker implements CompilationUnitTreeMat
     }
     for (Map.Entry<Symbol, List<TypeToImport>> entry : toFix.entrySet()) {
       final Symbol owner = entry.getKey();
-      if (entry.getValue().size() > MAX_MEMBER_IMPORTS) {
+      if (entry.getKey().getKind() != ElementKind.PACKAGE
+          && entry.getValue().size() > MAX_MEMBER_IMPORTS) {
         qualifiedNameFix(fix, owner, state);
       } else {
         for (TypeToImport toImport : entry.getValue()) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/InheritDoc.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/InheritDoc.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.javadoc;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.bugpatterns.javadoc.Utils.diagnosticPosition;
+import static com.google.errorprone.util.ASTHelpers.findSuperMethods;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.BugPattern.StandardTags;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.InheritDocTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.DocTreePath;
+import com.sun.source.util.DocTreePathScanner;
+import com.sun.source.util.SimpleTreeVisitor;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+
+/**
+ * Matches invalid usage of {@literal @inheritDoc}.
+ *
+ * @author ghm@google.com (Graeme Morgan)
+ */
+@BugPattern(
+    name = "InheritDoc",
+    summary = "Invalid use of @inheritDoc.",
+    severity = WARNING,
+    tags = StandardTags.STYLE,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+public final class InheritDoc extends BugChecker
+    implements ClassTreeMatcher, MethodTreeMatcher, VariableTreeMatcher {
+
+  @Override
+  public Description matchClass(ClassTree classTree, VisitorState state) {
+    return handle(state);
+  }
+
+  @Override
+  public Description matchMethod(MethodTree methodTree, VisitorState state) {
+    return handle(state);
+  }
+
+  @Override
+  public Description matchVariable(VariableTree variableTree, VisitorState state) {
+    return handle(state);
+  }
+
+  private Description handle(VisitorState state) {
+    DocTreePath path = Utils.getDocTreePath(state);
+    if (path != null) {
+      new InheritDocChecker(state).scan(path, null);
+    }
+    return Description.NO_MATCH;
+  }
+
+  private final class InheritDocChecker extends DocTreePathScanner<Void, Void> {
+    private final VisitorState state;
+
+    private InheritDocChecker(VisitorState state) {
+      this.state = state;
+    }
+
+    @Override
+    public Void visitInheritDoc(InheritDocTree inheritDocTree, Void unused) {
+      new SimpleTreeVisitor<Void, Void>() {
+        @Override
+        public Void visitVariable(VariableTree variableTree, Void unused) {
+          state.reportMatch(
+              buildDescription(diagnosticPosition(getCurrentPath(), state))
+                  .setMessage(
+                      "@inheritDoc doesn't make sense on variables as "
+                          + "they cannot override a super element.")
+                  .build());
+          return null;
+        }
+
+        @Override
+        public Void visitMethod(MethodTree methodTree, Void unused) {
+          MethodSymbol methodSymbol = getSymbol(methodTree);
+          if (methodSymbol != null && findSuperMethods(methodSymbol, state.getTypes()).isEmpty()) {
+            state.reportMatch(
+                buildDescription(diagnosticPosition(getCurrentPath(), state))
+                    .setMessage(
+                        "This method does not override anything to inherit documentation from.")
+                    .build());
+          }
+          return null;
+        }
+
+        @Override
+        public Void visitClass(ClassTree classTree, Void unused) {
+          if (classTree.getExtendsClause() == null && classTree.getImplementsClause().isEmpty()) {
+            state.reportMatch(
+                buildDescription(diagnosticPosition(getCurrentPath(), state))
+                    .setMessage(
+                        "This class does not extend or implement anything to inherit "
+                            + "documentation from.")
+                    .build());
+          }
+          return null;
+        }
+      }.visit(getCurrentPath().getTreePath().getLeaf(), null);
+      return super.visitInheritDoc(inheritDocTree, null);
+    }
+
+    @Override
+    public Void scan(DocTree docTree, Void aVoid) {
+      return super.scan(docTree, aVoid);
+    }
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/MissingSummary.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/MissingSummary.java
@@ -66,6 +66,10 @@ import javax.lang.model.element.Modifier;
 public final class MissingSummary extends BugChecker
     implements ClassTreeMatcher, MethodTreeMatcher, VariableTreeMatcher {
 
+  private static final String CONSIDER_USING_MESSAGE =
+      "A summary fragment is required; consider using the value of the @%s block as a "
+          + "summary fragment instead.";
+
   @Override
   public Description matchClass(ClassTree classTree, VisitorState state) {
     return handle(getDocTreePath(state), state);
@@ -131,9 +135,7 @@ public final class MissingSummary extends BugChecker
                     lowerFirstLetter(description), description.endsWith(".") ? "" : "."))
             .build();
     return buildDescription(diagnosticPosition(docTreePath, state))
-        .setMessage(
-            "A summary fragment is required; the value of @return might make a"
-                + " good summary of this method.")
+        .setMessage(String.format(CONSIDER_USING_MESSAGE, "link"))
         .addFix(fix)
         .build();
   }
@@ -151,7 +153,7 @@ public final class MissingSummary extends BugChecker
                     seeTree.getReference().stream().map(Object::toString).collect(joining(" "))))
             .build();
     return buildDescription(diagnosticPosition(docTreePath, state))
-        .setMessage("A summary fragment is required; the value of @see might make a good summary.")
+        .setMessage(String.format(CONSIDER_USING_MESSAGE, "see"))
         .addFix(fix)
         .build();
   }

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -76,6 +76,7 @@ import com.google.errorprone.bugpatterns.DeadThread;
 import com.google.errorprone.bugpatterns.DeduplicateConstants;
 import com.google.errorprone.bugpatterns.DefaultCharset;
 import com.google.errorprone.bugpatterns.DepAnn;
+import com.google.errorprone.bugpatterns.DiscardedPostfixExpression;
 import com.google.errorprone.bugpatterns.DivZero;
 import com.google.errorprone.bugpatterns.DoNotCallChecker;
 import com.google.errorprone.bugpatterns.DoubleBraceInitialization;
@@ -452,6 +453,7 @@ public class BuiltInCheckerSuppliers {
           ComplexBooleanConstant.class,
           ConditionalExpressionNumericPromotion.class,
           ConstantOverflow.class,
+          DiscardedPostfixExpression.class,
           DeadException.class,
           DeadThread.class,
           DoNotCallChecker.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -333,6 +333,7 @@ import com.google.errorprone.bugpatterns.inject.guice.InjectOnFinalField;
 import com.google.errorprone.bugpatterns.inject.guice.OverridesGuiceInjectableMethod;
 import com.google.errorprone.bugpatterns.inject.guice.OverridesJavaxInjectableMethod;
 import com.google.errorprone.bugpatterns.inject.guice.ProvidesMethodOutsideOfModule;
+import com.google.errorprone.bugpatterns.javadoc.InheritDoc;
 import com.google.errorprone.bugpatterns.javadoc.InvalidParam;
 import com.google.errorprone.bugpatterns.javadoc.InvalidTag;
 import com.google.errorprone.bugpatterns.javadoc.InvalidThrows;
@@ -733,6 +734,7 @@ public class BuiltInCheckerSuppliers {
           IterablePathParameter.class,
           JMockTestWithoutRunWithOrRuleAnnotation.class,
           Java7ApiChecker.class,
+          InheritDoc.class,
           InvalidTag.class,
           InvalidParam.class,
           ReturnFromVoid.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/CompileTimeConstantCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/CompileTimeConstantCheckerTest.java
@@ -360,4 +360,42 @@ public class CompileTimeConstantCheckerTest {
         .setArgs(ImmutableList.of("-XepOpt:CompileTimeConstantChecker:ForbidMethodReferences=true"))
         .doTest();
   }
+
+  @Test
+  public void testMatches_lambdaExpression() {
+    compilationHelper
+        .addSourceLines(
+            "test/CompileTimeConstantTestCase.java",
+            "package test;",
+            "import com.google.errorprone.annotations.CompileTimeConstant;",
+            "import java.util.function.Consumer;",
+            "public class CompileTimeConstantTestCase {",
+            "  // BUG: Diagnostic contains: Lambda expressions with @CompileTimeConstant",
+            "  Consumer<String> c = (@CompileTimeConstant String s) -> {};",
+            "}")
+        .setArgs(ImmutableList.of("-XepOpt:CompileTimeConstantChecker:ForbidMethodReferences=true"))
+        .doTest();
+  }
+
+  @Test
+  public void testMatches_lambdaExpressionWithoutExplicitFormalParameters() {
+    compilationHelper
+        .addSourceLines(
+            "test/CompileTimeConstantTestCase.java",
+            "package test;",
+            "import com.google.errorprone.annotations.CompileTimeConstant;",
+            "public class CompileTimeConstantTestCase {",
+            "  @FunctionalInterface",
+            "  interface I {",
+            "    void f(@CompileTimeConstant String x);",
+            "  }",
+            "  void f(String s) {",
+            "    I i = x -> {};",
+            "    // BUG: Diagnostic contains: Non-compile-time constant expression passed",
+            "    i.f(s);",
+            "  }",
+            "}")
+        .setArgs(ImmutableList.of("-XepOpt:CompileTimeConstantChecker:ForbidMethodReferences=true"))
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/DiscardedPostfixExpressionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/DiscardedPostfixExpressionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** {@link DiscardedPostfixExpression}Test */
+@RunWith(JUnit4.class)
+public final class DiscardedPostfixExpressionTest {
+  @Test
+  public void negative() {
+    CompilationTestHelper.newInstance(DiscardedPostfixExpression.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            "import java.util.function.UnaryOperator;",
+            "class Test {",
+            "  int x;",
+            "  UnaryOperator<Integer> f = x1 -> x++;",
+            "  UnaryOperator<Integer> g = x1 -> x--;",
+            "  UnaryOperator<Integer> h = x -> ++x;",
+            "  UnaryOperator<Integer> i = x -> --x;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void refactoring() {
+    BugCheckerRefactoringTestHelper.newInstance(new DiscardedPostfixExpression(), getClass())
+        .addInputLines(
+            "Test.java",
+            "import java.util.function.UnaryOperator;",
+            "class Test {",
+            "  UnaryOperator<Integer> f = x -> x++;",
+            "  UnaryOperator<Integer> g = x -> x--;",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.util.function.UnaryOperator;",
+            "class Test {",
+            "  UnaryOperator<Integer> f = x -> x + 1;",
+            "  UnaryOperator<Integer> g = x -> x - 1;",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MultiVariableDeclarationTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MultiVariableDeclarationTest.java
@@ -173,12 +173,8 @@ public class MultiVariableDeclarationTest {
             "out/A.java",
             "package a;",
             "public class A {",
-            // javac's pretty printer uses the system line separator
-            "  @Deprecated()"
-                + System.lineSeparator()
-                + "int x = 1; @Deprecated()"
-                + System.lineSeparator()
-                + "int y = 2;",
+            "  @Deprecated int x = 1;",
+            "  @Deprecated int y = 2;",
             "}")
         .doTest(TEXT_MATCH);
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TypeNameShadowingTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TypeNameShadowingTest.java
@@ -308,4 +308,16 @@ public class TypeNameShadowingTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void fieldClashOk() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  final Object T = new Object();",
+            "  <T> void doIt(T t) {}",
+            "}")
+        .doTest();
+  }
 }

--- a/docs/bugpattern/CompileTimeConstant.md
+++ b/docs/bugpattern/CompileTimeConstant.md
@@ -7,3 +7,6 @@ Getting Java 8 references to methods with `@CompileTimeConstant` parameters is
 disallowed because we couldn't check if the method reference is later applied
 to a compile-time constant. Use the methods directly instead.
 
+
+For the same reason, it's also disallowed to create lambda expressions with
+`@CompileTimeConstant` parameters.

--- a/docs/bugpattern/javadoc/InheritDoc.md
+++ b/docs/bugpattern/javadoc/InheritDoc.md
@@ -1,0 +1,11 @@
+The `@inheritDoc` tag should only be used on classes/interfaces which extend or
+implement another and methods which override a method from a superclass.
+
+```java {.bad}
+class Frobnicator {
+  /** {@inheritDoc} */
+  public void frobnicate() {
+    // ...
+  }
+}
+```


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Resolve unintended double-negation.

RELNOTES: n/a

faf56a45184366ea16c3d1a43c675563b976ec8d

-------

<p> Change TypeNameShadowing to not complain about clashes between type parameters
and other program elements like fields, only other type names.

AFAICT, the intent of this check was to complain about clashes with other types,
not fields et al. See the description of 0aa9d3f13700c82a86d32a9db344dbb257dff412

RELNOTES: none

6c249b9514d6af9cd7fa829889ea14e08cd36567

-------

<p> Adjust MissingSummary description.

RELNOTES: N/A

35e7317613677fcb96434c48e8135d867b3210c5

-------

<p> Add a Javadoc checker to validate usage of @inheritDoc.

Specifically, it only makes sense (as far as I can tell!) on methods marked @Override and classes which extend or implement something.

RELNOTES: Validate usage of @inheritDoc

e86dcf93946c32b12d7a0ee5a6ac8914877eec21

-------

<p> Improve wildcard import qualified name fix

qualified names only work for member type imports, not for wildcard
package imports.

RELNOTES: N/A

2c440007a66ddad9cf0cb8d356f96416f6146af1

-------

<p> Add a check for discarded postfix expression results

`x -> x++` is equivalent to `x -> x`; the intent was probably `x -> x + 1`.

RELNOTES: N/A

3ca7f7da9cecc788c59713db3f5b9fb747cddfe3

-------

<p> RELNOTES: Disallow lambda expressions with @CompileTimeConstant parameters.

We are currently not able to check if the lambda expression is later applied to a @CompileTimeConstant thus we are banning creating lambda expressions accepting @CompileTimeConstant.

This is controlled by the CompileTimeConstantChecker:ForbidMethodReferences flag for the time being.

fd837e763ada590e627d84491b6b3e471b0a5cce

-------

<p> Omit empty `()` from marker annotations in MultiVariableDeclaration

The fix relies on pretty-printing the desugared AST nodes for the individual
variable declarations. Normally we try to avoid pretty-printing and manipulate
source text directly, but in this case the alternative is to re-implement
parsing and desugaring multi-variable declarations.

RELNOTES: N/A

c5a61a282c2e9de9cee7c474e7d5147f6531774f