### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/inference/InferredNullability.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/inference/InferredNullability.java
@@ -56,7 +56,9 @@ public class InferredNullability {
     for (TypeVariableSymbol tvs :
         TreeInfo.symbol((JCTree) callsite.getMethodSelect()).getTypeParameters()) {
       InferenceVariable iv = TypeVariableInferenceVar.create(tvs, callsite);
-      getNullness(iv).ifPresent(nullness -> result.put(tvs, nullness));
+      if (constraintGraph.nodes().contains(iv)) {
+        getNullness(iv).ifPresent(nullness -> result.put(tvs, nullness));
+      }
     }
     return result.build();
   }

--- a/check_api/src/main/java/com/google/errorprone/scanner/Scanner.java
+++ b/check_api/src/main/java/com/google/errorprone/scanner/Scanner.java
@@ -25,6 +25,7 @@ import com.google.errorprone.annotations.CheckReturnValue;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Suppressible;
 import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import com.sun.source.util.TreePathScanner;
@@ -80,11 +81,16 @@ public class Scanner extends TreePathScanner<Void, VisitorState> {
    */
   private SuppressionInfo updateSuppressions(Tree tree, VisitorState state) {
     SuppressionInfo prevSuppressionInfo = currentSuppressions;
-    Symbol sym = ASTHelpers.getDeclaredSymbol(tree);
-    if (sym != null) {
+    if (tree instanceof CompilationUnitTree) {
       currentSuppressions =
-          currentSuppressions.withExtendedSuppressions(
-              sym, state, getCustomSuppressionAnnotations());
+          currentSuppressions.forCompilationUnit((CompilationUnitTree) tree, state);
+    } else {
+      Symbol sym = ASTHelpers.getDeclaredSymbol(tree);
+      if (sym != null) {
+        currentSuppressions =
+            currentSuppressions.withExtendedSuppressions(
+                sym, state, getCustomSuppressionAnnotations());
+      }
     }
     return prevSuppressionInfo;
   }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RedundantOverride.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RedundantOverride.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.util.ASTHelpers.findSuperMethod;
+import static com.google.errorprone.util.ASTHelpers.getReceiver;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ErrorProneTokens;
+import com.sun.source.doctree.DocCommentTree;
+import com.sun.source.tree.ExpressionStatementTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.ReturnTree;
+import com.sun.source.tree.StatementTree;
+import com.sun.source.util.SimpleTreeVisitor;
+import com.sun.tools.javac.api.JavacTrees;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import javax.lang.model.element.Modifier;
+
+/** Removes overrides which purely pass through to the method in the super class. */
+@BugPattern(
+    name = "RedundantOverride",
+    summary = "This override is redundant, and can be removed.",
+    severity = WARNING,
+    providesFix = REQUIRES_HUMAN_ATTENTION)
+public final class RedundantOverride extends BugChecker implements MethodTreeMatcher {
+
+  @Override
+  public Description matchMethod(MethodTree tree, VisitorState state) {
+    MethodSymbol methodSymbol = getSymbol(tree);
+    if (methodSymbol == null) {
+      return NO_MATCH;
+    }
+    Optional<MethodSymbol> maybeSuperMethod = findSuperMethod(methodSymbol, state.getTypes());
+    if (!maybeSuperMethod.isPresent()) {
+      return NO_MATCH;
+    }
+    MethodSymbol superMethod = maybeSuperMethod.get();
+    if (tree.getBody() == null || tree.getBody().getStatements().size() != 1) {
+      return NO_MATCH;
+    }
+    StatementTree statement = tree.getBody().getStatements().get(0);
+    ExpressionTree expression = getSingleInvocation(statement);
+    if (expression == null) {
+      return NO_MATCH;
+    }
+    MethodInvocationTree methodInvocationTree = (MethodInvocationTree) expression;
+    if (!getSymbol(methodInvocationTree).equals(superMethod)) {
+      return NO_MATCH;
+    }
+    ExpressionTree receiver = getReceiver(methodInvocationTree);
+    if (!(receiver instanceof IdentifierTree)) {
+      return NO_MATCH;
+    }
+    if (!((IdentifierTree) receiver).getName().contentEquals("super")) {
+      return NO_MATCH;
+    }
+    // Exempt Javadocs; the override might be here to add documentation.
+    DocCommentTree docCommentTree =
+        JavacTrees.instance(state.context).getDocCommentTree(state.getPath());
+    if (docCommentTree != null) {
+      return NO_MATCH;
+    }
+    // Exempt broadening of visibility.
+    if (!methodSymbol.getModifiers().equals(superMethod.getModifiers())) {
+      return NO_MATCH;
+    }
+    // Overriding a protected member in another package broadens the visibility to the new package.
+    if (methodSymbol.getModifiers().contains(Modifier.PROTECTED)
+        && !Objects.equals(superMethod.packge(), methodSymbol.packge())) {
+      return NO_MATCH;
+    }
+    // Exempt any change in annotations (aside from @Override).
+    ImmutableSet<Symbol> superAnnotations = getAnnotations(superMethod);
+    ImmutableSet<Symbol> methodAnnotations = getAnnotations(methodSymbol);
+    if (!Sets.difference(
+            Sets.symmetricDifference(superAnnotations, methodAnnotations),
+            ImmutableSet.of(state.getSymtab().overrideType.tsym))
+        .isEmpty()) {
+      return NO_MATCH;
+    }
+    for (int i = 0; i < tree.getParameters().size(); ++i) {
+      if (!(methodInvocationTree.getArguments().get(i) instanceof IdentifierTree)) {
+        return NO_MATCH;
+      }
+      if (!getSymbol(tree.getParameters().get(i))
+          .equals(getSymbol(methodInvocationTree.getArguments().get(i)))) {
+        return NO_MATCH;
+      }
+    }
+    // Exempt if there are comments within the body. (Do this last, as it's expensive.)
+    if (ErrorProneTokens.getTokens(state.getSourceForNode(tree.getBody()), state.context).stream()
+        .anyMatch(t -> !t.comments().isEmpty())) {
+      return NO_MATCH;
+    }
+
+    return describeMatch(tree, SuggestedFix.delete(tree));
+  }
+
+  @Nullable
+  private static MethodInvocationTree getSingleInvocation(StatementTree statement) {
+    return statement.accept(
+        new SimpleTreeVisitor<MethodInvocationTree, Void>() {
+          @Override
+          public MethodInvocationTree visitReturn(ReturnTree returnTree, Void unused) {
+            return visit(returnTree.getExpression(), null);
+          }
+
+          @Override
+          public MethodInvocationTree visitExpressionStatement(
+              ExpressionStatementTree expressionStatement, Void unused) {
+            return visit(expressionStatement.getExpression(), null);
+          }
+
+          @Override
+          public MethodInvocationTree visitMethodInvocation(
+              MethodInvocationTree methodInvocationTree, Void unused) {
+            return methodInvocationTree;
+          }
+        },
+        null);
+  }
+
+  private static ImmutableSet<Symbol> getAnnotations(MethodSymbol symbol) {
+    return symbol.getRawAttributes().stream().map(a -> a.type.tsym).collect(toImmutableSet());
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/Unused.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Unused.java
@@ -245,7 +245,7 @@ public final class Unused extends BugChecker implements CompilationUnitTreeMatch
               if (var.getKind() == Kind.IDENTIFIER) {
                 // Anything that is not @Parameters(value = ...), e.g.
                 // @Parameters(source = ...) or @Parameters(method = ...)
-                if (((IdentifierTree) var).getName().contentEquals(JUNIT_PARAMS_VALUE)) {
+                if (!((IdentifierTree) var).getName().contentEquals(JUNIT_PARAMS_VALUE)) {
                   return true;
                 }
               }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/InheritDoc.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/InheritDoc.java
@@ -30,7 +30,6 @@ import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.matchers.Description;
-import com.sun.source.doctree.DocTree;
 import com.sun.source.doctree.InheritDocTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
@@ -125,11 +124,6 @@ public final class InheritDoc extends BugChecker
         }
       }.visit(getCurrentPath().getTreePath().getLeaf(), null);
       return super.visitInheritDoc(inheritDocTree, null);
-    }
-
-    @Override
-    public Void scan(DocTree docTree, Void aVoid) {
-      return super.scan(docTree, aVoid);
     }
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/UnescapedEntity.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/UnescapedEntity.java
@@ -285,11 +285,6 @@ public final class UnescapedEntity extends BugChecker
           .addFix(replace(getCurrentPath().getLeaf(), replacement, state))
           .build();
     }
-
-    @Override
-    public Void scan(DocTree docTree, Void aVoid) {
-      return super.scan(docTree, aVoid);
-    }
   }
 
   private static SuggestedFix wrapInCodeTag(Range<Integer> containingPre) {

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -222,6 +222,7 @@ import com.google.errorprone.bugpatterns.ProvidesFixChecker;
 import com.google.errorprone.bugpatterns.RandomCast;
 import com.google.errorprone.bugpatterns.RandomModInteger;
 import com.google.errorprone.bugpatterns.ReachabilityFenceUsage;
+import com.google.errorprone.bugpatterns.RedundantOverride;
 import com.google.errorprone.bugpatterns.RedundantThrows;
 import com.google.errorprone.bugpatterns.ReferenceEquality;
 import com.google.errorprone.bugpatterns.RemoveUnusedImports;
@@ -761,6 +762,7 @@ public class BuiltInCheckerSuppliers {
           InvalidBlockTag.class,
           InvalidInlineTag.class,
           InvalidParam.class,
+          RedundantOverride.class,
           ReturnFromVoid.class,
           InvalidThrows.class,
           JavaxInjectOnFinalField.class,

--- a/core/src/test/java/com/google/errorprone/ErrorProneCompilerIntegrationTest.java
+++ b/core/src/test/java/com/google/errorprone/ErrorProneCompilerIntegrationTest.java
@@ -413,16 +413,15 @@ public class ErrorProneCompilerIntegrationTest {
   @Test
   public void suppressGeneratedWarning() {
     String[] generatedFile = {
+      "import java.util.List;",
       "@javax.annotation.Generated(\"Foo\")",
       "class Generated {",
-      "  public Generated() {",
-      "    if (true);",
-      "  }",
+      "  public Generated() {}",
       "}"
     };
 
     {
-      String[] args = {"-Xep:EmptyIf:WARN"};
+      String[] args = {"-Xep:RemoveUnusedImports:WARN"};
       Result exitCode =
           compiler.compile(
               args,
@@ -431,14 +430,14 @@ public class ErrorProneCompilerIntegrationTest {
       outputStream.flush();
       assertThat(diagnosticHelper.getDiagnostics()).hasSize(1);
       assertThat(diagnosticHelper.getDiagnostics().get(0).getMessage(ENGLISH))
-          .contains("[EmptyIf]");
+          .contains("[RemoveUnusedImports]");
       assertThat(outputStream.toString(), exitCode, is(Result.OK));
     }
 
     diagnosticHelper.clearDiagnostics();
 
     {
-      String[] args = {"-Xep:EmptyIf:WARN", "-XepDisableWarningsInGeneratedCode"};
+      String[] args = {"-Xep:RemoveUnusedImports:WARN", "-XepDisableWarningsInGeneratedCode"};
       Result exitCode =
           compiler.compile(
               args,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/RedundantOverrideTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/RedundantOverrideTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link RedundantOverride}. */
+@RunWith(JUnit4.class)
+public final class RedundantOverrideTest {
+  private final CompilationTestHelper testHelper =
+      CompilationTestHelper.newInstance(RedundantOverride.class, getClass());
+
+  @Test
+  public void positive() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  // BUG: Diagnostic contains:",
+            "  @Override public boolean equals(Object o) {",
+            "    return super.equals(o);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void addingJavadoc() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  /** Adding javadoc. */",
+            "  @Override public boolean equals(Object o) {",
+            "    return super.equals(o);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void addingComments() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  @Override public boolean equals(Object o) {",
+            "    // TODO..",
+            "    return super.equals(o);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void considersParameterOrder() {
+    testHelper
+        .addSourceLines(
+            "A.java", //
+            "class A {",
+            "  public void swap(int a, int b) {}",
+            "}")
+        .addSourceLines(
+            "B.java",
+            "class B extends A {",
+            "  @Override public void swap(int a, int b) {",
+            "    super.swap(b, a);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void wideningVisibilityNoMatch() {
+    testHelper
+        .addSourceLines(
+            "A.java", //
+            "class A {",
+            "  void swap(int a, int b) {}",
+            "}")
+        .addSourceLines(
+            "B.java",
+            "class B extends A {",
+            "  @Override public void swap(int a, int b) {",
+            "    super.swap(a, b);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void addingAnnotations() {
+    testHelper
+        .addSourceLines(
+            "A.java", //
+            "class A {",
+            "  Object swap(int a, int b) {",
+            "    return null;",
+            "  }",
+            "}")
+        .addSourceLines(
+            "B.java",
+            "import javax.annotation.Nullable;",
+            "class B extends A {",
+            "  @Nullable",
+            "  @Override public Object swap(int a, int b) {",
+            "    return super.swap(a, b);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void sameAnnotation() {
+    testHelper
+        .addSourceLines(
+            "A.java", //
+            "import javax.annotation.Nullable;",
+            "class A {",
+            "  @Nullable Object swap(int a, int b) {",
+            "    return null;",
+            "  }",
+            "}")
+        .addSourceLines(
+            "B.java",
+            "import javax.annotation.Nullable;",
+            "class B extends A {",
+            "  @Nullable",
+            "  // BUG: Diagnostic contains:",
+            "  @Override Object swap(int a, int b) {",
+            "    return super.swap(a, b);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void removesAnnotation() {
+    testHelper
+        .addSourceLines(
+            "A.java", //
+            "import javax.annotation.Nullable;",
+            "class A {",
+            "  @Nullable Object swap(int a, int b) {",
+            "    return null;",
+            "  }",
+            "}")
+        .addSourceLines(
+            "B.java",
+            "import javax.annotation.Nullable;",
+            "class B extends A {",
+            "  @Override Object swap(int a, int b) {",
+            "    return super.swap(a, b);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void addsAnnotation() {
+    testHelper
+        .addSourceLines(
+            "A.java", //
+            "class A {",
+            "  Object swap(int a, int b) {",
+            "    return null;",
+            "  }",
+            "}")
+        .addSourceLines(
+            "B.java",
+            "import javax.annotation.Nullable;",
+            "class B extends A {",
+            "  @Nullable",
+            "  @Override Object swap(int a, int b) {",
+            "    return super.swap(a, b);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void protectedOverrideInDifferentPackage() {
+    testHelper
+        .addSourceLines(
+            "A.java", //
+            "package foo;",
+            "public class A {",
+            "  protected void swap() {}",
+            "}")
+        .addSourceLines(
+            "B.java",
+            "package bar;",
+            "public class B extends foo.A {",
+            "  @Override protected void swap() {",
+            "    super.swap();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void protectedOverrideInSamePackage() {
+    testHelper
+        .addSourceLines(
+            "A.java", //
+            "package foo;",
+            "class A {",
+            "  protected void swap() {}",
+            "}")
+        .addSourceLines(
+            "B.java",
+            "package foo;",
+            "class B extends A {",
+            "  // BUG: Diagnostic contains:",
+            "  @Override protected void swap() {",
+            "    super.swap();",
+            "  }",
+            "}")
+        .doTest();
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove pointless overrides that delegate to super.

<img src="shamecube.gif"/>

RELNOTES: N/A

f48f96b11eeca3308ba0c16b8bc9605c8da0ac88

-------

<p> Unused: fix @Parameters check.

RELNOTES: N/A

715d2388420297d16d55086623dc2845c9731ade

-------

<p> Update SuppressionInfo to look for @Generated annotations on top level classes when visiting CompilationUnitTrees.

This stops CompilationUnitTreeMatchers from firing on generated code when -XepDisableWarningsInGeneratedCode is passed.

Fixes #1165

RELNOTES: Suppress checks thoroughly when -XepDisableWarningsInGeneratedCode is passed.

baa90dd114da8d3cd43e571ea84e5e5178e8e6b1

-------

<p> Don't consider annotated type variable uses when inferring nullness qualifiers for type variables.

This for instance avoids issues with Guava's verifyNotNull, by "disconnecting" nullness of the method's result from the parameter.
RELNOTES: None.

75775e7987e39818825e8582b2e80cb4bac32ffe

-------

<p> RedundantOverride: match redundant overrides that can be removed, e.g.:

@Override
public int hashCode() {
  return super.hashCode();
}

RELNOTES: RedundantOverride: match redundant overrides which only delegate to super

8ba608d8effa4a45b89042ee2ed21396a38f61fc