### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/AbstractSuppressWarningsMatcher.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AbstractSuppressWarningsMatcher.java
@@ -20,6 +20,7 @@ import com.google.common.base.Joiner;
 import com.google.errorprone.bugpatterns.BugChecker.AnnotationTreeMatcher;
 import com.google.errorprone.fixes.Fix;
 import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.ExpressionTree;
@@ -44,7 +45,9 @@ abstract class AbstractSuppressWarningsMatcher extends BugChecker implements Ann
     List<String> values = new ArrayList<>();
     for (ExpressionTree argumentTree : annotationTree.getArguments()) {
       AssignmentTree assignmentTree = (AssignmentTree) argumentTree;
-      if (assignmentTree.getVariable().toString().equals("value")) {
+      if (ASTHelpers.getSymbol(assignmentTree.getVariable())
+          .getSimpleName()
+          .contentEquals("value")) {
         ExpressionTree expressionTree = assignmentTree.getExpression();
         switch (expressionTree.getKind()) {
           case STRING_LITERAL:

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ArrayEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ArrayEquals.java
@@ -62,11 +62,11 @@ public class ArrayEquals extends BugChecker implements MethodInvocationTreeMatch
     String arg1;
     String arg2;
     if (instanceEqualsMatcher.matches(t, state)) {
-      arg1 = ((JCFieldAccess) t.getMethodSelect()).getExpression().toString();
-      arg2 = t.getArguments().get(0).toString();
+      arg1 = state.getSourceForNode(((JCFieldAccess) t.getMethodSelect()).getExpression());
+      arg2 = state.getSourceForNode(t.getArguments().get(0));
     } else if (staticEqualsMatcher.matches(t, state)) {
-      arg1 = t.getArguments().get(0).toString();
-      arg2 = t.getArguments().get(1).toString();
+      arg1 = state.getSourceForNode(t.getArguments().get(0));
+      arg2 = state.getSourceForNode(t.getArguments().get(1));
     } else {
       return NO_MATCH;
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadComparable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadComparable.java
@@ -144,9 +144,19 @@ public class BadComparable extends BugChecker implements TypeCastTreeMatcher {
     ExpressionTree rhs = subtract.getRightOperand();
     Fix fix;
     if (ASTHelpers.getType(lhs).isPrimitive()) {
-      fix = SuggestedFix.replace(tree, "Long.compare(" + lhs + ", " + rhs + ")");
+      fix =
+          SuggestedFix.replace(
+              tree,
+              "Long.compare("
+                  + state.getSourceForNode(lhs)
+                  + ", "
+                  + state.getSourceForNode(rhs)
+                  + ")");
     } else {
-      fix = SuggestedFix.replace(tree, lhs + ".compareTo(" + rhs + ")");
+      fix =
+          SuggestedFix.replace(
+              tree,
+              state.getSourceForNode(lhs) + ".compareTo(" + state.getSourceForNode(rhs) + ")");
     }
     return describeMatch(tree, fix);
   }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EqualsNaN.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EqualsNaN.java
@@ -74,13 +74,14 @@ public class EqualsNaN extends BugChecker implements BinaryTreeMatcher {
     return Description.NO_MATCH;
   }
 
-  private CharSequence toString(JCTree tree, VisitorState state) {
+  @SuppressWarnings("TreeToString")
+  private static CharSequence toString(JCTree tree, VisitorState state) {
     CharSequence source = state.getSourceForNode(tree);
     return (source == null) ? tree.toString() : source;
   }
 
   @Nullable
-  private String matchNaN(ExpressionTree tree) {
+  private static String matchNaN(ExpressionTree tree) {
     Symbol sym = ASTHelpers.getSymbol(tree);
     if (sym != null
         && sym.owner != null

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FuturesGetCheckedIllegalExceptionType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FuturesGetCheckedIllegalExceptionType.java
@@ -76,7 +76,8 @@ public final class FuturesGetCheckedIllegalExceptionType extends BugChecker
       return describeUncheckedExceptionTypeMatch(
           tree,
           SuggestedFix.builder()
-              .replace(tree, "getUnchecked(" + tree.getArguments().get(0) + ")")
+              .replace(
+                  tree, "getUnchecked(" + state.getSourceForNode(tree.getArguments().get(0)) + ")")
               .addStaticImport(Futures.class.getName() + ".getUnchecked")
               .build());
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnClass.java
@@ -53,7 +53,7 @@ public class GetClassOnClass extends BugChecker implements MethodInvocationTreeM
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (getClassMethodMatcher.matches(tree, state)) {
-      String methodInvoker = ASTHelpers.getReceiver(tree).toString();
+      String methodInvoker = state.getSourceForNode(ASTHelpers.getReceiver(tree));
       Fix removeGetClass = SuggestedFix.replace(tree, methodInvoker);
       Fix changeToClassDotClass = SuggestedFix.replace(tree, "Class.class");
       return buildDescription(tree).addFix(removeGetClass).addFix(changeToClassDotClass).build();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IdentityBinaryExpression.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IdentityBinaryExpression.java
@@ -53,6 +53,7 @@ public class IdentityBinaryExpression extends BugChecker implements BinaryTreeMa
           staticMethod().anyClass().namedAnyOf("assertTrue", "assertFalse", "assertThat"));
 
   @Override
+  @SuppressWarnings("TreeToString")
   public Description matchBinary(BinaryTree tree, VisitorState state) {
     if (constValue(tree.getLeftOperand()) != null) {
       switch (tree.getKind()) {
@@ -105,6 +106,7 @@ public class IdentityBinaryExpression extends BugChecker implements BinaryTreeMa
       default:
         return NO_MATCH;
     }
+    // toString rather than getSourceForNode is intentional.
     if (!tree.getLeftOperand().toString().equals(tree.getRightOperand().toString())) {
       return NO_MATCH;
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InstanceOfAndCastMatchWrongType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InstanceOfAndCastMatchWrongType.java
@@ -70,7 +70,9 @@ public class InstanceOfAndCastMatchWrongType extends BugChecker implements TypeC
     if (castingMatcher.matches(typeCastTree, visitorState)) {
       return buildDescription(typeCastTree)
           .addFix(
-              SuggestedFix.replace(castingMatcher.nodeToReplace, typeCastTree.getType().toString()))
+              SuggestedFix.replace(
+                  castingMatcher.nodeToReplace,
+                  visitorState.getSourceForNode(typeCastTree.getType())))
           .build();
     }
     return Description.NO_MATCH;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InterfaceWithOnlyStatics.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InterfaceWithOnlyStatics.java
@@ -17,8 +17,8 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getLast;
+import static com.google.errorprone.bugpatterns.inject.dagger.DaggerAnnotations.isAnyModule;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
-import static com.google.errorprone.util.ASTHelpers.hasAnnotation;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
@@ -60,7 +60,7 @@ public final class InterfaceWithOnlyStatics extends BugChecker implements ClassT
     if (!tree.getImplementsClause().isEmpty()) {
       return Description.NO_MATCH;
     }
-    if (hasAnnotation(tree, "dagger.Module", state)) {
+    if (isAnyModule().matches(tree, state)) {
       return Description.NO_MATCH;
     }
     List<? extends Tree> members = tree.getMembers();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MathRoundIntLong.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MathRoundIntLong.java
@@ -95,6 +95,7 @@ public final class MathRoundIntLong extends BugChecker implements MethodInvocati
               .postfixWith(tree, ")")
               .build());
     }
-    throw new AssertionError("Unknown argument type to round call: " + tree);
+    throw new AssertionError(
+        "Unknown argument type to round call: " + state.getSourceForNode(tree));
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MisusedWeekYear.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MisusedWeekYear.java
@@ -36,7 +36,6 @@ import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
-import com.sun.tools.javac.tree.JCTree;
 
 /**
  * Ban use of YYYY in a SimpleDateFormat pattern, unless it is being used for a week date. Otherwise
@@ -107,7 +106,7 @@ public class MisusedWeekYear extends BugChecker
       return Description.NO_MATCH;
     }
 
-    return constructDescription(tree, tree.getArguments().get(0));
+    return constructDescription(tree, tree.getArguments().get(0), state);
   }
 
   /**
@@ -122,7 +121,7 @@ public class MisusedWeekYear extends BugChecker
       return Description.NO_MATCH;
     }
 
-    return constructDescription(tree, tree.getArguments().get(0));
+    return constructDescription(tree, tree.getArguments().get(0), state);
   }
 
   /**
@@ -131,11 +130,12 @@ public class MisusedWeekYear extends BugChecker
    * May be {@link Description#NO_MATCH} if the pattern does not have a constant value, does not use
    * the week year format specifier, or is in proper week date format.
    */
-  private Description constructDescription(Tree tree, ExpressionTree patternArg) {
-    String pattern = (String) ASTHelpers.constValue((JCTree) patternArg);
+  private Description constructDescription(
+      Tree tree, ExpressionTree patternArg, VisitorState state) {
+    String pattern = (String) ASTHelpers.constValue(patternArg);
     if (pattern != null && pattern.contains("Y") && !pattern.contains("w")) {
       if (patternArg.getKind() == Kind.STRING_LITERAL) {
-        String replacement = patternArg.toString().replace('Y', 'y');
+        String replacement = state.getSourceForNode(patternArg).replace('Y', 'y');
         return describeMatch(tree, SuggestedFix.replace(patternArg, replacement));
       } else {
         return describeMatch(tree);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MixedDescriptors.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MixedDescriptors.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+import static com.google.errorprone.predicates.TypePredicates.isDescendantOf;
+import static com.google.errorprone.util.ASTHelpers.getReceiver;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.google.errorprone.util.ASTHelpers.isSubtype;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.suppliers.Supplier;
+import com.google.errorprone.suppliers.Suppliers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.code.Symbol.TypeSymbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.code.Type;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Checks for calls to {@code Descriptor#findFieldByNumber} with field numbers from a different
+ * proto.
+ *
+ * @author ghm@google.com (Graeme Morgan)
+ */
+@BugPattern(
+    name = "MixedDescriptors",
+    summary =
+        "The field number passed into #getFieldByNumber belongs to a different proto"
+            + " to the Descriptor.",
+    severity = WARNING,
+    providesFix = REQUIRES_HUMAN_ATTENTION)
+public final class MixedDescriptors extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private static final Matcher<ExpressionTree> GET_DESCRIPTOR =
+      staticMethod().onClass(isDescendantOf("com.google.protobuf.Message")).named("getDescriptor");
+
+  private static final Matcher<ExpressionTree> FIND_FIELD =
+      instanceMethod()
+          .onDescendantOf("com.google.protobuf.Descriptors.Descriptor")
+          .named("findFieldByNumber");
+
+  private static final Supplier<Type> MESSAGE =
+      Suppliers.typeFromString("com.google.protobuf.Message");
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (!FIND_FIELD.matches(tree, state)) {
+      return Description.NO_MATCH;
+    }
+    ExpressionTree receiver = getReceiver(tree);
+    if (!GET_DESCRIPTOR.matches(receiver, state)) {
+      return Description.NO_MATCH;
+    }
+    List<? extends ExpressionTree> arguments = tree.getArguments();
+    if (arguments.size() != 1) {
+      return Description.NO_MATCH;
+    }
+    Symbol argumentSymbol = getSymbol(getOnlyElement(arguments));
+    if (!(argumentSymbol instanceof VarSymbol)
+        || !argumentSymbol.getSimpleName().toString().endsWith("_FIELD_NUMBER")) {
+      return Description.NO_MATCH;
+    }
+    Optional<TypeSymbol> descriptorType = protoType(getOnlyElement(arguments), state);
+    Optional<TypeSymbol> receiverType = protoType(receiver, state);
+    return !descriptorType.isPresent()
+            || !receiverType.isPresent()
+            || descriptorType.get().equals(receiverType.get())
+        ? Description.NO_MATCH
+        : describeMatch(tree);
+  }
+
+  private static Optional<TypeSymbol> protoType(Tree tree, VisitorState state) {
+    Symbol symbol = getSymbol(tree);
+    if (symbol != null
+        && symbol.owner instanceof ClassSymbol
+        && isSubtype(symbol.owner.type, MESSAGE.get(state), state)) {
+      return Optional.of(symbol.owner.type.tsym);
+    }
+    return Optional.empty();
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ModifyingCollectionWithItself.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ModifyingCollectionWithItself.java
@@ -162,7 +162,7 @@ public class ModifyingCollectionWithItself extends BugChecker
     if (parent instanceof ExpressionStatementTree) {
       Fix fix;
       if (instanceMethod().anyClass().named("removeAll").matches(methodInvocationTree, state)) {
-        fix = SuggestedFix.replace(methodInvocationTree, lhs + ".clear()");
+        fix = SuggestedFix.replace(methodInvocationTree, state.getSourceForNode(lhs) + ".clear()");
       } else {
         fix = SuggestedFix.delete(parent);
       }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NonOverridingEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NonOverridingEquals.java
@@ -162,7 +162,7 @@ public class NonOverridingEquals extends BugChecker implements MethodTreeMatcher
             "if (!("
                 + parameterName
                 + " instanceof "
-                + parameterType
+                + state.getSourceForNode(parameterType)
                 + ")) {\n"
                 + "  return false;\n"
                 + "}\n";
@@ -171,7 +171,8 @@ public class NonOverridingEquals extends BugChecker implements MethodTreeMatcher
         // Cast all uses of the parameter name using a recursive TreeScanner.
         new CastScanner()
             .scan(
-                methodTree.getBody(), new CastState(parameterName, parameterType.toString(), fix));
+                methodTree.getBody(),
+                new CastState(parameterName, state.getSourceForNode(parameterType), fix));
       }
 
       return describeMatch(methodTree, fix.build());

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PackageLocation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PackageLocation.java
@@ -28,6 +28,8 @@ import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.CompilationUnitTree;
+import com.sun.tools.javac.code.Symbol.PackageSymbol;
+import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
@@ -54,7 +56,11 @@ public class PackageLocation extends BugChecker implements CompilationUnitTreeMa
       return Description.NO_MATCH;
     }
 
-    String packageName = tree.getPackageName().toString();
+    PackageSymbol packageSymbol = ((JCCompilationUnit) state.getPath().getCompilationUnit()).packge;
+    if (packageSymbol == null) {
+      return Description.NO_MATCH;
+    }
+    String packageName = packageSymbol.fullname.toString();
     String actualFileName = ASTHelpers.getFileName(tree);
     if (actualFileName == null) {
       return Description.NO_MATCH;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullPrimitive.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullPrimitive.java
@@ -106,7 +106,8 @@ public class PreconditionsCheckNotNullPrimitive extends BugChecker
 
     // Assignment, return, etc.
     if (parent.getKind() != Kind.EXPRESSION_STATEMENT) {
-      return describeMatch(arg1, SuggestedFix.replace(methodInvocationTree, arg1.toString()));
+      return describeMatch(
+          arg1, SuggestedFix.replace(methodInvocationTree, state.getSourceForNode(arg1)));
     }
 
     // Comparison to null
@@ -114,11 +115,11 @@ public class PreconditionsCheckNotNullPrimitive extends BugChecker
       BinaryTree binaryExpr = (BinaryTree) arg1;
       if (binaryExpr.getLeftOperand().getKind() == Kind.NULL_LITERAL) {
         return describeMatch(
-            arg1, SuggestedFix.replace(arg1, binaryExpr.getRightOperand().toString()));
+            arg1, SuggestedFix.replace(arg1, state.getSourceForNode(binaryExpr.getRightOperand())));
       }
       if (binaryExpr.getRightOperand().getKind() == Kind.NULL_LITERAL) {
         return describeMatch(
-            arg1, SuggestedFix.replace(arg1, binaryExpr.getLeftOperand().toString()));
+            arg1, SuggestedFix.replace(arg1, state.getSourceForNode(binaryExpr.getLeftOperand())));
       }
     }
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SelfAssignment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SelfAssignment.java
@@ -116,11 +116,11 @@ public class SelfAssignment extends BugChecker
   }
 
   public Description describeForVarDecl(VariableTree tree, VisitorState state) {
-    String varDeclStr = tree.toString();
+    String varDeclStr = state.getSourceForNode(tree);
     int equalsIndex = varDeclStr.indexOf('=');
     if (equalsIndex < 0) {
       throw new IllegalStateException(
-          "Expected variable declaration to have an initializer: " + tree);
+          "Expected variable declaration to have an initializer: " + state.getSourceForNode(tree));
     }
     varDeclStr = varDeclStr.substring(0, equalsIndex - 1) + ";";
 
@@ -157,7 +157,7 @@ public class SelfAssignment extends BugChecker
     // if this is a method invocation, they must be calling checkNotNull()
     if (assignmentTree.getExpression().getKind() == METHOD_INVOCATION) {
       // change the default fix to be "checkNotNull(x)" instead of "x = checkNotNull(x)"
-      fix = SuggestedFix.replace(assignmentTree, rhs.toString());
+      fix = SuggestedFix.replace(assignmentTree, state.getSourceForNode(rhs));
       // new rhs is first argument to checkNotNull()
       rhs = stripNullCheck(rhs, state);
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SizeGreaterThanOrEqualsZero.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SizeGreaterThanOrEqualsZero.java
@@ -246,7 +246,9 @@ public class SizeGreaterThanOrEqualsZero extends BugChecker implements BinaryTre
     String expSrc = state.getSourceForNode(protoGetSize);
     java.util.regex.Matcher protoGetCountMatcher = PROTO_COUNT_METHOD_PATTERN.matcher(expSrc);
     if (!protoGetCountMatcher.find()) {
-      throw new AssertionError(protoGetSize + " does not contain a get<RepeatedField>Count method");
+      throw new AssertionError(
+          state.getSourceForNode(protoGetSize)
+              + " does not contain a get<RepeatedField>Count method");
     }
     return describeMatch(
         tree,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TruthSelfEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TruthSelfEquals.java
@@ -110,7 +110,7 @@ public class TruthSelfEquals extends BugChecker implements MethodInvocationTreeM
           .setMessage(
               generateSummary(
                   ASTHelpers.getSymbol(methodInvocationTree).getSimpleName().toString(), "passes"))
-          .addFix(suggestEqualsTesterFix(methodInvocationTree, toReplace));
+          .addFix(suggestEqualsTesterFix(methodInvocationTree, toReplace, state));
     } else if (NOT_EQUALS_MATCHER.matches(methodInvocationTree, state)) {
       description.setMessage(
           generateSummary(
@@ -156,9 +156,11 @@ public class TruthSelfEquals extends BugChecker implements MethodInvocationTreeM
   }
 
   private static Fix suggestEqualsTesterFix(
-      MethodInvocationTree methodInvocationTree, ExpressionTree toReplace) {
+      MethodInvocationTree methodInvocationTree, ExpressionTree toReplace, VisitorState state) {
     String equalsTesterSuggest =
-        "new EqualsTester().addEqualityGroup(" + toReplace + ").testEquals()";
+        "new EqualsTester().addEqualityGroup("
+            + state.getSourceForNode(toReplace)
+            + ").testEquals()";
     return SuggestedFix.builder()
         .replace(methodInvocationTree, equalsTesterSuggest)
         .addImport("com.google.common.testing.EqualsTester")

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/MislabeledAndroidString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/MislabeledAndroidString.java
@@ -92,7 +92,9 @@ public class MislabeledAndroidString extends BugChecker implements MemberSelectT
                 R_STRING_CLASSNAME,
                 preferred))
         // Keep the way tree refers to android.R.string as it is but replace the identifier
-        .addFix(SuggestedFix.replace(tree, tree.getExpression() + "." + preferred))
+        .addFix(
+            SuggestedFix.replace(
+                tree, state.getSourceForNode(tree.getExpression()) + "." + preferred))
         .build();
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringAnnotationChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringAnnotationChecker.java
@@ -125,7 +125,7 @@ public final class FormatStringAnnotationChecker extends BugChecker
               .setMessage(
                   "A parameter can only be annotated @FormatString in a method annotated "
                       + "@FormatMethod: "
-                      + param)
+                      + state.getSourceForNode(param))
               .build();
         }
         if (!isStringParam) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/DaggerAnnotations.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/DaggerAnnotations.java
@@ -22,70 +22,43 @@ import com.google.errorprone.matchers.Matcher;
 import com.sun.source.tree.Tree;
 
 /** A utility class for static analysis having to do with Dagger annotations. */
-final class DaggerAnnotations {
+public final class DaggerAnnotations {
+
   // Dagger types
   static final String BINDS_CLASS_NAME = "dagger.Binds";
   static final String PROVIDES_CLASS_NAME = "dagger.Provides";
   static final String MODULE_CLASS_NAME = "dagger.Module";
   static final String MULTIBINDS_CLASS_NAME = "dagger.multibindings.Multibinds";
 
-  // Dagger matchers
-  static <T extends Tree> Matcher<T> isModule() {
-    return hasAnnotation(MODULE_CLASS_NAME);
-  }
-
-  static <T extends Tree> Matcher<T> isProvidesMethod() {
-    return hasAnnotation(PROVIDES_CLASS_NAME);
-  }
-
-  static <T extends Tree> Matcher<T> isBindsMethod() {
-    return hasAnnotation(BINDS_CLASS_NAME);
-  }
-
-  static <T extends Tree> Matcher<T> isMultibindsMethod() {
-    return hasAnnotation(MULTIBINDS_CLASS_NAME);
-  }
-
   // Dagger Producers types
   static final String PRODUCES_CLASS_NAME = "dagger.producers.Produces";
   static final String PRODUCER_MODULE_CLASS_NAME = "dagger.producers.ProducerModule";
-
-  // Dagger Producers matchers
-  static <T extends Tree> Matcher<T> isProducerModule() {
-    return hasAnnotation(PRODUCER_MODULE_CLASS_NAME);
-  }
-
-  static <T extends Tree> Matcher<T> isProducesMethod() {
-    return hasAnnotation(PRODUCES_CLASS_NAME);
-  }
 
   // Multibinding types
   static final String INTO_SET_CLASS_NAME = "dagger.multibindings.IntoSet";
   static final String ELEMENTS_INTO_SET_CLASS_NAME = "dagger.multibindings.ElementsIntoSet";
   static final String INTO_MAP_CLASS_NAME = "dagger.multibindings.IntoMap";
 
-  static <T extends Tree> Matcher<T> isMultibindingMethod() {
-    return anyOf(
-        hasAnnotation(INTO_SET_CLASS_NAME),
-        hasAnnotation(ELEMENTS_INTO_SET_CLASS_NAME),
-        hasAnnotation(INTO_MAP_CLASS_NAME));
-  }
+  private static final Matcher<Tree> ANY_MODULE =
+      anyOf(hasAnnotation(MODULE_CLASS_NAME), hasAnnotation(PRODUCER_MODULE_CLASS_NAME));
+
+  private static final Matcher<Tree> BINDING_METHOD =
+      anyOf(hasAnnotation(PROVIDES_CLASS_NAME), hasAnnotation(PRODUCES_CLASS_NAME));
+
+  private static final Matcher<Tree> BINDING_DECLARATION_METHOD =
+      anyOf(hasAnnotation(BINDS_CLASS_NAME), hasAnnotation(MULTIBINDS_CLASS_NAME));
 
   // Common Matchers
-  static <T extends Tree> Matcher<T> isAnyModule() {
-    return anyOf(isModule(), isProducerModule());
+  public static Matcher<Tree> isAnyModule() {
+    return ANY_MODULE;
   }
 
-  static <T extends Tree> Matcher<T> isBindingMethod() {
-    return anyOf(isProvidesMethod(), isProducesMethod());
+  static Matcher<Tree> isBindingMethod() {
+    return BINDING_METHOD;
   }
 
-  static <T extends Tree> Matcher<T> isBindingDeclarationMethod() {
-    return anyOf(isBindsMethod(), isMultibindsMethod());
-  }
-
-  static <T extends Tree> Matcher<T> isAnyBindingDeclaringMethod() {
-    return anyOf(isBindingMethod(), isBindingDeclarationMethod());
+  static Matcher<Tree> isBindingDeclarationMethod() {
+    return BINDING_DECLARATION_METHOD;
   }
 
   private DaggerAnnotations() {}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationGetTemporalUnit.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationGetTemporalUnit.java
@@ -83,7 +83,10 @@ public final class DurationGetTemporalUnit extends BugChecker
       if (invalidUnit.isPresent()) {
         if (SUGGESTIONS.containsKey(invalidUnit.get())) {
           SuggestedFix.Builder builder = SuggestedFix.builder();
-          builder.replace(tree, ASTHelpers.getReceiver(tree) + SUGGESTIONS.get(invalidUnit.get()));
+          builder.replace(
+              tree,
+              state.getSourceForNode(ASTHelpers.getReceiver(tree))
+                  + SUGGESTIONS.get(invalidUnit.get()));
           return describeMatch(tree, builder.build());
         }
         return describeMatch(tree);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaDurationWithNanos.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaDurationWithNanos.java
@@ -70,7 +70,7 @@ public final class JavaDurationWithNanos extends BugChecker implements MethodInv
     String replacement =
         SuggestedFixes.qualifyType(state, builder, "java.time.Duration")
             + ".ofSeconds("
-            + receiver
+            + state.getSourceForNode(receiver)
             + ".getSeconds(), ";
 
     builder.replace(

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaDurationWithSeconds.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaDurationWithSeconds.java
@@ -66,9 +66,9 @@ public final class JavaDurationWithSeconds extends BugChecker
     String replacement =
         SuggestedFixes.qualifyType(state, builder, "java.time.Duration")
             + ".ofSeconds("
-            + secondsArg
+            + state.getSourceForNode(secondsArg)
             + ", "
-            + receiver
+            + state.getSourceForNode(receiver)
             + ".getNano())";
 
     builder.replace(tree, replacement);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaDurationConstructor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaDurationConstructor.java
@@ -66,7 +66,7 @@ public final class JodaDurationConstructor extends BugChecker implements NewClas
         SuggestedFix.replace(
             ((JCTree) tree).getStartPosition(),
             ((JCTree) millisArg).getStartPosition(),
-            tree.getIdentifier() + ".millis(");
+            state.getSourceForNode(tree.getIdentifier()) + ".millis(");
     return describeMatch(tree, fix);
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/TimeUnitConversionChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/TimeUnitConversionChecker.java
@@ -87,7 +87,7 @@ public final class TimeUnitConversionChecker extends BugChecker
     ExpressionTree arg0 = tree.getArguments().get(0);
 
     // if we have a constant and can Long-parse it...
-    Long constant = Longs.tryParse(String.valueOf(arg0));
+    Long constant = Longs.tryParse(String.valueOf(state.getSourceForNode(arg0)));
     if (constant != null) {
       long converted = invokeConversion(receiver.get(), methodName, constant);
 
@@ -108,7 +108,7 @@ public final class TimeUnitConversionChecker extends BugChecker
 
     // if we're trying to convert the unit to itself, just return the arg
     if (receiver.get().equals(convertTo)) {
-      SuggestedFix fix = replaceTreeWith(tree, convertTo, arg0.toString());
+      SuggestedFix fix = replaceTreeWith(tree, convertTo, state.getSourceForNode(arg0));
       return describeMatch(tree, fix);
     }
     return Description.NO_MATCH;

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -160,6 +160,7 @@ import com.google.errorprone.bugpatterns.MissingSuperCall;
 import com.google.errorprone.bugpatterns.MissingTestCall;
 import com.google.errorprone.bugpatterns.MisusedWeekYear;
 import com.google.errorprone.bugpatterns.MixedArrayDimensions;
+import com.google.errorprone.bugpatterns.MixedDescriptors;
 import com.google.errorprone.bugpatterns.MockitoCast;
 import com.google.errorprone.bugpatterns.MockitoInternalUsage;
 import com.google.errorprone.bugpatterns.MockitoUsage;
@@ -643,6 +644,7 @@ public class BuiltInCheckerSuppliers {
           MissingCasesInEnumSwitch.class,
           MissingFail.class,
           MissingOverride.class,
+          MixedDescriptors.class,
           MockitoInternalUsage.class,
           ModifiedButNotUsed.class,
           ModifyCollectionInEnhancedForLoop.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -252,7 +252,7 @@ import com.google.errorprone.bugpatterns.ThrowIfUncheckedKnownChecked;
 import com.google.errorprone.bugpatterns.ThrowNull;
 import com.google.errorprone.bugpatterns.ThrowsUncheckedException;
 import com.google.errorprone.bugpatterns.ToStringReturnsNull;
-import com.google.errorprone.bugpatterns.TreeToStringChecker;
+import com.google.errorprone.bugpatterns.TreeToString;
 import com.google.errorprone.bugpatterns.TruthAssertExpected;
 import com.google.errorprone.bugpatterns.TruthConstantAsserts;
 import com.google.errorprone.bugpatterns.TruthSelfEquals;
@@ -686,7 +686,7 @@ public class BuiltInCheckerSuppliers {
           ThreeLetterTimeZoneID.class,
           TimeUnitConversionChecker.class,
           ToStringReturnsNull.class,
-          TreeToStringChecker.class,
+          TreeToString.class,
           TruthAssertExpected.class,
           TruthConstantAsserts.class,
           TruthIncompatibleType.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/InterfaceWithOnlyStaticsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/InterfaceWithOnlyStaticsTest.java
@@ -92,16 +92,27 @@ public class InterfaceWithOnlyStaticsTest {
   }
 
   @Test
-  public void negative_module() {
+  public void negative_daggerModules() {
     testHelper
         .addSourceLines(
             "Module.java", //
             "package dagger;",
             "public @interface Module {}")
         .addSourceLines(
+            "ProducerModule.java", //
+            "package dagger.producers;",
+            "public @interface ProducerModule {}")
+        .addSourceLines(
             "Test.java", //
             "import dagger.Module;",
             "@Module",
+            "interface Test {",
+            "  public static final int foo = 42;",
+            "}")
+        .addSourceLines(
+            "Test.java", //
+            "import dagger.producers.ProducerModule;",
+            "@ProducerModule",
             "interface Test {",
             "  public static final int foo = 42;",
             "}")

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MixedDescriptorsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MixedDescriptorsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import org.junit.Ignore;
+
+/**
+ * Tests for {@link MixedDescriptors} bugpattern.
+ *
+ * @author ghm@google.com (Graeme Morgan)
+ */
+@Ignore("b/74365407 test proto sources are broken")
+@RunWith(JUnit4.class)
+public final class MixedDescriptorsTest {
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(MixedDescriptors.class, getClass());
+
+  @Test
+  public void negative() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestFieldProtoMessage;",
+            "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestProtoMessage;",
+            "import com.google.protobuf.Descriptors.Descriptor;",
+            "final class Test {",
+            "  void test(Descriptor d) {",
+            "    TestFieldProtoMessage.getDescriptor().findFieldByNumber(",
+            "        TestFieldProtoMessage.FIELD_FIELD_NUMBER);",
+            "    TestFieldProtoMessage.getDescriptor().findFieldByNumber(1);",
+            "    d.findFieldByNumber(TestFieldProtoMessage.FIELD_FIELD_NUMBER);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positive() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestFieldProtoMessage;",
+            "import com.google.errorprone.bugpatterns.proto.ProtoTest.TestProtoMessage;",
+            "final class Test {",
+            "  void test() {",
+            "    // BUG: Diagnostic contains:",
+            "    TestFieldProtoMessage.getDescriptor().findFieldByNumber(",
+            "        TestProtoMessage.MULTI_FIELD_FIELD_NUMBER);",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TreeToStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TreeToStringTest.java
@@ -21,11 +21,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link TreeToStringChecker}. */
+/** Unit tests for {@link TreeToString}. */
 @RunWith(JUnit4.class)
-public class TreeToStringCheckerTest {
+public class TreeToStringTest {
   private final CompilationTestHelper testHelper =
-      CompilationTestHelper.newInstance(TreeToStringChecker.class, getClass());
+      CompilationTestHelper.newInstance(TreeToString.class, getClass());
 
   @Test
   public void noMatch() {
@@ -70,7 +70,7 @@ public class TreeToStringCheckerTest {
             "@BugPattern(name = \"Example\", summary = \"\", severity = SeverityLevel.ERROR)",
             "public class ExampleChecker extends BugChecker implements ClassTreeMatcher {",
             "  @Override public Description matchClass(ClassTree tree, VisitorState state) {",
-            "    // BUG: Diagnostic contains: TreeToString",
+            "    // BUG: Diagnostic contains: state.getSourceForNode(tree).contains",
             "    if (tree.toString().contains(\"match\")) {",
             "      return describeMatch(tree);",
             "    }",

--- a/core/src/test/java/com/google/errorprone/util/ASTHelpersTest.java
+++ b/core/src/test/java/com/google/errorprone/util/ASTHelpersTest.java
@@ -1002,7 +1002,10 @@ public class ASTHelpersTest extends CompilerBasedAbstractTest {
       TargetType targetType = ASTHelpers.targetType(state);
       return buildDescription(tree)
           .setMessage(
-              "Target type of " + tree + " is " + (targetType != null ? targetType.type() : null))
+              "Target type of "
+                  + state.getSourceForNode(tree)
+                  + " is "
+                  + (targetType != null ? targetType.type() : null))
           .build();
     }
   }

--- a/docs/bugpattern/MixedDescriptors.md
+++ b/docs/bugpattern/MixedDescriptors.md
@@ -1,0 +1,14 @@
+A proto's `Descriptor` was created by mixing the `Descriptors` class from one
+proto with the field number from another. E.g.:
+
+```java {.bad}
+Foo.getDescriptors().findFieldByNumber(Bar.ID_FIELD_NUMBER)
+```
+
+This accesses the `Descriptor` of a field in `Foo` with a field number from
+`Bar`. One of these was probably intended:
+
+```java {.good}
+Foo.getDescriptors().findFieldByNumber(Foo.ID_FIELD_NUMBER)
+Bar.getDescriptors().findFieldByNumber(Bar.ID_FIELD_NUMBER)
+```


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> InterfaceWithOnlyStatics: match ProducerModule too.

Also pull out constants for the Dagger matchers, so they don't get reallocated for each potential match.

RELNOTES: N/A

bd135d910280299f902f6ce9e1e409bc958db9d4

-------

<p> Add a suggested fix to TreeToString by searching for an available VisitorState.

(And move it to TreeToString to match the check name.)

RELNOTES: N/A

38424c9c562f39c8100a8fba5e70a1425d0b6ae4

-------

<p> Fix (most) TreeToString violations in ErrorProne.

RELNOTES: N/A

24f66dc77f8118d27cfb2afb7cc94471aacb0e8e

-------

<p> Add a BugPattern for $a$.getDescriptor().findFieldByNumber($b$.FOO_FIELD_INDEX) where type($a$) != type($b$).

RELNOTES: [MixedDescriptors] find proto Descriptors generated from mixed proto definitions

ac4bb5060df0e460ad8680bc8fe73e0a96ec0dbc