### PR TITLE
Moe Sync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <version>7</version>
   </parent>
 
-  <name>Maven parent POM</name>
+  <name>Error Prone parent POM</name>
   <groupId>com.google.errorprone</groupId>
   <artifactId>error_prone_parent</artifactId>
   <version>2.3.3-SNAPSHOT</version>
@@ -115,6 +115,7 @@
         <version>3.0.0</version>
         <configuration>
           <notimestamp>true</notimestamp>
+          <doctitle>Error Prone ${project.version} API</doctitle>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Tell Maven the project is called "Error Prone", not "Maven parent POM"

In particular this makes the Javadocs look nicer. The existing docs at
errorprone.info/api/latest have a header reading
"Maven parent POM 2.3.3-SNAPSHOT API". After this change, that header
instead reads "Error Prone 2.3.2-SNAPSHOT API".

78eb8520c7bbaf0c341fa89c5c0fe1755168b515