### PR TITLE
Add IntelliJ IDEA ImportOrganizer

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/ImportOrderParser.java
+++ b/check_api/src/main/java/com/google/errorprone/ImportOrderParser.java
@@ -36,6 +36,8 @@ public class ImportOrderParser {
         return ImportOrganizer.ANDROID_STATIC_FIRST_ORGANIZER;
       case "android-static-last":
         return ImportOrganizer.ANDROID_STATIC_LAST_ORGANIZER;
+      case "idea":
+        return ImportOrganizer.IDEA_ORGANIZER;
       default:
         throw new IllegalStateException("Unknown import order: '" + importOrder + "'");
     }

--- a/check_api/src/main/java/com/google/errorprone/apply/IdeaImportOrganizer.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/IdeaImportOrganizer.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.apply;
+
+import static com.google.common.collect.ImmutableSortedSet.toImmutableSortedSet;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Organizes imports based on the default format provided by IntelliJ IDEA.
+ *
+ * <p>This groups the imports into three groups, each delimited by a newline:
+ *
+ * <ol>
+ *   <li>Non-static, non-{@code java.*}, non-{@code javax.*} imports.
+ *   <li>{@code javax.*} and {@code java.*} imports, with {@code javax.*} imports ordered first.
+ *   <li>Static imports.
+ * </ol>
+ */
+public class IdeaImportOrganizer implements ImportOrganizer {
+
+  private static final String JAVA_PREFIX = "java.";
+
+  private static final String JAVAX_PREFIX = "javax.";
+
+  @Override
+  public OrganizedImports organizeImports(List<Import> imports) {
+    Map<PackageType, ImmutableSortedSet<Import>> partitioned =
+        imports.stream()
+            .collect(Collectors.groupingBy(
+                IdeaImportOrganizer::getPackageType,
+                TreeMap::new,
+                toImmutableSortedSet(IdeaImportOrganizer::compareImport)));
+
+    return new OrganizedImports()
+        .addGroups(
+            partitioned,
+            ImmutableList.of(
+                PackageType.NON_STATIC,
+                PackageType.JAVAX_JAVA,
+                PackageType.STATIC));
+  }
+
+  private static int compareImport(Import a, Import b) {
+    if (a.isStatic() || b.isStatic()) {
+      return a.getType().compareTo(b.getType());
+    } else if (a.getType().startsWith(JAVA_PREFIX) && b.getType().startsWith(JAVAX_PREFIX)) {
+      return 1;
+    } else if (a.getType().startsWith(JAVAX_PREFIX) && b.getType().startsWith(JAVA_PREFIX)) {
+      return -1;
+    } else {
+      return a.getType().compareTo(b.getType());
+    }
+  }
+
+  private static PackageType getPackageType(Import anImport) {
+    if (anImport.isStatic()) {
+      return PackageType.STATIC;
+    } else if (anImport.getType().startsWith(JAVA_PREFIX)) {
+      return PackageType.JAVAX_JAVA;
+    } else if (anImport.getType().startsWith(JAVAX_PREFIX)) {
+      return PackageType.JAVAX_JAVA;
+    } else {
+      return PackageType.NON_STATIC;
+    }
+  }
+
+  private enum PackageType {
+    JAVAX_JAVA,
+    NON_STATIC,
+    STATIC
+  }
+}

--- a/check_api/src/main/java/com/google/errorprone/apply/ImportOrganizer.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/ImportOrganizer.java
@@ -89,6 +89,20 @@ public interface ImportOrganizer {
   ImportOrganizer ANDROID_STATIC_LAST_ORGANIZER =
       new AndroidImportOrganizer(StaticOrder.STATIC_LAST);
 
+  /**
+   * An {@link ImportOrganizer} that organizes imports based on the default format provided by IntelliJ IDEA.
+   *
+   * <p>This groups the imports into three groups, each delimited by a newline:
+   *
+   * <ol>
+   *   <li>Non-static, non-{@code java.*}, non-{@code javax.*} imports.
+   *   <li>{@code javax.*} and {@code java.*} imports, with {@code javax.*} imports ordered first.
+   *   <li>Static imports.
+   * </ol>
+   */
+  ImportOrganizer IDEA_ORGANIZER =
+      new IdeaImportOrganizer();
+
   /** Represents an import. */
   @AutoValue
   abstract class Import {

--- a/check_api/src/test/java/com/google/errorprone/apply/IdeaImportOrganizerTest.java
+++ b/check_api/src/test/java/com/google/errorprone/apply/IdeaImportOrganizerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.apply;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class IdeaImportOrganizerTest {
+
+  private static final List<ImportOrganizer.Import> IMPORTS =
+      ImmutableList.of(
+          "import com.android.blah",
+          "import android.foo",
+          "import java.ping",
+          "import javax.pong",
+          "import unknown.fred",
+          "import unknown.barney",
+          "import net.wilma",
+          "import static com.android.blah.blah",
+          "import static android.foo.bar",
+          "import static java.ping.pong",
+          "import static javax.pong.ping",
+          "import static unknown.fred.flintstone",
+          "import static net.wilma.flintstone")
+          .stream()
+          .map(ImportOrganizer.Import::importOf)
+          .collect(Collectors.toList());
+
+  @Test
+  public void testStaticFirstOrdering() {
+    IdeaImportOrganizer organizer = new IdeaImportOrganizer();
+    ImportOrganizer.OrganizedImports organized = organizer.organizeImports(IMPORTS);
+    assertThat(organized.asImportBlock())
+        .isEqualTo(
+            "import android.foo;\n"
+                + "import com.android.blah;\n"
+                + "import net.wilma;\n"
+                + "import unknown.barney;\n"
+                + "import unknown.fred;\n"
+                + "\n"
+                + "import javax.pong;\n"
+                + "import java.ping;\n"
+                + "\n"
+                + "import static android.foo.bar;\n"
+                + "import static com.android.blah.blah;\n"
+                + "import static java.ping.pong;\n"
+                + "import static javax.pong.ping;\n"
+                + "import static net.wilma.flintstone;\n"
+                + "import static unknown.fred.flintstone;\n");
+  }
+}


### PR DESCRIPTION
Many projects use the default import ordering provided by IntelliJ IDEA.
In order to apply Error Prone without adjusting this ordering, one can
now set `-XepPatchImportOrder:idea`.