### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
@@ -1264,7 +1264,7 @@ public class Matchers {
    * Converts the given matcher to one that can be applied to any tree but is only executed when run
    * on a tree of {@code type} and returns {@code false} for all other tree types.
    */
-  public static <S extends Tree, T extends Tree> Matcher<T> toType(
+  public static <S extends T, T extends Tree> Matcher<T> toType(
       final Class<S> type, final Matcher<? super S> matcher) {
     return new Matcher<T>() {
       @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CompareToZero.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CompareToZero.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.Category.JDK;
+import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+import static com.google.errorprone.util.ASTHelpers.constValue;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.BinaryTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.ParenthesizedTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
+import com.sun.source.util.SimpleTreeVisitor;
+import com.sun.source.util.TreePath;
+
+/** Suggests comparing the result of {@code compareTo} to only {@code 0}. */
+@BugPattern(
+    name = "CompareToZero",
+    summary =
+        "The result of #compareTo or #compare should only be compared to 0. It is an "
+            + "implementation detail whether a given type returns strictly the values {-1, 0, +1} "
+            + "or others.",
+    category = JDK,
+    providesFix = REQUIRES_HUMAN_ATTENTION,
+    severity = WARNING)
+public final class CompareToZero extends BugChecker implements MethodInvocationTreeMatcher {
+  private static final String SUGGEST_IMPROVEMENT =
+      "It is generally more robust (and readable) to compare the result of #compareTo/#compare to"
+          + "0. Although the suggested replacement is identical in this case, we'd suggest it for"
+          + "consistency.";
+
+  private static final ImmutableSet<Kind> COMPARISONS =
+      ImmutableSet.of(
+          Kind.EQUAL_TO,
+          Kind.NOT_EQUAL_TO,
+          Kind.LESS_THAN,
+          Kind.LESS_THAN_EQUAL,
+          Kind.GREATER_THAN,
+          Kind.GREATER_THAN_EQUAL);
+
+  private static final ImmutableMap<Kind, Kind> REVERSE =
+      ImmutableMap.of(
+          Kind.LESS_THAN, Kind.GREATER_THAN,
+          Kind.LESS_THAN_EQUAL, Kind.GREATER_THAN_EQUAL,
+          Kind.GREATER_THAN, Kind.LESS_THAN,
+          Kind.GREATER_THAN_EQUAL, Kind.LESS_THAN_EQUAL);
+
+  private static final ImmutableSet<Kind> OTHER_STRANGE_OPERATIONS =
+      ImmutableSet.of(Kind.PLUS, Kind.MINUS);
+
+  private static final Matcher<ExpressionTree> COMPARE_TO =
+      anyOf(
+          instanceMethod().onDescendantOf("java.lang.Comparable").named("compareTo"),
+          instanceMethod().onDescendantOf("java.util.Comparator").named("compare"));
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (COMPARE_TO.matches(tree, state)) {
+      new Visitor().visitParent(state);
+    }
+    return NO_MATCH;
+  }
+
+  private final class Visitor extends SimpleTreeVisitor<Void, VisitorState> {
+    private Tree child;
+
+    @Override
+    public Void visitParenthesized(ParenthesizedTree parenthesizedTree, VisitorState state) {
+      return visitParent(state);
+    }
+
+    @Override
+    public Void visitBinary(BinaryTree binaryTree, VisitorState state) {
+      Kind kind = binaryTree.getKind();
+      if (OTHER_STRANGE_OPERATIONS.contains(kind)) {
+        state.reportMatch(describeMatch(binaryTree));
+        return null;
+      }
+      // `child` is the Tree we had before bubbling up to this BinaryTree. Check which side it
+      // corresponds to.
+      boolean reversed = binaryTree.getRightOperand() == child;
+      ExpressionTree comparatorSide =
+          reversed ? binaryTree.getRightOperand() : binaryTree.getLeftOperand();
+      ExpressionTree otherSide =
+          reversed ? binaryTree.getLeftOperand() : binaryTree.getRightOperand();
+      Integer constantInt = constValue(otherSide, Integer.class);
+      if (constantInt == null) {
+        return null;
+      }
+      if (constantInt == 0) {
+        return null;
+      }
+      if (binaryTree.getKind() == Kind.EQUAL_TO) {
+        SuggestedFix fix =
+            generateFix(binaryTree, state, comparatorSide, constantInt < 0 ? "<" : ">");
+        state.reportMatch(describeMatch(binaryTree, fix));
+        return null;
+      }
+      if (reversed) {
+        kind = REVERSE.get(kind);
+      }
+      if (kind == null) {
+        return null;
+      }
+      if ((kind == Kind.GREATER_THAN || kind == Kind.NOT_EQUAL_TO) && constantInt == -1) {
+        SuggestedFix fix = generateFix(binaryTree, state, comparatorSide, ">=");
+        state.reportMatch(describeMatch(binaryTree, fix));
+        return null;
+      }
+      if ((kind == Kind.LESS_THAN || kind == Kind.NOT_EQUAL_TO) && constantInt == 1) {
+        SuggestedFix fix = generateFix(binaryTree, state, comparatorSide, "<=");
+        state.reportMatch(describeMatch(binaryTree, fix));
+        return null;
+      }
+      if (kind == Kind.LESS_THAN_EQUAL && constantInt == -1) {
+        SuggestedFix fix = generateFix(binaryTree, state, comparatorSide, "<");
+        state.reportMatch(
+            buildDescription(binaryTree).setMessage(SUGGEST_IMPROVEMENT).addFix(fix).build());
+        return null;
+      }
+      if (kind == Kind.GREATER_THAN_EQUAL && constantInt == 1) {
+        SuggestedFix fix = generateFix(binaryTree, state, comparatorSide, ">");
+        state.reportMatch(
+            buildDescription(binaryTree).setMessage(SUGGEST_IMPROVEMENT).addFix(fix).build());
+      }
+      if (COMPARISONS.contains(binaryTree.getKind())) {
+        state.reportMatch(describeMatch(binaryTree));
+      }
+      return null;
+    }
+
+    private SuggestedFix generateFix(
+        BinaryTree binaryTree,
+        VisitorState state,
+        ExpressionTree comparatorSide,
+        String comparator) {
+      return SuggestedFix.replace(
+          binaryTree, String.format("%s %s 0", state.getSourceForNode(comparatorSide), comparator));
+    }
+
+    private Void visitParent(VisitorState state) {
+      child = state.getPath().getLeaf();
+      TreePath parentPath = state.getPath().getParentPath();
+      return visit(parentPath.getLeaf(), state.withPath(parentPath));
+    }
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -62,6 +62,7 @@ import com.google.errorprone.bugpatterns.CollectionToArraySafeParameter;
 import com.google.errorprone.bugpatterns.CollectorShouldNotUseState;
 import com.google.errorprone.bugpatterns.ComparableAndComparator;
 import com.google.errorprone.bugpatterns.ComparableType;
+import com.google.errorprone.bugpatterns.CompareToZero;
 import com.google.errorprone.bugpatterns.ComparingThisWithNull;
 import com.google.errorprone.bugpatterns.ComparisonContractViolated;
 import com.google.errorprone.bugpatterns.ComparisonOutOfRange;
@@ -602,6 +603,7 @@ public class BuiltInCheckerSuppliers {
           CloseableProvides.class,
           CollectorShouldNotUseState.class,
           ComparableAndComparator.class,
+          CompareToZero.class,
           ComplexBooleanConstant.class,
           DateFormatConstant.class,
           DefaultCharset.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/CompareToZeroTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/CompareToZeroTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link CompareToZero} bugpattern. */
+@RunWith(JUnit4.class)
+public final class CompareToZeroTest {
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(CompareToZero.class, getClass());
+  private final BugCheckerRefactoringTestHelper refactoringHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new CompareToZero(), getClass());
+
+  @Test
+  public void positive() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  boolean test(Integer i) {",
+            "    // BUG: Diagnostic contains: compared",
+            "    return i.compareTo(2) == -1;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positiveSuggestionForConsistency() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  boolean test(Integer i) {",
+            "    // BUG: Diagnostic contains: consistency",
+            "    return i.compareTo(2) <= -1;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positiveAddition() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  int test(Integer i) {",
+            "    // BUG: Diagnostic contains:",
+            "    return i.compareTo(2) + i.compareTo(3);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void refactoring() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  void test(Integer i) {",
+            "    boolean b1 = i.compareTo(2) == -1;",
+            "    boolean b2 = i.compareTo(2) > -1;",
+            "    boolean b3 = -1 < i.compareTo(2);",
+            "    boolean b4 = i.compareTo(2) < 1;",
+            "    boolean b5 = i.compareTo(2) != -1;",
+            "    boolean b6 = i.compareTo(2) != 1;",
+            "    boolean b7 = i.compareTo(2) <= -1;",
+            "    boolean b8 = ((i.compareTo(2))) >= 1;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "class Test {",
+            "  void test(Integer i) {",
+            "    boolean b1 = i.compareTo(2) < 0;",
+            "    boolean b2 = i.compareTo(2) >= 0;",
+            "    boolean b3 = i.compareTo(2) >= 0;",
+            "    boolean b4 = i.compareTo(2) <= 0;",
+            "    boolean b5 = i.compareTo(2) >= 0;",
+            "    boolean b6 = i.compareTo(2) <= 0;",
+            "    boolean b7 = i.compareTo(2) < 0;",
+            "    boolean b8 = ((i.compareTo(2))) > 0;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void test(Integer i) {",
+            "    boolean b1 = i.compareTo(2) < 0;",
+            "    boolean b2 = i.compareTo(2) > 0;",
+            "    boolean b3 = i.compareTo(2) == 0;",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/docs/bugpattern/CompareToZero.md
+++ b/docs/bugpattern/CompareToZero.md
@@ -1,0 +1,34 @@
+The contract for `Comparator#compare` and `Comparable#compareTo` states that the
+result is an integer which is `< 0` for less than, `== 0` for equality and `> 0`
+for greater than. While most implementations return `-1`, `0` and `+1` for those
+cases respectively, this is not guaranteed. Always comparing to `0` is the
+safest use of the return value.
+
+```java {.bad}
+  boolean <T> isLessThan(Comparator<T> comparator, T a, T b) {
+    // Fragile: it's not guaranteed that `comparator` returns -1 to mean
+    // "less than".
+    return comparator.compare(a, b) == -1;
+  }
+```
+
+```java {.good}
+  boolean <T> isLessThan(Comparator<T> comparator, T a, T b) {
+    return comparator.compare(a, b) < 0;
+  }
+```
+
+Even comparisons which are otherwise correct are significantly clearer to other
+readers of the code if turned into a comparison to `0`, e.g.:
+
+```java
+  boolean <T> greaterOrEqual(Comparator<T> comparator, T a, T b) {
+    return comparator.compare(a, b) > 1;
+  }
+```
+
+```java {.good}
+  boolean <T> greaterOrEqual(Comparator<T> comparator, T a, T b) {
+    return comparator.compare(a, b) >= 0;
+  }
+```


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Constrain toType's signature to forbid using it in silly ways

To adapt a Matcher to another's type, it's not enough for them to have Tree as a common
ancestor. It would make no sense to, for example, convert a Matcher<ExpressionTree> to
a Matcher<MethodTree>. The instanceof check would fail for all MethodTree objects,
meaning the ExpressionTree match would never be tested.

Instead, we require that the input Matcher be for some subtype of the desired output
type. This way, it is possible that the instanceof check will succeed, causing the
wrapped Matcher to actually exercise its logic.

This does exclude one possible way someone could use toType: if I have a Matcher<Tree> that matches some subset of ExpressionTree and MethodTree nodes, and I want to constrain it to only match MethodTree nodes, it was previously possible to use toType to narrow the scope of this matcher; my proposed change makes it only possible to widen scope. Currently it seems nobody is using this feature, and I think it's a confusing way to use the method, so I propose getting rid of it, but would welcome contrary feedback. After this CL clients would instead need to use isInstance to do this narrowing.

RELNOTES: none

7ad33be8423739987e4e4946b5b46bfda41deae0

-------

<p> Suggest always comparing the result of `compare`/`compareTo` to 0.

RELNOTES: Suggest always comparing the result of `compare`/`compareTo` to 0.

8cb1ba6a2581c5c136999547022e596f968edd2f