### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/inference/TypeArgInferenceVar.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/inference/TypeArgInferenceVar.java
@@ -34,7 +34,7 @@ import com.sun.source.tree.Tree;
  */
 @AutoValue
 abstract class TypeArgInferenceVar implements InferenceVariable {
-  static InferenceVariable create(ImmutableList<Integer> typeArgSelector, Tree astNode) {
+  static TypeArgInferenceVar create(ImmutableList<Integer> typeArgSelector, Tree astNode) {
     return new AutoValue_TypeArgInferenceVar(typeArgSelector, astNode);
   }
 

--- a/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/inference/TypeVariableInferenceVar.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/inference/TypeVariableInferenceVar.java
@@ -17,6 +17,7 @@
 package com.google.errorprone.dataflow.nullnesspropagation.inference;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Symbol.TypeVariableSymbol;
 
@@ -26,12 +27,36 @@ import com.sun.tools.javac.code.Symbol.TypeVariableSymbol;
  */
 @AutoValue
 abstract class TypeVariableInferenceVar implements InferenceVariable {
-  static InferenceVariable create(TypeVariableSymbol typeVar, MethodInvocationTree typeAppSite) {
-    return new AutoValue_TypeVariableInferenceVar(typeVar, typeAppSite);
+  static TypeVariableInferenceVar create(
+      TypeVariableSymbol typeVar, MethodInvocationTree typeAppSite) {
+    return create(typeVar, typeAppSite, ImmutableList.of());
+  }
+
+  static TypeVariableInferenceVar create(
+      TypeVariableSymbol typeVar,
+      MethodInvocationTree typeAppSite,
+      ImmutableList<Integer> typeArgSelector) {
+    return new AutoValue_TypeVariableInferenceVar(typeVar, typeAppSite, typeArgSelector);
+  }
+
+  public final TypeVariableInferenceVar withSelector(ImmutableList<Integer> newSelector) {
+    return create(typeVar(), typeApplicationSite(), newSelector);
   }
 
   abstract TypeVariableSymbol typeVar();
 
   /** AST Node for a method invocation whose type is parameterized by the given type var. */
   abstract MethodInvocationTree typeApplicationSite();
+
+  /**
+   * An empty list selects the type variable itself, while non-empty lists select type variables
+   * within the actual type the type variable was instantiated with at the application site, using
+   * the format as described for {@link TypeArgInferenceVar}.
+   *
+   * <p>As a simple example, consider a method declared to return its only type variable, {@code T}.
+   * For a given invocation of that method, let's say the type variable is instantiated as {@code
+   * Map&lt;String, Integer&gt;}. Then, an empty selector here selects {@code T} itself, while a
+   * selector [0] selects {@code String} and [1] selects {@code Integer}.
+   */
+  abstract ImmutableList<Integer> typeArgSelector();
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MixedMutabilityReturnType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MixedMutabilityReturnType.java
@@ -97,7 +97,11 @@ public final class MixedMutabilityReturnType extends BugChecker
           constructor().forClass("java.util.HashMap").withParameters(),
           staticMethod()
               .onClass("com.google.common.collect.Lists")
-              .namedAnyOf("newArrayList", "newHashSet", "newLinkedList")
+              .namedAnyOf("newArrayList", "newLinkedList")
+              .withParameters(),
+          staticMethod()
+              .onClass("com.google.common.collect.Sets")
+              .namedAnyOf("newHashSet", "newLinkedHashSet")
               .withParameters());
 
   private static final Matcher<ExpressionTree> IMMUTABLE =
@@ -114,9 +118,7 @@ public final class MixedMutabilityReturnType extends BugChecker
           isSubtypeOf(LinkedList.class),
           isSubtypeOf(HashMap.class),
           isSubtypeOf(HashBiMap.class),
-          isSubtypeOf(TreeMap.class),
-          staticMethod().onClass("com.google.common.collect.Lists"),
-          staticMethod().onClass("com.google.common.collect.Sets"));
+          isSubtypeOf(TreeMap.class));
 
   private static final Matcher<Tree> RETURNS_COLLECTION =
       anyOf(isSubtypeOf(Collection.class), isSubtypeOf(Map.class));

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedMethod.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.Iterables.getLast;
+import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.isSameType;
+import static com.google.errorprone.matchers.Matchers.isVoidType;
+import static com.google.errorprone.matchers.Matchers.methodHasParameters;
+import static com.google.errorprone.matchers.Matchers.methodIsNamed;
+import static com.google.errorprone.matchers.Matchers.methodReturns;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.google.errorprone.util.ASTHelpers.getType;
+import static com.google.errorprone.util.ASTHelpers.isSubtype;
+
+import com.google.common.base.Ascii;
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.suppliers.Supplier;
+import com.google.errorprone.suppliers.Suppliers;
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MemberReferenceTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
+import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import com.sun.tools.javac.code.Symbol.TypeSymbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.tree.JCTree.JCAnnotation;
+import com.sun.tools.javac.tree.JCTree.JCAssign;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.Name;
+
+/** Bugpattern to detect unused declarations. */
+@BugPattern(
+    name = "UnusedMethod",
+    altNames = {"Unused", "unused", "UnusedParameters"},
+    summary = "Unused.",
+    providesFix = REQUIRES_HUMAN_ATTENTION,
+    severity = WARNING,
+    documentSuppression = false)
+public final class UnusedMethod extends BugChecker implements CompilationUnitTreeMatcher {
+  private static final String GWT_JAVASCRIPT_OBJECT = "com.google.gwt.core.client.JavaScriptObject";
+  private static final String EXEMPT_PREFIX = "unused";
+  private static final String JUNIT_PARAMS_VALUE = "value";
+  private static final String JUNIT_PARAMS_ANNOTATION_TYPE = "junitparams.Parameters";
+
+  private static final Supplier<Type> OBJECT = Suppliers.typeFromString("java.lang.Object");
+
+  /** Method signature of special methods. */
+  private static final Matcher<MethodTree> SPECIAL_METHODS =
+      anyOf(
+          allOf(
+              methodIsNamed("readObject"),
+              methodHasParameters(isSameType("java.io.ObjectInputStream"))),
+          allOf(
+              methodIsNamed("writeObject"),
+              methodHasParameters(isSameType("java.io.ObjectOutputStream"))),
+          allOf(methodIsNamed("readObjectNoData"), methodReturns(isVoidType())),
+          allOf(methodIsNamed("readResolve"), methodReturns(OBJECT)),
+          allOf(methodIsNamed("writeReplace"), methodReturns(OBJECT)));
+
+
+  private static final ImmutableSet<String> EXEMPTING_METHOD_ANNOTATIONS =
+      ImmutableSet.of(
+          "com.google.inject.Provides",
+          "com.google.inject.Inject",
+          "javax.inject.Inject");
+
+  /** The set of types exempting a type that is extending or implementing them. */
+  private static final ImmutableSet<String> EXEMPTING_SUPER_TYPES =
+      ImmutableSet.of(
+          );
+
+  @Override
+  public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {
+    // Map of symbols to method declarations. Initially this is a map of all of the methods. As we
+    // go we remove those variables which are used.
+    Map<Symbol, TreePath> unusedMethods = new HashMap<>();
+
+    // We will skip reporting on the whole compilation if there are any native methods found.
+    // Use a TreeScanner to find all local variables and fields.
+    if (hasNativeMethods(tree)) {
+      return Description.NO_MATCH;
+    }
+    AtomicBoolean ignoreUnusedMethods = new AtomicBoolean(false);
+
+    class MethodFinder extends TreePathScanner<Void, Void> {
+      @Override
+      public Void visitClass(ClassTree tree, Void unused) {
+        if (isSuppressed(tree) || exemptedBySuperType(getType(tree), state)) {
+          return null;
+        }
+        return super.visitClass(tree, null);
+      }
+
+      private boolean exemptedBySuperType(Type type, VisitorState state) {
+        return EXEMPTING_SUPER_TYPES.stream()
+            .anyMatch(t -> isSubtype(type, Suppliers.typeFromString(t).get(state), state));
+      }
+
+      @Override
+      public Void visitMethod(MethodTree tree, Void unused) {
+        if (hasJUnitParamsParametersForMethodAnnotation(tree.getModifiers().getAnnotations())) {
+          // Since this method uses @Parameters, there will be another method that appears to
+          // be unused. Don't warn about unusedMethods at all in this case.
+          ignoreUnusedMethods.set(true);
+        }
+
+        if (isSuppressed(tree)) {
+          // @SuppressWarnings("unused") applies to the entire AST, not just the symbol it's bound
+          // to.  Skip the whole method.
+          return null;
+        }
+
+        if (isMethodSymbolEligibleForChecking(tree)) {
+          unusedMethods.put(getSymbol(tree), getCurrentPath());
+        }
+        return super.visitMethod(tree, unused);
+      }
+
+      private boolean hasJUnitParamsParametersForMethodAnnotation(
+          Collection<? extends AnnotationTree> annotations) {
+        for (AnnotationTree tree : annotations) {
+          JCAnnotation annotation = (JCAnnotation) tree;
+          if (annotation.getAnnotationType().type != null
+              && annotation
+                  .getAnnotationType()
+                  .type
+                  .toString()
+                  .equals(JUNIT_PARAMS_ANNOTATION_TYPE)) {
+            if (annotation.getArguments().isEmpty()) {
+              // @Parameters, which uses implicit provider methods
+              return true;
+            }
+            for (JCExpression arg : annotation.getArguments()) {
+              if (arg.getKind() != Kind.ASSIGNMENT) {
+                // Implicit value annotation, e.g. @Parameters({"1"}); no exemption required.
+                return false;
+              }
+              JCExpression var = ((JCAssign) arg).getVariable();
+              if (var.getKind() == Kind.IDENTIFIER) {
+                // Anything that is not @Parameters(value = ...), e.g.
+                // @Parameters(source = ...) or @Parameters(method = ...)
+                if (!((IdentifierTree) var).getName().contentEquals(JUNIT_PARAMS_VALUE)) {
+                  return true;
+                }
+              }
+            }
+          }
+        }
+        return false;
+      }
+
+      private boolean isMethodSymbolEligibleForChecking(MethodTree tree) {
+        if (exemptedByName(tree.getName())) {
+          return false;
+        }
+        // Assume the method is called if annotated with a called-reflectively annotation.
+        if (exemptedByAnnotation(tree.getModifiers().getAnnotations(), state)) {
+          return false;
+        }
+        // Skip constructors and special methods.
+        MethodSymbol methodSymbol = getSymbol(tree);
+        if (methodSymbol == null
+            || methodSymbol.getKind() == ElementKind.CONSTRUCTOR
+            || SPECIAL_METHODS.matches(tree, state)) {
+          return false;
+        }
+
+        // Ignore this method if the last parameter is a GWT JavaScriptObject.
+        if (!tree.getParameters().isEmpty()) {
+          Type lastParamType = getType(getLast(tree.getParameters()));
+          if (lastParamType != null && lastParamType.toString().equals(GWT_JAVASCRIPT_OBJECT)) {
+            return false;
+          }
+        }
+
+        return tree.getModifiers().getFlags().contains(Modifier.PRIVATE);
+      }
+    }
+    new MethodFinder().scan(state.getPath(), null);
+
+    class FilterUsedMethods extends TreePathScanner<Void, Void> {
+      @Override
+      public Void visitMemberSelect(MemberSelectTree memberSelectTree, Void unused) {
+        Symbol symbol = getSymbol(memberSelectTree);
+        unusedMethods.remove(symbol);
+        return super.visitMemberSelect(memberSelectTree, null);
+      }
+
+      @Override
+      public Void visitMemberReference(MemberReferenceTree tree, Void unused) {
+        super.visitMemberReference(tree, null);
+        MethodSymbol symbol = getSymbol(tree);
+        unusedMethods.remove(symbol);
+        if (symbol != null) {
+          symbol.getParameters().forEach(unusedMethods::remove);
+        }
+        return null;
+      }
+
+      @Override
+      public Void visitMethodInvocation(MethodInvocationTree tree, Void unused) {
+        Symbol methodSymbol = getSymbol(tree);
+        if (methodSymbol != null) {
+          unusedMethods.remove(methodSymbol);
+        }
+        super.visitMethodInvocation(tree, null);
+        return null;
+      }
+    }
+
+    new FilterUsedMethods().scan(state.getPath(), null);
+
+    if (ignoreUnusedMethods.get()) {
+      return Description.NO_MATCH;
+    }
+
+    for (TreePath unusedPath : unusedMethods.values()) {
+      Tree unusedTree = unusedPath.getLeaf();
+      String message =
+          String.format("Private method '%s' is never used.", ((MethodTree) unusedTree).getName());
+      state.reportMatch(
+          buildDescription(unusedTree)
+              .addFix(SuggestedFixes.replaceIncludingComments(unusedPath, "", state))
+              .setMessage(message)
+              .build());
+    }
+    return Description.NO_MATCH;
+  }
+
+  static boolean hasNativeMethods(CompilationUnitTree tree) {
+    AtomicBoolean hasAnyNativeMethods = new AtomicBoolean(false);
+    new TreeScanner<Void, Void>() {
+      @Override
+      public Void visitMethod(MethodTree tree, Void unused) {
+        if (tree.getModifiers().getFlags().contains(Modifier.NATIVE)) {
+          hasAnyNativeMethods.set(true);
+        }
+        return null;
+      }
+    }.scan(tree, null);
+    return hasAnyNativeMethods.get();
+  }
+
+  /**
+   * Looks at the list of {@code annotations} and see if there is any annotation which exists {@code
+   * exemptingAnnotations}.
+   */
+  private static boolean exemptedByAnnotation(
+      List<? extends AnnotationTree> annotations,
+      VisitorState state) {
+    for (AnnotationTree annotation : annotations) {
+      if (((JCAnnotation) annotation).type != null) {
+        TypeSymbol tsym = ((JCAnnotation) annotation).type.tsym;
+        if (EXEMPTING_METHOD_ANNOTATIONS.contains(tsym.getQualifiedName().toString())) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static boolean exemptedByName(Name name) {
+    return Ascii.toLowerCase(name.toString()).startsWith(EXEMPT_PREFIX);
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -282,11 +282,12 @@ import com.google.errorprone.bugpatterns.UnnecessaryTypeArgument;
 import com.google.errorprone.bugpatterns.UnsafeFinalization;
 import com.google.errorprone.bugpatterns.UnsafeReflectiveConstructionCast;
 import com.google.errorprone.bugpatterns.UnsynchronizedOverridesSynchronized;
-import com.google.errorprone.bugpatterns.Unused;
 import com.google.errorprone.bugpatterns.UnusedAnonymousClass;
 import com.google.errorprone.bugpatterns.UnusedCollectionModifiedInPlace;
 import com.google.errorprone.bugpatterns.UnusedException;
+import com.google.errorprone.bugpatterns.UnusedMethod;
 import com.google.errorprone.bugpatterns.UnusedNestedClass;
+import com.google.errorprone.bugpatterns.UnusedVariable;
 import com.google.errorprone.bugpatterns.UseCorrectAssertInTests;
 import com.google.errorprone.bugpatterns.VarChecker;
 import com.google.errorprone.bugpatterns.VarTypeName;
@@ -718,8 +719,9 @@ public class BuiltInCheckerSuppliers {
           UnsafeFinalization.class,
           UnsafeReflectiveConstructionCast.class,
           UnsynchronizedOverridesSynchronized.class,
-          Unused.class,
+          UnusedMethod.class,
           UnusedNestedClass.class,
+          UnusedVariable.class,
           URLEqualsHashCode.class,
           UseCorrectAssertInTests.class,
           VariableNameSameAsType.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MixedMutabilityReturnTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MixedMutabilityReturnTypeTest.java
@@ -133,6 +133,22 @@ public final class MixedMutabilityReturnTypeTest {
   }
 
   @Test
+  public void immutableEnumSetNotMisclassified() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.collect.Sets;",
+            "import java.util.Set;",
+            "class Test {",
+            "  enum E { A, B }",
+            "  Set<E> test() {",
+            "    return Sets.immutableEnumSet(E.A);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void simpleRefactoring() {
     refactoringHelper
         .addInputLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedMethodTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedMethodTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link UnusedMethod}. */
+@RunWith(JUnit4.class)
+public final class UnusedMethodTest {
+
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(UnusedMethod.class, getClass());
+  private final BugCheckerRefactoringTestHelper refactoringHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new UnusedMethod(), getClass());
+
+
+
+  @Test
+  public void unusedNative() {
+    helper
+        .addSourceLines(
+            "UnusedNative.java",
+            "package unusedvars;",
+            "public class UnusedNative {",
+            "  private native void aNativeMethod();",
+            "}")
+        .doTest();
+  }
+
+
+  @Test
+  public void unuseds() {
+    helper
+        .addSourceLines(
+            "Unuseds.java",
+            "package unusedvars;",
+            "import java.io.IOException;",
+            "import java.io.ObjectStreamException;",
+            "import java.util.List;",
+            "import javax.inject.Inject;",
+            "public class Unuseds {",
+            "  // BUG: Diagnostic contains:",
+            "  private void notUsedMethod() {}",
+            "  // BUG: Diagnostic contains:",
+            "  private static void staticNotUsedMethod() {}",
+            "  @SuppressWarnings({\"deprecation\", \"unused\"})",
+            "  class UsesSuppressWarning {",
+            "    private int f1;",
+            "    private void test1() {",
+            "      int local;",
+            "    }",
+            "    @SuppressWarnings(value = \"unused\")",
+            "    private void test2() {",
+            "      int local;",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void exemptedMethods() {
+    helper
+        .addSourceLines(
+            "Unuseds.java",
+            "package unusedvars;",
+            "import java.io.IOException;",
+            "import java.io.ObjectStreamException;",
+            "public class Unuseds {",
+            "  private void readObject(java.io.ObjectInputStream in) throws IOException {",
+            "    in.hashCode();",
+            "  }",
+            "  private void writeObject(java.io.ObjectOutputStream out) throws IOException {",
+            "    out.writeInt(123);",
+            "  }",
+            "  private Object readResolve() {",
+            "    return null;",
+            "  }",
+            "  private void readObjectNoData() throws ObjectStreamException {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void exemptedByName() {
+    helper
+        .addSourceLines(
+            "Unuseds.java",
+            "package unusedvars;",
+            "class ExemptedByName {",
+            "  private void unused1(int a, int unusedParam) {",
+            "    int unusedLocal = a;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void suppressions() {
+    helper
+        .addSourceLines(
+            "Unuseds.java",
+            "package unusedvars;",
+            "class Suppressed {",
+            "  @SuppressWarnings({\"deprecation\", \"unused\"})",
+            "  class UsesSuppressWarning {",
+            "    private void test1() {",
+            "      int local;",
+            "    }",
+            "    @SuppressWarnings(value = \"unused\")",
+            "    private void test2() {",
+            "      int local;",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void removal_javadocsAndNonJavadocs() {
+    refactoringHelper
+        .addInputLines(
+            "UnusedWithComment.java",
+            "package unusedvars;",
+            "public class UnusedWithComment {",
+            "  /**",
+            "   * Method comment",
+            "   */private void test1() {",
+            "  }",
+            "  /** Method comment */",
+            "  private void test2() {",
+            "  }",
+            "  // Non javadoc comment",
+            "  private void test3() {",
+            "  }",
+            "}")
+        .addOutputLines(
+            "UnusedWithComment.java", //
+            "package unusedvars;",
+            "public class UnusedWithComment {",
+            "}")
+        .doTest(TestMode.TEXT_MATCH);
+  }
+
+  @Test
+  public void usedInLambda() {
+    helper
+        .addSourceLines(
+            "UsedInLambda.java",
+            "package unusedvars;",
+            "import java.util.Arrays;",
+            "import java.util.List;",
+            "import java.util.function.Function;",
+            "import java.util.stream.Collectors;",
+            "/** Method parameters used in lambdas and anonymous classes */",
+            "public class UsedInLambda {",
+            "  private Function<Integer, Integer> usedInLambda() {",
+            "    return x -> 1;",
+            "  }",
+            "  private String print(Object o) {",
+            "    return o.toString();",
+            "  }",
+            "  public List<String> print(List<Object> os) {",
+            "    return os.stream().map(this::print).collect(Collectors.toList());",
+            "  }",
+            "  public static void main(String[] args) {",
+            "    System.err.println(new UsedInLambda().usedInLambda());",
+            "    System.err.println(new UsedInLambda().print(Arrays.asList(1, 2, 3)));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void onlyForMethodReference() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.function.Predicate;",
+            "class Test {",
+            "  private static boolean foo(int a) {",
+            "    return true;",
+            "  }",
+            "  Predicate<Integer> pred = Test::foo;",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedVariableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedVariableTest.java
@@ -25,15 +25,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link Unused}. */
+/** Tests for {@link UnusedVariable}. */
 @RunWith(JUnit4.class)
-public class UnusedTest {
+public class UnusedVariableTest {
 
   private final CompilationTestHelper helper =
-      CompilationTestHelper.newInstance(Unused.class, getClass());
+      CompilationTestHelper.newInstance(UnusedVariable.class, getClass());
   private final BugCheckerRefactoringTestHelper refactoringHelper =
-      BugCheckerRefactoringTestHelper.newInstance(new Unused(ErrorProneFlags.empty()), getClass());
-
+      BugCheckerRefactoringTestHelper.newInstance(
+          new UnusedVariable(ErrorProneFlags.empty()), getClass());
 
 
   @Test
@@ -266,7 +266,6 @@ public class UnusedTest {
         .doTest();
   }
 
-
   @Test
   public void unuseds() {
     helper
@@ -329,10 +328,6 @@ public class UnusedTest {
             "    // Must not be reported as unused",
             "    notUseds.get(indexInMethodCall).publicOne = 0;",
             "  }",
-            "  // BUG: Diagnostic contains:",
-            "  private void notUsedMethod() {}",
-            "  // BUG: Diagnostic contains:",
-            "  private static void staticNotUsedMethod() {}",
             "  void memberSelectUpdate1() {",
             "    List<Unuseds> l = null;",
             "    // `u` should not be reported as unused.",
@@ -371,34 +366,7 @@ public class UnusedTest {
             "    private void test1() {",
             "      int local;",
             "    }",
-            "    @SuppressWarnings(value = \"unused\")",
-            "    private void test2() {",
-            "      int local;",
-            "    }",
             "  }",
-            "}")
-        .doTest();
-  }
-
-  @Test
-  public void exemptedMethods() {
-    helper
-        .addSourceLines(
-            "Unuseds.java",
-            "package unusedvars;",
-            "import java.io.IOException;",
-            "import java.io.ObjectStreamException;",
-            "public class Unuseds {",
-            "  private void readObject(java.io.ObjectInputStream in) throws IOException {",
-            "    in.hashCode();",
-            "  }",
-            "  private void writeObject(java.io.ObjectOutputStream out) throws IOException {",
-            "    out.writeInt(123);",
-            "  }",
-            "  private Object readResolve() {",
-            "    return null;",
-            "  }",
-            "  private void readObjectNoData() throws ObjectStreamException {}",
             "}")
         .doTest();
   }
@@ -467,9 +435,6 @@ public class UnusedTest {
             "  private int unused;",
             "  private int unusedInt;",
             "  private static final int UNUSED_CONSTANT = 5;",
-            "  private void unused1(int a, int unusedParam) {",
-            "    int unusedLocal = a;",
-            "  }",
             "}")
         .doTest();
   }
@@ -554,16 +519,6 @@ public class UnusedTest {
             "   * Comment for a field */",
             "  @SuppressWarnings(\"test\")",
             "  private Object field;",
-            "  /**",
-            "   * Method comment",
-            "   */private void test1() {",
-            "  }",
-            "  /** Method comment */",
-            "  private void test2() {",
-            "  }",
-            "  // Non javadoc comment",
-            "  private void test3() {",
-            "  }",
             "}")
         .addOutputLines(
             "UnusedWithComment.java", //
@@ -637,7 +592,7 @@ public class UnusedTest {
             "package unusedvars;",
             "public class UnusedWithComment {",
             "  private static final String foo = null, // foo",
-            "  // BUG: Diagnostic contains: Unused",
+            "  // BUG: Diagnostic contains:",
             "      bar = null;",
             "  public static String foo() { return foo; }",
             "}")
@@ -975,21 +930,6 @@ public class UnusedTest {
             "  ONE() {};",
             "  private Test() {",
             "  }",
-            "}")
-        .doTest();
-  }
-
-  @Test
-  public void onlyForMethodReference() {
-    helper
-        .addSourceLines(
-            "Test.java",
-            "import java.util.function.Predicate;",
-            "class Test {",
-            "  private static boolean foo(int a) {",
-            "    return true;",
-            "  }",
-            "  Predicate<Integer> pred = Test::foo;",
             "}")
         .doTest();
   }

--- a/docs/bugpattern/CompareToZero.md
+++ b/docs/bugpattern/CompareToZero.md
@@ -18,17 +18,17 @@ safest use of the return value.
   }
 ```
 
-Even comparisons which are otherwise correct are significantly clearer to other
-readers of the code if turned into a comparison to `0`, e.g.:
+Even comparisons which are otherwise correct are clearer to other readers of the
+code if turned into a comparison to `0`, e.g.:
 
 ```java
-  boolean <T> greaterOrEqual(Comparator<T> comparator, T a, T b) {
-    return comparator.compare(a, b) > 1;
+  boolean <T> greaterThan(Comparator<T> comparator, T a, T b) {
+    return comparator.compare(a, b) >= 1;
   }
 ```
 
 ```java {.good}
-  boolean <T> greaterOrEqual(Comparator<T> comparator, T a, T b) {
-    return comparator.compare(a, b) >= 0;
+  boolean <T> greaterThan(Comparator<T> comparator, T a, T b) {
+    return comparator.compare(a, b) > 0;
   }
 ```


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> track nullness constraints for actual types inferred for method type parameters.

Fixes issues with constraints getting "lost" when type parameters are instantiated with generic types
RELNOTES: None.

2d271ecea38de50a5a6fd7c53ef6f17381a5fc2d

-------

<p> Fix bug in MixedMutabilityReturnType which caused it to misclassify Sets#immutableEnumSet as mutable and get confused.

I'm confused by the empty fix though. It looks like empty fixes should not be emitted at all, and I can't reproduce that it was doing anything weird to get around that.

RELNOTES: N/A

504f6db6c227ef147ccd01374977c5fb1f5137cb

-------

<p> Fix a typo

b43284267779a0d2e727f316ee470dcace726759

-------

<p> Split unused method detection out into a separate check.

(Just because Unused is way, way too unwieldy.)

RELNOTES: N/A

38d6ade12d1c8afc18c8d57f9dd11f6bbcbabae1