### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/Nullness.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/Nullness.java
@@ -127,7 +127,8 @@ public enum Nullness implements AbstractValue<Nullness> {
   // TODO(kmb): Correctly handle JSR 305 @Nonnull(NEVER) etc.
   private static final Predicate<String> ANNOTATION_RELEVANT_TO_NULLNESS =
       Pattern.compile(
-              ".*\\.((Recently)?Nullable(Decl)?|(Recently)?NotNull|Nonnull|NonNull|CheckForNull)$")
+              ".*\\.((Recently)?Nullable(Decl)?|(Recently)?NotNull(Decl)?|NonNull(Decl)?|Nonnull|"
+                  + "CheckForNull)$")
           .asPredicate();
 
   private static final Predicate<String> NULLABLE_ANNOTATION =

--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -855,6 +855,23 @@ public class ASTHelpers {
     return sym == null ? null : sym.name.toString();
   }
 
+  /** Returns the erasure of the given type tree, i.e. {@code List} for {@code List<Foo>}. */
+  public static Tree getErasedTypeTree(Tree tree) {
+    return tree.accept(
+        new SimpleTreeVisitor<Tree, Void>() {
+          @Override
+          public Tree visitIdentifier(IdentifierTree tree, Void unused) {
+            return tree;
+          }
+
+          @Override
+          public Tree visitParameterizedType(ParameterizedTypeTree tree, Void unused) {
+            return tree.getType();
+          }
+        },
+        null);
+  }
+
   /** Return the enclosing {@code ClassSymbol} of the given symbol, or {@code null}. */
   public static ClassSymbol enclosingClass(Symbol sym) {
     return sym.owner.enclClass();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AssignmentToMock.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AssignmentToMock.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.AT_LEAST_ONE;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.JUnitMatchers.isJUnit4TestRunnerOfType;
+import static com.google.errorprone.matchers.Matchers.annotations;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.hasAnnotation;
+import static com.google.errorprone.matchers.Matchers.hasArgumentWithValue;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.AssignmentTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.MultiMatcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.google.errorprone.util.ErrorProneToken;
+import com.google.errorprone.util.ErrorProneTokens;
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.AssignmentTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.parser.Tokens.TokenKind;
+import com.sun.tools.javac.tree.JCTree;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** Discourage manual initialization or assignment to fields annotated with {@code @Mock}. */
+@BugPattern(
+    name = "AssignmentToMock",
+    summary = "Fields annotated with @Mock should not be manually assigned to.",
+    severity = WARNING,
+    providesFix = REQUIRES_HUMAN_ATTENTION)
+public final class AssignmentToMock extends BugChecker
+    implements AssignmentTreeMatcher, VariableTreeMatcher {
+
+  private static final Matcher<Tree> HAS_MOCK_ANNOTATION = hasAnnotation("org.mockito.Mock");
+
+  private static final Matcher<ExpressionTree> MOCK_FACTORY =
+      staticMethod().onClass("org.mockito.Mockito").named("mock");
+
+  private static final Matcher<ExpressionTree> INITIALIZES_MOCKS =
+      anyOf(
+          staticMethod().onClass("org.mockito.MockitoAnnotations").named("initMocks"));
+
+  private static final MultiMatcher<ClassTree, AnnotationTree> MOCKITO_RUNNER =
+      annotations(
+          AT_LEAST_ONE,
+          hasArgumentWithValue(
+              "value",
+              isJUnit4TestRunnerOfType(
+                  ImmutableList.of("org.mockito.runners.MockitoJUnitRunner"))));
+
+  @Override
+  public Description matchAssignment(AssignmentTree tree, VisitorState state) {
+    if (!HAS_MOCK_ANNOTATION.matches(tree.getVariable(), state)) {
+      return NO_MATCH;
+    }
+
+    SuggestedFix fix = SuggestedFix.delete(tree);
+    return describeMatch(tree, fix);
+  }
+
+  @Override
+  public Description matchVariable(VariableTree tree, VisitorState state) {
+    if (tree.getInitializer() == null || !HAS_MOCK_ANNOTATION.matches(tree, state)) {
+      return NO_MATCH;
+    }
+
+    return describeMatch(tree, createFix(tree, state));
+  }
+
+  private static SuggestedFix createFix(VariableTree tree, VisitorState state) {
+    if (MOCK_FACTORY.matches(tree.getInitializer(), state)
+        && !classContainsInitializer(state.findEnclosing(ClassTree.class), state)) {
+      AnnotationTree anno =
+          ASTHelpers.getAnnotationWithSimpleName(tree.getModifiers().getAnnotations(), "Mock");
+      return SuggestedFix.delete(anno);
+    }
+    int startPos = ((JCTree) tree).getStartPosition();
+    ImmutableList<ErrorProneToken> tokens =
+        ErrorProneTokens.getTokens(
+            state
+                .getSourceCode()
+                .subSequence(startPos, ((JCTree) tree.getInitializer()).getStartPosition())
+                .toString(),
+            state.context);
+    for (ErrorProneToken token : tokens.reverse()) {
+      if (token.kind() == TokenKind.EQ) {
+        return SuggestedFix.replace(
+            startPos + token.pos(), state.getEndPosition(tree.getInitializer()), "");
+      }
+    }
+    return SuggestedFix.builder().build();
+  }
+
+  private static boolean classContainsInitializer(ClassTree classTree, VisitorState state) {
+    AtomicBoolean initialized = new AtomicBoolean(false);
+    new TreeScanner<Void, Void>() {
+      @Override
+      public Void visitClass(ClassTree classTree, Void unused) {
+        if (MOCKITO_RUNNER.matches(classTree, state)) {
+          initialized.set(true);
+          return null;
+        }
+        return super.visitClass(classTree, null);
+      }
+
+      @Override
+      public Void visitMethodInvocation(MethodInvocationTree methodInvocationTree, Void unused) {
+        if (INITIALIZES_MOCKS.matches(methodInvocationTree, state)) {
+          initialized.set(true);
+          return null;
+        }
+        return super.visitMethodInvocation(methodInvocationTree, null);
+      }
+
+      @Override
+      public Void visitNewClass(NewClassTree newClassTree, Void unused) {
+        if (INITIALIZES_MOCKS.matches(newClassTree, state)) {
+          initialized.set(true);
+          return null;
+        }
+        return super.visitNewClass(newClassTree, null);
+      }
+    }.scan(classTree, null);
+    return initialized.get();
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AutoValueImmutableFields.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AutoValueImmutableFields.java
@@ -51,7 +51,7 @@ import javax.lang.model.element.Modifier;
 public class AutoValueImmutableFields extends BugChecker implements ClassTreeMatcher {
 
   private static final String MESSAGE =
-      "AutoValue instances should be deeply immutable. Therefore, we recommend returning a %s "
+      "AutoValue instances should be deeply immutable. Therefore, we recommend returning %s "
           + "instead. Read more at "
           + "http://goo.gl/qWo9sC"
       ;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MixedMutabilityReturnType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MixedMutabilityReturnType.java
@@ -1,0 +1,453 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.fixes.SuggestedFixes.qualifyType;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.isSubtypeOf;
+import static com.google.errorprone.matchers.Matchers.nothing;
+import static com.google.errorprone.matchers.method.MethodMatchers.constructor;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.google.errorprone.util.ASTHelpers.getType;
+import static com.google.errorprone.util.ASTHelpers.methodCanBeOverridden;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.ReturnTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.code.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import javax.lang.model.type.TypeKind;
+
+/**
+ * Flags methods which return mutable collections from some code paths, but immutable ones from
+ * others.
+ */
+@BugPattern(
+    name = "MixedMutabilityReturnType",
+    summary =
+        "This method returns both mutable and immutable collections or maps from different "
+            + "paths. This may be confusing for users of the method.",
+    severity = SeverityLevel.WARNING,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+public final class MixedMutabilityReturnType extends BugChecker
+    implements CompilationUnitTreeMatcher {
+
+  private static final Matcher<ExpressionTree> IMMUTABLE_FACTORY =
+      staticMethod()
+          .onClass("java.util.Collections")
+          .namedAnyOf("emptyList", "emptyMap", "emptySet", "singleton", "singletonList");
+
+  private static final Matcher<ExpressionTree> EMPTY_INITIALIZER =
+      anyOf(
+          constructor().forClass("java.util.ArrayList").withParameters(),
+          constructor().forClass("java.util.HashMap").withParameters(),
+          staticMethod()
+              .onClass("com.google.common.collect.Lists")
+              .namedAnyOf("newArrayList", "newHashSet", "newLinkedList")
+              .withParameters());
+
+  private static final Matcher<ExpressionTree> IMMUTABLE =
+      anyOf(
+          IMMUTABLE_FACTORY,
+          isSubtypeOf(ImmutableCollection.class),
+          isSubtypeOf(ImmutableMap.class));
+
+  private static final Matcher<ExpressionTree> MUTABLE =
+      anyOf(
+          isSubtypeOf(ArrayList.class),
+          isSubtypeOf(LinkedHashSet.class),
+          isSubtypeOf(LinkedHashMap.class),
+          isSubtypeOf(LinkedList.class),
+          isSubtypeOf(HashMap.class),
+          isSubtypeOf(HashBiMap.class),
+          isSubtypeOf(TreeMap.class),
+          staticMethod().onClass("com.google.common.collect.Lists"),
+          staticMethod().onClass("com.google.common.collect.Sets"));
+
+  private static final Matcher<Tree> RETURNS_COLLECTION =
+      anyOf(isSubtypeOf(Collection.class), isSubtypeOf(Map.class));
+
+  private static final ImmutableMap<Matcher<Tree>, TypeDetails> REFACTORING_DETAILS =
+      ImmutableMap.of(
+          isSubtypeOf(BiMap.class),
+              TypeDetails.of(
+                  "com.google.common.collect.ImmutableBiMap",
+                  instanceMethod()
+                      .onDescendantOf(BiMap.class.getName())
+                      .namedAnyOf("put", "putAll"),
+                  nothing()),
+          isSubtypeOf(Map.class),
+              TypeDetails.of(
+                  "com.google.common.collect.ImmutableMap",
+                  instanceMethod().onDescendantOf(Map.class.getName()).namedAnyOf("put", "putAll"),
+                  isSubtypeOf(SortedMap.class)),
+          isSubtypeOf(List.class),
+              TypeDetails.of(
+                  "com.google.common.collect.ImmutableList",
+                  instanceMethod().onDescendantOf(List.class.getName()).namedAnyOf("add", "addAll"),
+                  nothing()),
+          isSubtypeOf(Set.class),
+              TypeDetails.of(
+                  "com.google.common.collect.ImmutableSet",
+                  instanceMethod().onDescendantOf(Set.class.getName()).namedAnyOf("add", "addAll"),
+                  nothing()));
+
+  @Override
+  public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {
+    VariableMutabilityScanner variableMutabilityScanner = new VariableMutabilityScanner(state);
+    variableMutabilityScanner.scan(state.getPath(), null);
+    new ReturnTypesScanner(
+            state, variableMutabilityScanner.immutable, variableMutabilityScanner.mutable)
+        .scan(state.getPath(), null);
+    return Description.NO_MATCH;
+  }
+
+  private static final class VariableMutabilityScanner extends TreePathScanner<Void, Void> {
+    private final VisitorState state;
+
+    private final Set<VarSymbol> mutable = new HashSet<>();
+    private final Set<VarSymbol> immutable = new HashSet<>();
+
+    private VariableMutabilityScanner(VisitorState state) {
+      this.state = state;
+    }
+
+    @Override
+    public Void visitVariable(VariableTree variableTree, Void unused) {
+      VarSymbol symbol = getSymbol(variableTree);
+      ExpressionTree initializer = variableTree.getInitializer();
+      if (initializer != null
+          && getType(initializer) != null
+          && getType(initializer).getKind() != TypeKind.NULL
+          && RETURNS_COLLECTION.matches(initializer, state)) {
+        if (IMMUTABLE.matches(initializer, state)) {
+          immutable.add(symbol);
+        }
+        if (MUTABLE.matches(initializer, state)) {
+          mutable.add(symbol);
+        }
+      }
+      return super.visitVariable(variableTree, unused);
+    }
+  }
+
+  private final class ReturnTypesScanner extends TreePathScanner<Void, Void> {
+    private final VisitorState state;
+
+    private final Set<VarSymbol> mutable;
+    private final Set<VarSymbol> immutable;
+
+    private ReturnTypesScanner(
+        VisitorState state, Set<VarSymbol> immutable, Set<VarSymbol> mutable) {
+      this.state = state;
+      this.immutable = immutable;
+      this.mutable = mutable;
+    }
+
+    @Override
+    public Void visitClass(ClassTree classTree, Void unused) {
+      return isSuppressed(classTree) ? null : super.visitClass(classTree, null);
+    }
+
+    @Override
+    public Void visitMethod(MethodTree methodTree, Void unused) {
+      if (isSuppressed(methodTree)
+          || !RETURNS_COLLECTION.matches(methodTree.getReturnType(), state)) {
+        return super.visitMethod(methodTree, unused);
+      }
+      MethodScanner scanner = new MethodScanner();
+      scanner.scan(getCurrentPath(), null);
+      if (!scanner.immutableReturns.isEmpty() && !scanner.mutableReturns.isEmpty()) {
+        state.reportMatch(
+            buildDescription(methodTree)
+                .addAllFixes(
+                    generateFixes(
+                        ImmutableList.<ReturnTree>builder()
+                            .addAll(scanner.mutableReturns)
+                            .addAll(scanner.immutableReturns)
+                            .build(),
+                        getCurrentPath(),
+                        state))
+                .build());
+      }
+      return super.visitMethod(methodTree, unused);
+    }
+
+    private final class MethodScanner extends TreePathScanner<Void, Void> {
+      private final List<ReturnTree> immutableReturns = new ArrayList<>();
+      private final List<ReturnTree> mutableReturns = new ArrayList<>();
+      private boolean skipMethods = false;
+
+      @Override
+      public Void visitMethod(MethodTree node, Void unused) {
+        if (skipMethods) {
+          return null;
+        }
+        skipMethods = true;
+        return super.visitMethod(node, null);
+      }
+
+      @Override
+      public Void visitReturn(ReturnTree returnTree, Void unused) {
+        if (returnTree.getExpression() instanceof IdentifierTree) {
+          Symbol symbol = getSymbol(returnTree.getExpression());
+          if (mutable.contains(symbol)) {
+            mutableReturns.add(returnTree);
+            return super.visitReturn(returnTree, null);
+          }
+          if (immutable.contains(symbol)) {
+            immutableReturns.add(returnTree);
+            return super.visitReturn(returnTree, null);
+          }
+        }
+        Type type = getType(returnTree.getExpression());
+        if (type == null || type.getKind() == TypeKind.NULL) {
+          return super.visitReturn(returnTree, null);
+        }
+        if (IMMUTABLE.matches(returnTree.getExpression(), state)) {
+          immutableReturns.add(returnTree);
+        }
+        if (MUTABLE.matches(returnTree.getExpression(), state)) {
+          mutableReturns.add(returnTree);
+        }
+        return super.visitReturn(returnTree, null);
+      }
+
+      @Override
+      public Void visitLambdaExpression(LambdaExpressionTree node, Void unused) {
+        return null;
+      }
+    }
+  }
+
+  private static ImmutableList<SuggestedFix> generateFixes(
+      List<ReturnTree> returnTrees, TreePath methodTree, VisitorState state) {
+    SuggestedFix.Builder simpleFix = SuggestedFix.builder();
+    SuggestedFix.Builder fixWithBuilders = SuggestedFix.builder();
+    boolean anyBuilderFixes = false;
+
+    Matcher<Tree> returnTypeMatcher = null;
+    for (Map.Entry<Matcher<Tree>, TypeDetails> entry : REFACTORING_DETAILS.entrySet()) {
+      Tree returnType = ((MethodTree) methodTree.getLeaf()).getReturnType();
+      Matcher<Tree> matcher = entry.getKey();
+      if (matcher.matches(returnType, state)) {
+        // Only change the return type if the method is not overridable, otherwise this could
+        // break builds.
+        if (!methodCanBeOverridden(getSymbol((MethodTree) methodTree.getLeaf()))) {
+          SuggestedFix.Builder fixBuilder = SuggestedFix.builder();
+          fixBuilder.replace(
+              ASTHelpers.getErasedTypeTree(returnType),
+              qualifyType(state, fixBuilder, entry.getValue().immutableType()));
+          simpleFix.merge(fixBuilder);
+          fixWithBuilders.merge(fixBuilder);
+        }
+        returnTypeMatcher = isSubtypeOf(entry.getValue().immutableType());
+        break;
+      }
+    }
+    if (returnTypeMatcher == null) {
+      return ImmutableList.of();
+    }
+    for (ReturnTree returnTree : returnTrees) {
+      if (returnTypeMatcher.matches(returnTree.getExpression(), state)) {
+        break;
+      }
+      for (Map.Entry<Matcher<Tree>, TypeDetails> entry : REFACTORING_DETAILS.entrySet()) {
+        Matcher<Tree> predicate = entry.getKey();
+        TypeDetails typeDetails = entry.getValue();
+        ExpressionTree expression = returnTree.getExpression();
+        // Skip already immutable returns.
+        if (!predicate.matches(expression, state)) {
+          continue;
+        }
+        if (expression instanceof IdentifierTree) {
+          SuggestedFix simple = applySimpleFix(typeDetails.immutableType(), expression, state);
+          // If we're returning an identifier of this mutable type, try to turn it into a Builder.
+          ReturnTypeFixer returnTypeFixer =
+              new ReturnTypeFixer(getSymbol(expression), typeDetails, state);
+          returnTypeFixer.scan(methodTree, null);
+
+          anyBuilderFixes |= !returnTypeFixer.failed;
+          simpleFix.merge(simple);
+          fixWithBuilders.merge(returnTypeFixer.failed ? simple : returnTypeFixer.fix.build());
+          continue;
+        }
+        if (IMMUTABLE_FACTORY.matches(expression, state)) {
+          SuggestedFix.Builder fix = SuggestedFix.builder();
+          fix.replace(
+              ((MethodInvocationTree) expression).getMethodSelect(),
+              qualifyType(state, fix, typeDetails.immutableType()) + ".of");
+          simpleFix.merge(fix);
+          fixWithBuilders.merge(fix);
+          continue;
+        }
+
+        SuggestedFix simple = applySimpleFix(typeDetails.immutableType(), expression, state);
+        simpleFix.merge(simple);
+        fixWithBuilders.merge(simple);
+      }
+    }
+    if (!anyBuilderFixes) {
+      return ImmutableList.of(simpleFix.build());
+    }
+    return ImmutableList.of(
+        simpleFix.build(),
+        fixWithBuilders
+            .setShortDescription(
+                "Fix using builders. Warning: this may change behaviour "
+                    + "if duplicate keys are added to ImmutableMap.Builder.")
+            .build());
+  }
+
+  private static SuggestedFix applySimpleFix(
+      String immutableType, ExpressionTree expression, VisitorState state) {
+    SuggestedFix.Builder fix = SuggestedFix.builder();
+    fix.replace(
+        expression,
+        String.format(
+            "%s.copyOf(%s)",
+            qualifyType(state, fix, immutableType), state.getSourceForNode(expression)));
+    return fix.build();
+  }
+
+  private static final class ReturnTypeFixer extends TreePathScanner<Void, Void> {
+    private final Symbol symbol;
+    private final TypeDetails details;
+    private final VisitorState state;
+    private final SuggestedFix.Builder fix = SuggestedFix.builder();
+    private boolean builderifiedVariable = false;
+    private boolean failed = false;
+
+    private ReturnTypeFixer(Symbol symbol, TypeDetails details, VisitorState state) {
+      this.symbol = symbol;
+      this.details = details;
+      this.state = state;
+    }
+
+    @Override
+    public Void visitVariable(VariableTree variableTree, Void unused) {
+      if (!getSymbol(variableTree).equals(symbol)) {
+        return super.visitVariable(variableTree, null);
+      }
+      if (variableTree.getInitializer() == null
+          || !EMPTY_INITIALIZER.matches(variableTree.getInitializer(), state)
+          || details.skipTypes().matches(variableTree.getInitializer(), state)) {
+        failed = true;
+        return null;
+      }
+
+      fix.replace(
+          ASTHelpers.getErasedTypeTree(variableTree.getType()),
+          qualifyType(state, fix, details.builderType()));
+      if (variableTree.getInitializer() != null) {
+        fix.replace(
+            variableTree.getInitializer(),
+            qualifyType(state, fix, details.immutableType()) + ".builder()");
+      }
+      builderifiedVariable = true;
+      return super.visitVariable(variableTree, null);
+    }
+
+    @Override
+    public Void visitIdentifier(IdentifierTree identifier, Void unused) {
+      Tree parent = getCurrentPath().getParentPath().getLeaf();
+      if (!getSymbol(identifier).equals(symbol)) {
+        return null;
+      }
+      if (parent instanceof VariableTree) {
+        VariableTree variable = (VariableTree) parent;
+        fix.replace(variable.getType(), qualifyType(state, fix, details.builderType()));
+        return null;
+      }
+      if (parent instanceof MemberSelectTree) {
+        Tree grandParent = getCurrentPath().getParentPath().getParentPath().getLeaf();
+        if (grandParent instanceof MethodInvocationTree) {
+          if (!details.appendMethods().matches((MethodInvocationTree) grandParent, state)) {
+            failed = true;
+            return null;
+          }
+        }
+        return null;
+      }
+      if (!builderifiedVariable) {
+        failed = true;
+        return null;
+      }
+      if (parent instanceof ReturnTree) {
+        fix.postfixWith(identifier, ".build()");
+      }
+      return null;
+    }
+  }
+
+  @AutoValue
+  abstract static class TypeDetails {
+    abstract String immutableType();
+
+    abstract String builderType();
+
+    abstract Matcher<ExpressionTree> appendMethods();
+
+    abstract Matcher<Tree> skipTypes();
+
+    static TypeDetails of(
+        String immutableType, Matcher<ExpressionTree> appendMethods, Matcher<Tree> skipTypes) {
+      return new AutoValue_MixedMutabilityReturnType_TypeDetails(
+          immutableType, immutableType + ".Builder", appendMethods, skipTypes);
+    }
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ModifiedButNotUsed.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ModifiedButNotUsed.java
@@ -351,7 +351,7 @@ public class ModifiedButNotUsed extends BugChecker implements VariableTreeMatche
         withoutSideEffects.replace(enclosingStatement, "");
       }
       return encounteredSideEffects
-          ? ImmutableList.of(withSideEffects.build(), withoutSideEffects.build())
+          ? ImmutableList.of(withoutSideEffects.build(), withSideEffects.build())
           : ImmutableList.of(withoutSideEffects.build());
     }
   }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MutableConstantField.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MutableConstantField.java
@@ -34,11 +34,8 @@ import com.google.errorprone.matchers.MultiMatcher;
 import com.google.errorprone.matchers.MultiMatcher.MultiMatchResult;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AnnotationTree;
-import com.sun.source.tree.IdentifierTree;
-import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
-import com.sun.source.util.SimpleTreeVisitor;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import javax.lang.model.element.ElementKind;
@@ -93,7 +90,7 @@ public final class MutableConstantField extends BugChecker implements VariableTr
     Type newLhsType = state.getTypeFromString(newLhsTypeQualifiedName);
     SuggestedFix.Builder fixBuilder = SuggestedFix.builder();
     fixBuilder.replace(
-        getTypeTree(lhsTree),
+        ASTHelpers.getErasedTypeTree(lhsTree),
         SuggestedFixes.qualifyType(state, fixBuilder, newLhsType.asElement()));
     SuggestedFix fix = fixBuilder.build();
 
@@ -117,21 +114,4 @@ public final class MutableConstantField extends BugChecker implements VariableTr
   private static boolean isConstantFieldName(String fieldName) {
     return Ascii.toUpperCase(fieldName).equals(fieldName);
   }
-
-  private static Tree getTypeTree(Tree tree) {
-    return tree.accept(GET_TYPE_TREE_VISITOR, null /* unused */);
-  }
-
-  private static final SimpleTreeVisitor<Tree, Void> GET_TYPE_TREE_VISITOR =
-      new SimpleTreeVisitor<Tree, Void>() {
-        @Override
-        public Tree visitIdentifier(IdentifierTree tree, Void unused) {
-          return tree;
-        }
-
-        @Override
-        public Tree visitParameterizedType(ParameterizedTypeTree tree, Void unused) {
-          return tree.getType();
-        }
-      };
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MutableMethodReturnType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MutableMethodReturnType.java
@@ -34,13 +34,10 @@ import com.google.errorprone.matchers.InjectMatchers;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
-import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MethodTree;
-import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.source.tree.Tree;
-import com.sun.source.util.SimpleTreeVisitor;
 import com.sun.source.util.TreeScanner;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Type;
@@ -105,7 +102,7 @@ public final class MutableMethodReturnType extends BugChecker implements MethodT
 
     Type newReturnType = state.getTypeFromString(immutableReturnType.get());
     SuggestedFix.Builder fixBuilder = SuggestedFix.builder();
-    Tree typeTree = getTypeTree(methodTree.getReturnType());
+    Tree typeTree = ASTHelpers.getErasedTypeTree(methodTree.getReturnType());
     verify(typeTree != null, "Could not find return type of %s", methodTree);
     fixBuilder.replace(
         typeTree, SuggestedFixes.qualifyType(state, fixBuilder, newReturnType.asElement()));
@@ -181,21 +178,4 @@ public final class MutableMethodReturnType extends BugChecker implements MethodT
         null /* unused */);
     return returnTypes.build();
   }
-
-  private static Tree getTypeTree(Tree tree) {
-    return tree.accept(GET_TYPE_TREE_VISITOR, null /* unused */);
-  }
-
-  private static final SimpleTreeVisitor<Tree, Void> GET_TYPE_TREE_VISITOR =
-      new SimpleTreeVisitor<Tree, Void>() {
-        @Override
-        public Tree visitIdentifier(IdentifierTree tree, Void unused) {
-          return tree;
-        }
-
-        @Override
-        public Tree visitParameterizedType(ParameterizedTypeTree tree, Void unused) {
-          return tree.getType();
-        }
-      };
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/Unused.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Unused.java
@@ -789,7 +789,7 @@ public final class Unused extends BugChecker implements CompilationUnitTreeMatch
       removeSideEffectsFix.replace(statement, replacement);
     }
     return encounteredSideEffects
-        ? ImmutableList.of(fix.build(), removeSideEffectsFix.build())
+        ? ImmutableList.of(removeSideEffectsFix.build(), fix.build())
         : ImmutableList.of(fix.build());
   }
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/RefersToDaggerCodegen.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/RefersToDaggerCodegen.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.inject.dagger;
+
+import static com.google.auto.common.AnnotationMirrors.getAnnotationValue;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.code.Attribute;
+import com.sun.tools.javac.code.Attribute.Compound;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.util.Name;
+import java.util.List;
+import javax.lang.model.element.AnnotationValue;
+
+/**
+ * Checks that the only code that refers to Dagger generated code is other Dagger generated code.
+ */
+@BugPattern(
+    name = "RefersToDaggerCodegen",
+    summary = "Don't refer to Dagger's internal or generated code",
+    severity = SeverityLevel.ERROR)
+public final class RefersToDaggerCodegen extends BugChecker implements MethodInvocationTreeMatcher {
+  private static final ImmutableSet<String> DAGGER_INTERNAL_PACKAGES =
+      ImmutableSet.of(
+          "dagger.internal",
+          "dagger.producers.internal",
+          "dagger.producers.monitoring.internal",
+          "dagger.android.internal");
+  private static final ImmutableSet<String> GENERATED_BASE_TYPES =
+      ImmutableSet.of("dagger.internal.Factory", "dagger.producers.internal.AbstractProducer");
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    MethodSymbol method = getSymbol(tree);
+    ClassSymbol rootClassOfMethod = method.outermostClass();
+
+    if (!isGeneratedFactoryType(rootClassOfMethod, state)
+        && !isMembersInjectionInvocation(method, state)
+        && !isDaggerInternalClass(rootClassOfMethod)) {
+      return Description.NO_MATCH;
+    }
+
+    if (isAllowedToReferenceDaggerInternals(state)) {
+      return Description.NO_MATCH;
+    }
+
+    return describeMatch(tree);
+  }
+
+  private boolean isMembersInjectionInvocation(MethodSymbol method, VisitorState state) {
+    if (method.getSimpleName().contentEquals("injectMembers")) {
+      return false;
+    }
+    return isGeneratedBaseType(method.outermostClass(), state, "dagger.MembersInjector");
+  }
+
+  // TODO(ronshapiro): if we ever start emitting an annotation that has class retention, use that
+  // instead of checking for subtypes of generated code
+  private static boolean isGeneratedFactoryType(ClassSymbol symbol, VisitorState state) {
+    // TODO(ronshapiro): check annotation creators, inaccessible map key proxies, or inaccessible
+    // module constructor proxies?
+    return GENERATED_BASE_TYPES.stream()
+        .anyMatch(baseType -> isGeneratedBaseType(symbol, state, baseType));
+  }
+
+  private static boolean isGeneratedBaseType(
+      ClassSymbol symbol, VisitorState state, String baseTypeName) {
+    Type baseType = state.getTypeFromString(baseTypeName);
+    return ASTHelpers.isSubtype(symbol.asType(), baseType, state);
+  }
+
+  private static boolean isDaggerInternalClass(ClassSymbol symbol) {
+    return DAGGER_INTERNAL_PACKAGES.contains(symbol.packge().getQualifiedName().toString());
+  }
+
+  private static boolean isAllowedToReferenceDaggerInternals(VisitorState state) {
+    ClassSymbol rootCallingClass = getSymbol(state.findEnclosing(ClassTree.class)).outermostClass();
+    if (rootCallingClass.getQualifiedName().toString().startsWith("dagger.")) {
+      return true;
+    }
+
+    for (Compound annotation : rootCallingClass.getAnnotationMirrors()) {
+      Name annotationName =
+          ((ClassSymbol) annotation.getAnnotationType().asElement()).getQualifiedName();
+      if (annotationName.contentEquals("javax.annotation.Generated")
+          || annotationName.contentEquals("javax.annotation.processing.Generated")) {
+        AnnotationValue valueAttribute = getAnnotationValue(annotation, "value");
+        @SuppressWarnings("unchecked")
+        List<Attribute> valuesList = (List<Attribute>) valueAttribute.getValue();
+        return valuesList.size() == 1
+            && getOnlyElement(valuesList)
+                .getValue()
+                .equals("dagger.internal.codegen.ComponentProcessor");
+      }
+    }
+    return false;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -32,6 +32,7 @@ import com.google.errorprone.bugpatterns.ArraysAsListPrimitiveArray;
 import com.google.errorprone.bugpatterns.AssertFalse;
 import com.google.errorprone.bugpatterns.AssertThrowsMultipleStatements;
 import com.google.errorprone.bugpatterns.AssertionFailureIgnored;
+import com.google.errorprone.bugpatterns.AssignmentToMock;
 import com.google.errorprone.bugpatterns.AsyncCallableReturnsNull;
 import com.google.errorprone.bugpatterns.AsyncFunctionReturnsNull;
 import com.google.errorprone.bugpatterns.AutoValueFinalMethods;
@@ -577,6 +578,7 @@ public class BuiltInCheckerSuppliers {
           AssertEqualsArgumentOrderChecker.class,
           AssertThrowsMultipleStatements.class,
           AssertionFailureIgnored.class,
+          AssignmentToMock.class,
           AutoValueFinalMethods.class,
           AutoValueImmutableFields.class,
           BadAnnotationImplementation.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -162,6 +162,7 @@ import com.google.errorprone.bugpatterns.MissingTestCall;
 import com.google.errorprone.bugpatterns.MisusedWeekYear;
 import com.google.errorprone.bugpatterns.MixedArrayDimensions;
 import com.google.errorprone.bugpatterns.MixedDescriptors;
+import com.google.errorprone.bugpatterns.MixedMutabilityReturnType;
 import com.google.errorprone.bugpatterns.MockitoCast;
 import com.google.errorprone.bugpatterns.MockitoInternalUsage;
 import com.google.errorprone.bugpatterns.MockitoUsage;
@@ -651,6 +652,7 @@ public class BuiltInCheckerSuppliers {
           MissingFail.class,
           MissingOverride.class,
           MixedDescriptors.class,
+          MixedMutabilityReturnType.class,
           MockitoInternalUsage.class,
           ModifiedButNotUsed.class,
           ModifyCollectionInEnhancedForLoop.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -336,6 +336,7 @@ import com.google.errorprone.bugpatterns.inject.dagger.AndroidInjectionBeforeSup
 import com.google.errorprone.bugpatterns.inject.dagger.EmptySetMultibindingContributions;
 import com.google.errorprone.bugpatterns.inject.dagger.PrivateConstructorForNoninstantiableModule;
 import com.google.errorprone.bugpatterns.inject.dagger.ProvidesNull;
+import com.google.errorprone.bugpatterns.inject.dagger.RefersToDaggerCodegen;
 import com.google.errorprone.bugpatterns.inject.dagger.ScopeOnModule;
 import com.google.errorprone.bugpatterns.inject.dagger.UseBinds;
 import com.google.errorprone.bugpatterns.inject.guice.AssistedInjectScoping;
@@ -547,6 +548,7 @@ public class BuiltInCheckerSuppliers {
           RandomModInteger.class,
           RandomCast.class,
           RectIntersectReturnValueIgnored.class,
+          RefersToDaggerCodegen.class,
           RestrictedApiChecker.class,
           ReturnValueIgnored.class,
           SelfAssignment.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/AssignmentToMockTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/AssignmentToMockTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link AssignmentToMock}. */
+@RunWith(JUnit4.class)
+public final class AssignmentToMockTest {
+  private final CompilationTestHelper testHelper =
+      CompilationTestHelper.newInstance(AssignmentToMock.class, getClass());
+
+  private final BugCheckerRefactoringTestHelper refactoringHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new AssignmentToMock(), getClass());
+
+  @Test
+  public void positive() {
+    testHelper
+        .addSourceLines(
+            "Test.java", //
+            "import org.mockito.Mock;",
+            "class Test {",
+            "  // BUG: Diagnostic contains:",
+            "  @Mock Object mockObject = new Object();",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative() {
+    testHelper
+        .addSourceLines(
+            "Test.java", //
+            "import org.mockito.Mock;",
+            "class Test {",
+            "  @Mock Object mockObject;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void refactoring() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java", //
+            "import org.mockito.Mock;",
+            "class Test {",
+            "  @Mock Object mockObject = new Object();",
+            "}")
+        .addOutputLines(
+            "Test.java", //
+            "import org.mockito.Mock;",
+            "class Test {",
+            "  @Mock Object mockObject;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void initializedViaInitMocks() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import org.mockito.Mock;",
+            "import org.mockito.Mockito;",
+            "import org.mockito.MockitoAnnotations;",
+            "class Test {",
+            "  @Mock Object mockObject = Mockito.mock(Object.class);",
+            "  void before() {",
+            "    MockitoAnnotations.initMocks(this);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import org.mockito.Mock;",
+            "import org.mockito.Mockito;",
+            "import org.mockito.MockitoAnnotations;",
+            "class Test {",
+            "  @Mock Object mockObject;",
+            "  void before() {",
+            "    MockitoAnnotations.initMocks(this);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void noInitializerPresent_retainManualInitialization() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java", //
+            "import org.mockito.Mock;",
+            "import org.mockito.Mockito;",
+            "class Test {",
+            "  @Mock Object mockObject = Mockito.mock(Object.class);",
+            "}")
+        .addOutputLines(
+            "Test.java", //
+            "import org.mockito.Mock;",
+            "import org.mockito.Mockito;",
+            "class Test {",
+            "  Object mockObject = Mockito.mock(Object.class);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void initializedViaRunner() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java", //
+            "import org.junit.runner.RunWith;",
+            "import org.mockito.Mock;",
+            "import org.mockito.Mockito;",
+            "import org.mockito.runners.MockitoJUnitRunner;",
+            "@RunWith(MockitoJUnitRunner.class)",
+            "public class Test {",
+            "  @Mock Object mockObject = Mockito.mock(Object.class);",
+            "}")
+        .addOutputLines(
+            "Test.java", //
+            "import org.junit.runner.RunWith;",
+            "import org.mockito.Mock;",
+            "import org.mockito.Mockito;",
+            "import org.mockito.runners.MockitoJUnitRunner;",
+            "@RunWith(MockitoJUnitRunner.class)",
+            "public class Test {",
+            "  @Mock Object mockObject;",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MixedMutabilityReturnTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MixedMutabilityReturnTypeTest.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.BugCheckerRefactoringTestHelper.FixChoosers;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link MixedMutabilityReturnType} bugpattern. */
+@RunWith(JUnit4.class)
+public final class MixedMutabilityReturnTypeTest {
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(MixedMutabilityReturnType.class, getClass());
+  private final BugCheckerRefactoringTestHelper refactoringHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new MixedMutabilityReturnType(), getClass());
+
+  @Test
+  public void positive() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Collections;",
+            "import java.util.List;",
+            "import java.util.ArrayList;",
+            "class Test {",
+            "  // BUG: Diagnostic contains: MixedMutabilityReturnType",
+            "  List<Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return Collections.emptyList();",
+            "    }",
+            "    return new ArrayList<>();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void tracksActualVariableTypes() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Collections;",
+            "import java.util.List;",
+            "import java.util.ArrayList;",
+            "class Test {",
+            "  // BUG: Diagnostic contains: MixedMutabilityReturnType",
+            "  List<Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return Collections.emptyList();",
+            "    }",
+            "    List<Integer> ints = new ArrayList<>();",
+            "    return ints;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void uninferrableTypes_noMatch() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Collections;",
+            "import java.util.List;",
+            "import java.util.ArrayList;",
+            "class Test {",
+            "  List<Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return Collections.emptyList();",
+            "    }",
+            "    return bar();",
+            "  }",
+            "  List<Integer> bar() {",
+            "    return new ArrayList<>();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void allImmutable_noMatch() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Collections;",
+            "import java.util.List;",
+            "import java.util.ArrayList;",
+            "class Test {",
+            "  List<Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return Collections.emptyList();",
+            "    }",
+            "    return Collections.singletonList(1);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nullType_noMatch() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Collections;",
+            "import java.util.List;",
+            "import java.util.ArrayList;",
+            "class Test {",
+            "  List<Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return null;",
+            "    }",
+            "    return Collections.singletonList(1);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void simpleRefactoring() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import java.util.ArrayList;",
+            "import java.util.Collections;",
+            "import java.util.List;",
+            "final class Test {",
+            "  List<Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return Collections.emptyList();",
+            "    }",
+            "    List<Integer> ints = new ArrayList<>();",
+            "    ints.add(1);",
+            "    return ints;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableList;",
+            "import java.util.ArrayList;",
+            "import java.util.Collections;",
+            "import java.util.List;",
+            "final class Test {",
+            "  ImmutableList<Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return ImmutableList.of();",
+            "    }",
+            "    ImmutableList.Builder<Integer> ints = ImmutableList.builder();",
+            "    ints.add(1);",
+            "    return ints.build();",
+            "  }",
+            "}")
+        .setFixChooser(FixChoosers.SECOND)
+        .doTest();
+  }
+
+  @Test
+  public void refactoringOverridable() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import java.util.ArrayList;",
+            "import java.util.Collections;",
+            "import java.util.List;",
+            "class Test {",
+            "  List<Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return Collections.emptyList();",
+            "    }",
+            "    List<Integer> ints = new ArrayList<>();",
+            "    ints.add(1);",
+            "    return ints;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableList;",
+            "import java.util.ArrayList;",
+            "import java.util.Collections;",
+            "import java.util.List;",
+            "class Test {",
+            "  List<Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return ImmutableList.of();",
+            "    }",
+            "    List<Integer> ints = new ArrayList<>();",
+            "    ints.add(1);",
+            "    return ImmutableList.copyOf(ints);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void refactoringCantReplaceWithBuilder() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableList;",
+            "import java.util.ArrayList;",
+            "import java.util.Collections;",
+            "import java.util.List;",
+            "final class Test {",
+            "  List<Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return ImmutableList.of();",
+            "    }",
+            "    List<Integer> ints = new ArrayList<>();",
+            "    ints.add(1);",
+            "    ints.clear();",
+            "    ints.add(2);",
+            "    return ints;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableList;",
+            "import java.util.ArrayList;",
+            "import java.util.Collections;",
+            "import java.util.List;",
+            "final class Test {",
+            "  ImmutableList<Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return ImmutableList.of();",
+            "    }",
+            "    List<Integer> ints = new ArrayList<>();",
+            "    ints.add(1);",
+            "    ints.clear();",
+            "    ints.add(2);",
+            "    return ImmutableList.copyOf(ints);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void refactoringIgnoresAlreadyImmutableMap() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableMap;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "final class Test {",
+            "  Map<Integer, Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return ImmutableMap.of(1, 1);",
+            "    }",
+            "    Map<Integer, Integer> ints = new HashMap<>();",
+            "    ints.put(2, 2);",
+            "    return ints;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableMap;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "final class Test {",
+            "  ImmutableMap<Integer, Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return ImmutableMap.of(1, 1);",
+            "    }",
+            "    ImmutableMap.Builder<Integer, Integer> ints = ImmutableMap.builder();",
+            "    ints.put(2, 2);",
+            "    return ints.build();",
+            "  }",
+            "}")
+        .setFixChooser(FixChoosers.SECOND)
+        .doTest();
+  }
+
+  @Test
+  public void refactoringGuavaFactories() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableList;",
+            "import com.google.common.collect.Lists;",
+            "import java.util.List;",
+            "final class Test {",
+            "  List<Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return ImmutableList.of(1);",
+            "    } else if (hashCode() < 0) {",
+            "      List<Integer> ints = Lists.newArrayList();",
+            "      ints.add(2);",
+            "      return ints;",
+            "    } else {",
+            "      List<Integer> ints = Lists.newArrayList(1, 3);",
+            "      ints.add(2);",
+            "      return ints;",
+            "    }",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableList;",
+            "import com.google.common.collect.Lists;",
+            "import java.util.List;",
+            "final class Test {",
+            "  ImmutableList<Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return ImmutableList.of(1);",
+            "    } else if (hashCode() < 0) {",
+            "      ImmutableList.Builder<Integer> ints = ImmutableList.builder();",
+            "      ints.add(2);",
+            "      return ints.build();",
+            "    } else {",
+            "      List<Integer> ints = Lists.newArrayList(1, 3);",
+            "      ints.add(2);",
+            "      return ImmutableList.copyOf(ints);",
+            "    }",
+            "  }",
+            "}")
+        .setFixChooser(FixChoosers.SECOND)
+        .doTest();
+  }
+
+  @Test
+  public void refactoringTreeMap() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableMap;",
+            "import java.util.Map;",
+            "import java.util.TreeMap;",
+            "final class Test {",
+            "  Map<Integer, Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return ImmutableMap.of(1, 1);",
+            "    }",
+            "    Map<Integer, Integer> ints = new TreeMap<>();",
+            "    ints.put(2, 1);",
+            "    return ints;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableMap;",
+            "import java.util.Map;",
+            "import java.util.TreeMap;",
+            "final class Test {",
+            "  ImmutableMap<Integer, Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return ImmutableMap.of(1, 1);",
+            "    }",
+            "    Map<Integer, Integer> ints = new TreeMap<>();",
+            "    ints.put(2, 1);",
+            "    return ImmutableMap.copyOf(ints);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void refactoringNonLocalReturnedVariable() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import java.util.ArrayList;",
+            "import java.util.Collections;",
+            "import java.util.List;",
+            "class Test {",
+            "  List<Integer> ints = new ArrayList<>();",
+            "  List<Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return Collections.emptyList();",
+            "    }",
+            "    ints.add(1);",
+            "    return ints;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableList;",
+            "import java.util.ArrayList;",
+            "import java.util.Collections;",
+            "import java.util.List;",
+            "class Test {",
+            "  List<Integer> ints = new ArrayList<>();",
+            "  List<Integer> foo() {",
+            "    if (hashCode() > 0) {",
+            "      return ImmutableList.of();",
+            "    }",
+            "    ints.add(1);",
+            "    return ImmutableList.copyOf(ints);",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ModifiedButNotUsedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ModifiedButNotUsedTest.java
@@ -17,6 +17,7 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.BugCheckerRefactoringTestHelper.FixChoosers;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,7 +59,7 @@ public final class ModifiedButNotUsedTest {
   }
 
   @Test
-  public void sideEffectFreeRefactoring() throws Exception {
+  public void sideEffectFreeRefactoring() {
     refactoringHelper
         .addInputLines(
             "Test.java",
@@ -72,7 +73,36 @@ public final class ModifiedButNotUsedTest {
             "    bar.add(sideEffects());",
             "    List<Integer> baz;",
             "    baz = new ArrayList<>();",
+            "    baz.add(sideEffects());",
+            "  }",
+            "  int sideEffects() { return 1; }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.util.ArrayList;",
+            "import java.util.List;",
+            "class Test {",
+            "  void test() {",
+            "  }",
+            "  int sideEffects() { return 1; }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void sideEffectPreservingRefactoring() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import java.util.ArrayList;",
+            "import java.util.List;",
+            "class Test {",
+            "  void test() {",
+            "    List<Integer> bar = new ArrayList<>();",
             "    bar.add(sideEffects());",
+            "    List<Integer> baz;",
+            "    baz = new ArrayList<>();",
+            "    baz.add(sideEffects());",
             "  }",
             "  int sideEffects() { return 1; }",
             "}")
@@ -87,6 +117,7 @@ public final class ModifiedButNotUsedTest {
             "  }",
             "  int sideEffects() { return 1; }",
             "}")
+        .setFixChooser(FixChoosers.SECOND)
         .doTest();
   }
 
@@ -197,7 +228,7 @@ public final class ModifiedButNotUsedTest {
 
   @Test
   @Ignore("b/74365407 test proto sources are broken")
-  public void protoSideEffects() throws Exception {
+  public void protoSideEffects() {
     refactoringHelper
         .addInputLines(
             "Test.java",
@@ -222,6 +253,7 @@ public final class ModifiedButNotUsedTest {
             "  }",
             "  TestFieldProtoMessage sideEffects() { throw new UnsupportedOperationException(); }",
             "}")
+        .setFixChooser(FixChoosers.SECOND)
         .doTest();
   }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NarrowingCompoundAssignmentTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NarrowingCompoundAssignmentTest.java
@@ -229,6 +229,21 @@ public class NarrowingCompoundAssignmentTest {
   }
 
   @Test
+  public void testPreservePrecedence3() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void m() {",
+            "    float f = 0;",
+            "    // BUG: Diagnostic contains: f = (float) (f - (3.0 > 0 ? 1.0 : 2.0))",
+            "    f -= 3.0 > 0 ? 1.0 : 2.0;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void testPreservePrecedenceExhaustive() throws Exception {
     testPrecedence("*", "*", /* parens= */ true);
     testPrecedence("*", "+", /* parens= */ true);

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedTest.java
@@ -789,7 +789,7 @@ public class UnusedTest {
             "     ImmutableList.of();",
             "  }",
             "}")
-        .setFixChooser(FixChoosers.FIRST)
+        .setFixChooser(FixChoosers.SECOND)
         .doTest();
   }
 
@@ -812,7 +812,6 @@ public class UnusedTest {
             "  void test() {",
             "  }",
             "}")
-        .setFixChooser(FixChoosers.SECOND)
         .doTest();
   }
 
@@ -1026,6 +1025,7 @@ public class UnusedTest {
             "Test.java", //
             "class Test {",
             "  public int a() {",
+            "    a();",
             "    return 1;",
             "  }",
             "}")

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/RefersToDaggerCodegenTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/RefersToDaggerCodegenTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.inject.dagger;
+
+import com.google.errorprone.CompilationTestHelper;
+import javax.inject.Inject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link RefersToDaggerCodegen}. */
+@RunWith(JUnit4.class)
+public class RefersToDaggerCodegenTest {
+  private static final String PACKAGE_NAME = InjectedClass.class.getPackage().getName();
+  private static final String FULLY_QUALIFIED_FACTORY_NAME =
+      PACKAGE_NAME + ".RefersToDaggerCodegenTest_InjectedClass_Factory";
+
+  private CompilationTestHelper compilationTestHelper =
+      CompilationTestHelper.newInstance(RefersToDaggerCodegen.class, getClass());
+
+  static class InjectedClass {
+    @Inject
+    InjectedClass() {}
+  }
+
+  public static class LooksLike_Factory {
+    public static LooksLike_Factory create() {
+      return new LooksLike_Factory();
+    }
+  }
+
+  public static class MembersInjectedClass {
+    @Inject Object object;
+  }
+
+  @Test
+  public void testPositiveCase() {
+    compilationTestHelper
+        .addSourceLines(
+            "in/TestClass.java",
+            "import static " + FULLY_QUALIFIED_FACTORY_NAME + ".create;",
+            "import " + FULLY_QUALIFIED_FACTORY_NAME + ";",
+            "",
+            "class TestClass {",
+            "  void TestClass() {",
+            "    // BUG: Diagnostic contains: Dagger's internal or generated code",
+            "    RefersToDaggerCodegenTest_InjectedClass_Factory.create();",
+            "",
+            "    // BUG: Diagnostic contains: Dagger's internal or generated code",
+            "    " + FULLY_QUALIFIED_FACTORY_NAME + ".create();",
+            "",
+            "    // BUG: Diagnostic contains: Dagger's internal or generated code",
+            "    create();",
+            "",
+            "    // BUG: Diagnostic contains: Dagger's internal or generated code",
+            "    RefersToDaggerCodegenTest_InjectedClass_Factory.newInstance();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void okToReferenceInDaggerCodegen() {
+    String generatedAnnotationName;
+    try {
+      Class.forName("java.lang.Module");
+      generatedAnnotationName = "javax.annotation.processing.Generated";
+    } catch (ClassNotFoundException e) {
+      generatedAnnotationName = "javax.annotation.Generated";
+    }
+    compilationTestHelper
+        .addSourceLines(
+            "in/TestClass.java",
+            "import static " + FULLY_QUALIFIED_FACTORY_NAME + ".create;",
+            "import " + FULLY_QUALIFIED_FACTORY_NAME + ";",
+            "",
+            "@" + generatedAnnotationName + "(\"dagger.internal.codegen.ComponentProcessor\")",
+            "class TestClass {",
+            "  void TestClass() {",
+            "    RefersToDaggerCodegenTest_InjectedClass_Factory.create();",
+            "",
+            "    " + FULLY_QUALIFIED_FACTORY_NAME + ".create();",
+            "",
+            "    create();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void dontErrorOnCodeThatLooksLikeDaggerGeneration() {
+    String looksLikeFactoryFullyQualifiedName =
+        PACKAGE_NAME + ".RefersToDaggerCodegenTest.LooksLike_Factory";
+    compilationTestHelper
+        .addSourceLines(
+            "in/TestClass.java",
+            "import static " + looksLikeFactoryFullyQualifiedName + ".create;",
+            "import " + looksLikeFactoryFullyQualifiedName + ";",
+            "",
+            "class TestClass {",
+            "  void TestClass() {",
+            "    LooksLike_Factory.create();",
+            "",
+            "    " + looksLikeFactoryFullyQualifiedName + ".create();",
+            "",
+            "    create();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void membersInjector() {
+    compilationTestHelper
+        .addSourceLines(
+            "in/TestClass.java",
+            "import dagger.MembersInjector;",
+            "import " + PACKAGE_NAME + ".RefersToDaggerCodegenTest;",
+            "import "
+                + PACKAGE_NAME
+                + ".RefersToDaggerCodegenTest_MembersInjectedClass_MembersInjector;",
+            "",
+            "class TestClass {",
+            "  void TestClass() {",
+            "    // BUG: Diagnostic contains: Dagger's internal or generated code",
+            "    RefersToDaggerCodegenTest_MembersInjectedClass_MembersInjector.create(null);",
+            "",
+            "    MembersInjector<RefersToDaggerCodegenTest.MembersInjectedClass> membersInjector",
+            "        = null;",
+            "    membersInjector.injectMembers(null);", // allowed
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/docs/bugpattern/AssignmentToMock.md
+++ b/docs/bugpattern/AssignmentToMock.md
@@ -1,0 +1,6 @@
+The `@Mock` annotation is used to automatically initialize mocks using
+`MockitoAnnotations.initMocks`, or `MockitoJUnitRunner`.
+
+Variables annotated this way should not be explicitly initialized, as this will
+be overwritten by automatic initialization.
+

--- a/docs/bugpattern/GuardedBy.md
+++ b/docs/bugpattern/GuardedBy.md
@@ -4,7 +4,7 @@ The GuardedBy analysis checks that fields or methods annotated with
 Example:
 
 ```java
-import javax.annotation.concurrent.GuardedBy;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 
 class Account {
   @GuardedBy("this")
@@ -106,7 +106,7 @@ should be deterministic.
 
 #### @GuardedBy
 
-javax.annotation.concurrent.GuardedBy
+com.google.errorprone.annotations.concurrent.GuardedBy
 
 The @GuardedBy annotation is used to document that a member (a field or a
 method) can only be accessed when the specified lock is held.
@@ -129,6 +129,12 @@ void m() {
   }
 }
 ```
+
+Note: there are a couple more annotations called `@GuardedBy`, including 
+`javax.annotation.concurrent.GuardedBy` and
+`org.checkerframework.checker.lock.qual.GuardedBy`. The check recognizes those
+versions of the annotation, but we recommend using
+`com.google.errorprone.annotations.concurrent.GuardedBy`.
 
 #### @LockMethod
 

--- a/docs/bugpattern/MethodCanBeStatic.md
+++ b/docs/bugpattern/MethodCanBeStatic.md
@@ -1,30 +1,22 @@
-Consider a method that doesn't override and is not overrideable. Note first that
-such a method should declare only the parameters it actually needs; this is
-widely accepted as a good general practice.
+Consider an instance method that is not an override, is not overrideable itself,
+and never accesses this (explicitly or implicitly) in its implementation. Such a
+method can always be marked `static` without harm.
 
-But if this is an *instance* method that never refers to `this` (either
-explicitly or implicitly), the resulting situation is actually quite similar to
-that of the unused parameter. This method is static "in spirit", yet calling it
-requires an extra "parameter", so to speak -- a receiver.
+The main benefit of adding `static` is that a caller who wants to use the method
+and doesn't already have an instance handy won't have to conjure one up
+unnecessarily. Doing that is a pain, and in unit tests it also creates the false
+impression that instances in multiple states need to be tested.
 
-Adding an explicit `static` keyword to such a method is conceptually similar to
-removing that unused parameter. This has several desirable effects:
+But adding `static` also benefits your implementation in some ways. It becomes a
+little easier to read and to reason about, since you don't need to wonder how it
+might be interacting with instance state. And auto-completion will stop
+suggesting the names of instance fields and methods (which you probably don't
+want to use).
 
-*   An actual static method can call your method if it wants to, without having
-    to figure out an instance to call it on.
-*   It makes it clear (and, indeed, guarantees) that the method's behavior
-    relies only on its parameters and not on instance state.
-
-<!-- if we extend this to include package-visible members, then the ability to
-     unit-test normally is another advantage. -->
-
-Another effect of adding `static` is that it renders instance fields and methods
-inaccessible within the body of the method, so (for example) an auto-completion
-feature won't suggest them.
-
-A common reason to omit `static` is when you believe the method may need to
-access instance state in the future. However, it usually works fine to just
-remove `static` if and when it becomes necessary. You'd have to revisit any
-calls that accrued in static contexts, but that's probably no worse than those
-callers being out of luck in the first place.
+This analogy might work for you: it's widely accepted that a method like this
+shouldn't declare any parameters it doesn't actually use; such parameters should
+normally be removed. This situation with `static` is fairly similar: in either
+case there is one additional instance the caller needs to have in order to
+access the method. So, adding `static` is conceptually similar to removing that
+unused parameter.
 

--- a/docs/bugpattern/MixedMutabilityReturnType.md
+++ b/docs/bugpattern/MixedMutabilityReturnType.md
@@ -1,0 +1,31 @@
+It is dangerous for a method to return a mutable instance in some circumstances,
+but immutable in others. Doing so may lead users of your API to make incorrect
+assumptions about the mutability of the return type. For example, consider this
+method:
+
+```java {.bad}
+List<Integer> primeFactors(int n) {
+  if (isPrime(n)) {
+    return Collections.singletonList(n);
+  }
+  List<Integer> factors = new ArrayList<>();
+  for (...) {
+    factors.add(i);
+  }
+  return factors;
+}
+```
+
+If someone were to add another method to include the trivial factor `1`, a bug
+will be introduced.
+
+```java
+List<Integer> primeFactorsAndOne(int n) {
+  List<Integer> primeFactors = primeFactors(n);
+  primeFactors.add(1);
+  return primeFactors;
+}
+```
+
+`primeFactorsAndOne` will behave as intended for composite numbers, but throw an
+exception for primes.

--- a/docs/bugpattern/MoveToSafeHtmlResponse.md
+++ b/docs/bugpattern/MoveToSafeHtmlResponse.md
@@ -1,0 +1,3 @@
+Prefer SafeHtmlResponse to HtmlResponse to avoid cross-side-scripting attacks.
+See go/safehtmltypes#java and go/prevent-xss for more information.
+


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a bugpattern to detect methods which return a mixture of immutable and mutable types.

RELNOTES: [MixedMutabilityReturnType] flag methods which return both mutable and immutable types

1e67d9fcef7e932d9975de13ee5ccab3ed0a129b

-------

<p> UnescapedEntity: don't suggest wrapping in {@code } in code/pre tags if the enclosing content contains HTML entities or annotations.

Instead, escape 'em individually. Otherwise, we can produce fixes that just make life worse.

RELNOTES: N/A

9c4c0d5156e28b110debe1b5901f815c60c25641

-------

<p> consistently check for declaration annotations in addition to type annotations in nullness qualifier inference.
Includes recognizing checkerframework's @NonNullDecl
RELNOTES: None.

b39ec304145c33d9db4f2cfcdf04dee3c5ae0a5a

-------

<p> Remove an unnecessary indefinite article.

As it stands, this produces messages like this:
"AutoValue instances should be deeply immutable. Therefore, we recommend returning a ImmutableMap instead." Saying "...return ImmutableMap" reads just as well in addition to being grammatically correct.

eb5ee7cf25cff59c74874e4935e0cd262a8540c1

-------

<p> AssignmentToMock: discourage manual assignment to fields annotated with @Mock.

RELNOTES: AssignmentToMock: discourage manual assignment to fields annotated with @Mock.

5710e010a50a7eac9a4289bde0af1139dfb137bb

-------

<p> Use non-deprecated GuardedBy annotation

b30d92ef7012238ff518dd60b89465741ffc147f

-------

<p> Prevent user-written code from referring to Dagger-generated implementation code

RELNOTES: New check that prevents user-written code from referring to Dagger-generated implementation code

4a0147a79dfcea25a3bbbc923955bd884aeef175

-------

<p> Update MethodCanBeStatic docs

RELNOTES: N/A

e68592b05e41c2659667d66b98eaa3ff15bb81fe

-------

<p> Put the side-effect-removing fix first in ModifiedButNotUsed and Unused.

Also simplify the heuristics used in SideEffectAnalysis; they're very
limited, and wrong anyway, so we might as well just consider any method
invocation as possibly side-effecting.

RELNOTES: N/A

63b685fc2d3f2f70cbfaf89ddd111c3e15d3a61e