### PR TITLE
Moe Sync

### DIFF
--- a/annotation/src/test/java/com/google/errorprone/BugPatternValidatorTest.java
+++ b/annotation/src/test/java/com/google/errorprone/BugPatternValidatorTest.java
@@ -19,7 +19,6 @@ package com.google.errorprone;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.LinkType;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import org.junit.Test;
@@ -40,7 +39,6 @@ public class BugPatternValidatorTest {
         name = "BasicBugPattern",
         summary = "Simplest possible BugPattern",
         explanation = "Simplest possible BugPattern ",
-        category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR)
     final class BugPatternTestClass {}
 
@@ -54,7 +52,6 @@ public class BugPatternValidatorTest {
         name = "LinkTypeNoneAndNoLink",
         summary = "linkType none and no link",
         explanation = "linkType none and no link",
-        category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
         linkType = LinkType.NONE)
     final class BugPatternTestClass {}
@@ -69,7 +66,6 @@ public class BugPatternValidatorTest {
         name = "LinkTypeNoneButIncludesLink",
         summary = "linkType none but includes link",
         explanation = "linkType none but includes link",
-        category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
         linkType = LinkType.NONE,
         link = "http://foo")
@@ -85,7 +81,6 @@ public class BugPatternValidatorTest {
         name = "LinkTypeCustomAndIncludesLink",
         summary = "linkType custom and includes link",
         explanation = "linkType custom and includes link",
-        category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
         linkType = LinkType.CUSTOM,
         link = "http://foo")
@@ -101,7 +96,6 @@ public class BugPatternValidatorTest {
         name = "LinkTypeCustomButNoLink",
         summary = "linkType custom but no link",
         explanation = "linkType custom but no link",
-        category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
         linkType = LinkType.CUSTOM)
     final class BugPatternTestClass {}
@@ -116,7 +110,6 @@ public class BugPatternValidatorTest {
         name = "Unsuppressible",
         summary = "An unsuppressible BugPattern",
         explanation = "An unsuppressible BugPattern",
-        category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
         suppressionAnnotations = {},
         disableable = false)
@@ -132,7 +125,6 @@ public class BugPatternValidatorTest {
         name = "customSuppressionAnnotation",
         summary = "Uses a custom suppression annotation",
         explanation = "Uses a custom suppression annotation",
-        category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
         suppressionAnnotations = CustomSuppressionAnnotation.class)
     final class BugPatternTestClass {}
@@ -147,7 +139,6 @@ public class BugPatternValidatorTest {
         name = "customSuppressionAnnotation",
         summary = "Uses multiple custom suppression annotations",
         explanation = "Uses multiple custom suppression annotations",
-        category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
         suppressionAnnotations = {
           CustomSuppressionAnnotation.class,
@@ -166,7 +157,6 @@ public class BugPatternValidatorTest {
         summary = "Specifies multiple custom suppression annotations including @SuppressWarnings",
         explanation =
             "Specifies multiple custom suppression annotations including @SuppressWarnings",
-        category = Category.ONE_OFF,
         severity = SeverityLevel.ERROR,
         suppressionAnnotations = {CustomSuppressionAnnotation.class, SuppressWarnings.class})
     final class BugPatternTestClass {}

--- a/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/inference/NullnessQualifierInference.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/inference/NullnessQualifierInference.java
@@ -252,8 +252,6 @@ public class NullnessQualifierInference extends TreeScanner<Void, Void> {
         sourceNode.getArguments().stream(),
         (formal, actual) -> {
           // formal parameter type (no l-val b/c that would wrongly constrain the method return)
-          // TODO(b/116977632): constraints for actual parameter type (i.e. after type variable
-          // substitution) without ignoring annotations directly on the parameter or vararg
           generateConstraintsForWrite(formal.type(), formal.symbol(), actual, /*lVal=*/ null);
         });
 
@@ -267,10 +265,10 @@ public class NullnessQualifierInference extends TreeScanner<Void, Void> {
       JCFieldAccess fieldAccess = ((JCFieldAccess) node.getMethodSelect());
       for (TypeVariableSymbol tvs : fieldAccess.selected.type.tsym.getTypeParameters()) {
         Type rcvrtype = fieldAccess.selected.type.tsym.type;
+        // Note this should be a singleton set, one for each type parameter
         ImmutableSet<InferenceVariable> rcvrReferences =
             findUnannotatedTypeVarRefs(tvs, rcvrtype, /*decl=*/ null, fieldAccess.selected);
         Type restype = fieldAccess.sym.type.asMethodType().restype;
-        // TODO(b/116977632): Propagate constraints for instantiated receiver types as well?
         findUnannotatedTypeVarRefs(tvs, restype, fieldAccess.sym, node)
             .forEach(
                 resRef ->

--- a/check_api/src/test/java/com/google/errorprone/matchers/DescriptionTest.java
+++ b/check_api/src/test/java/com/google/errorprone/matchers/DescriptionTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.matchers;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
@@ -72,7 +71,6 @@ public class DescriptionTest {
       name = "DeadException",
       summary = "Exception created but not thrown",
       explanation = "",
-      category = JDK,
       severity = ERROR)
   public static class MyChecker extends BugChecker {
     Description getDescription() {
@@ -107,7 +105,6 @@ public class DescriptionTest {
       name = "CustomLinkChecker",
       summary = "Exception created but not thrown",
       explanation = "",
-      category = JDK,
       severity = ERROR,
       linkType = CUSTOM,
       link = "https://www.google.com/")

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AmbiguousMethodReference.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AmbiguousMethodReference.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
@@ -45,7 +44,6 @@ import java.util.Map;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "AmbiguousMethodReference",
-    category = JDK,
     summary = "Method reference is ambiguous",
     severity = WARNING)
 public class AmbiguousMethodReference extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ArrayEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ArrayEquals.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -41,7 +40,6 @@ import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 @BugPattern(
     name = "ArrayEquals",
     summary = "Reference equality used to compare arrays",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ArrayEquals extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ArrayFillIncompatibleType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ArrayFillIncompatibleType.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
@@ -43,7 +42,6 @@ import com.sun.tools.javac.code.Type;
 @BugPattern(
     name = "ArrayFillIncompatibleType",
     summary = "Arrays.fill(Object[], Object) called with incompatible types.",
-    category = JDK,
     severity = ERROR)
 public class ArrayFillIncompatibleType extends BugChecker implements MethodInvocationTreeMatcher {
   private static final Matcher<ExpressionTree> ARRAY_FILL_MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ArrayHashCode.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ArrayHashCode.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.argument;
@@ -46,7 +45,6 @@ import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 @BugPattern(
     name = "ArrayHashCode",
     summary = "hashcode method on array does not hash array contents",
-    category = JDK,
     severity = ERROR,
     generateExamplesFromTestCases = false,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ArrayToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ArrayToString.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 
@@ -39,7 +38,6 @@ import com.sun.source.tree.Tree;
 @BugPattern(
     name = "ArrayToString",
     summary = "Calling toString on an array does not provide useful information",
-    category = JDK,
     severity = ERROR)
 public class ArrayToString extends AbstractToString {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ArraysAsListPrimitiveArray.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ArraysAsListPrimitiveArray.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -45,7 +44,6 @@ import javax.lang.model.type.TypeKind;
 @BugPattern(
     name = "ArraysAsListPrimitiveArray",
     summary = "Arrays.asList does not autobox primitive arrays, as one might expect.",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ArraysAsListPrimitiveArray extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AssertFalse.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AssertFalse.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.assertionWithCondition;
 import static com.google.errorprone.matchers.Matchers.booleanLiteral;
@@ -36,7 +35,6 @@ import com.sun.source.tree.AssertTree;
     summary =
         "Assertions may be disabled at runtime and do not guarantee that execution will "
             + "halt here; consider throwing an exception instead",
-    category = JDK,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class AssertFalse extends BugChecker implements AssertTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AsyncCallableReturnsNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AsyncCallableReturnsNull.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.GUAVA;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.common.util.concurrent.AsyncCallable;
@@ -26,7 +25,6 @@ import com.google.errorprone.BugPattern;
 @BugPattern(
     name = "AsyncCallableReturnsNull",
     summary = "AsyncCallable should not return a null Future, only a Future whose result is null.",
-    category = GUAVA,
     severity = ERROR)
 public final class AsyncCallableReturnsNull extends AbstractAsyncTypeReturnsNull {
   public AsyncCallableReturnsNull() {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AsyncFunctionReturnsNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AsyncFunctionReturnsNull.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.GUAVA;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.common.util.concurrent.AsyncFunction;
@@ -26,7 +25,6 @@ import com.google.errorprone.BugPattern;
 @BugPattern(
     name = "AsyncFunctionReturnsNull",
     summary = "AsyncFunction should not return a null Future, only a Future whose result is null.",
-    category = GUAVA,
     severity = ERROR,
     generateExamplesFromTestCases = false)
 public final class AsyncFunctionReturnsNull extends AbstractAsyncTypeReturnsNull {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadAnnotationImplementation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadAnnotationImplementation.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -56,7 +55,6 @@ import java.lang.annotation.Annotation;
     summary =
         "Classes that implement Annotation must override equals and hashCode. Consider "
             + "using AutoAnnotation instead of implementing Annotation by hand.",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.LIKELY_ERROR)
 public class BadAnnotationImplementation extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadComparable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadComparable.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.isSubtypeOf;
@@ -50,7 +49,6 @@ import com.sun.tools.javac.code.TypeTag;
 @BugPattern(
     name = "BadComparable",
     summary = "Possible sign flip from narrowing conversion",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadShiftAmount.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadShiftAmount.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -46,7 +45,6 @@ import com.sun.tools.javac.tree.JCTree;
 @BugPattern(
     name = "BadShiftAmount",
     summary = "Shift by an amount that is out of range",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class BadShiftAmount extends BugChecker implements BinaryTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BigDecimalEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BigDecimalEquals.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.equalsMethodDeclaration;
@@ -48,7 +47,6 @@ import java.util.List;
 @BugPattern(
     name = "BigDecimalEquals",
     summary = "BigDecimal#equals has surprising behavior: it also compares scale.",
-    category = JDK,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public final class BigDecimalEquals extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BigDecimalLiteralDouble.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BigDecimalLiteralDouble.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
@@ -45,7 +44,6 @@ import java.util.Optional;
 @BugPattern(
     name = "BigDecimalLiteralDouble",
     summary = "new BigDecimal(double) loses precision in this case.",
-    category = JDK,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class BigDecimalLiteralDouble extends BugChecker implements NewClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BoxedPrimitiveConstructor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BoxedPrimitiveConstructor.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.util.ASTHelpers.getType;
 import static com.google.errorprone.util.ASTHelpers.isSameType;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.BugPattern.StandardTags;
@@ -51,7 +50,6 @@ import com.sun.tools.javac.util.Context;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "BoxedPrimitiveConstructor",
-    category = Category.JDK,
     summary = "valueOf or autoboxing provides better time and space performance",
     severity = SeverityLevel.WARNING,
     tags = StandardTags.PERFORMANCE,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ByteBufferBackingArray.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ByteBufferBackingArray.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.isSameType;
@@ -53,7 +52,6 @@ import java.util.Optional;
     summary =
         "ByteBuffer.array() shouldn't be called unless ByteBuffer.arrayOffset() is used or "
             + "if the ByteBuffer was initialized using ByteBuffer.wrap() or ByteBuffer.allocate().",
-    category = JDK,
     severity = WARNING,
     generateExamplesFromTestCases = false)
 public class ByteBufferBackingArray extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CannotMockFinalClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CannotMockFinalClass.java
@@ -28,7 +28,6 @@ import static com.google.errorprone.matchers.Matchers.staticMethod;
 import static com.google.errorprone.matchers.Matchers.variableType;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -51,7 +50,6 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "CannotMockFinalClass",
     summary = "Mockito cannot mock final classes",
-    category = Category.MOCKITO,
     severity = SeverityLevel.WARNING)
 public class CannotMockFinalClass extends BugChecker
     implements MethodInvocationTreeMatcher, VariableTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ChainingConstructorIgnoresParameter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ChainingConstructorIgnoresParameter.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Maps.newHashMap;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.fixes.SuggestedFix.replace;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -68,7 +67,6 @@ import java.util.Map;
  */
 @BugPattern(
     name = "ChainingConstructorIgnoresParameter",
-    category = JDK,
     severity = ERROR,
     summary =
         "The called constructor accepts a parameter with the same name and type as one of "

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CheckReturnValue.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CheckReturnValue.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.util.ASTHelpers.enclosingClass;
 import static com.google.errorprone.util.ASTHelpers.enclosingPackage;
@@ -44,7 +43,6 @@ import javax.lang.model.element.ElementKind;
     name = "CheckReturnValue",
     altNames = {"ResultOfMethodCallIgnored", "ReturnValueIgnored"},
     summary = "Ignored return value of method that is annotated with @CheckReturnValue",
-    category = JDK,
     severity = ERROR)
 public class CheckReturnValue extends AbstractReturnValueIgnored
     implements MethodTreeMatcher, ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassCanBeStatic.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassCanBeStatic.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -40,7 +39,6 @@ import javax.lang.model.element.NestingKind;
 @BugPattern(
     name = "ClassCanBeStatic",
     summary = "Inner class is non-static but does not reference enclosing class",
-    category = JDK,
     severity = WARNING,
     tags = {StandardTags.STYLE, StandardTags.PERFORMANCE},
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassName.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassName.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
@@ -38,7 +37,6 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "ClassName",
     summary = "The source file name should match the name of the top-level class it contains",
-    category = JDK,
     severity = ERROR,
     documentSuppression = false,
     linkType = CUSTOM,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassNamedLikeTypeParameter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassNamedLikeTypeParameter.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 
 import com.google.errorprone.BugPattern;
@@ -31,7 +30,6 @@ import com.sun.source.tree.ClassTree;
 @BugPattern(
     name = "ClassNamedLikeTypeParameter",
     summary = "This class's name looks like a Type Parameter.",
-    category = JDK,
     severity = SUGGESTION,
     tags = StandardTags.STYLE)
 public class ClassNamedLikeTypeParameter extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassNewInstance.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassNewInstance.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 
@@ -59,7 +58,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "ClassNewInstance",
-    category = JDK,
     summary =
         "Class.newInstance() bypasses exception checking; prefer"
             + " getDeclaredConstructor().newInstance()",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CollectionToArraySafeParameter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CollectionToArraySafeParameter.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
@@ -40,7 +39,6 @@ import java.util.List;
     summary =
         "The type of the array parameter of Collection.toArray "
             + "needs to be compatible with the array type",
-    category = JDK,
     severity = ERROR)
 public class CollectionToArraySafeParameter extends BugChecker
     implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CollectorShouldNotUseState.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CollectorShouldNotUseState.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.contains;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
@@ -37,7 +36,6 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "CollectorShouldNotUseState",
     summary = "Collector.of() should not use state",
-    category = JDK,
     severity = WARNING)
 public class CollectorShouldNotUseState extends BugChecker implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ComparableAndComparator.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ComparableAndComparator.java
@@ -14,7 +14,6 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.isSubtypeOf;
@@ -39,7 +38,6 @@ import java.util.List;
 @BugPattern(
     name = "ComparableAndComparator",
     summary = "Class should not implement both `Comparable` and `Comparator`",
-    category = JDK,
     severity = WARNING)
 public class ComparableAndComparator extends BugChecker implements ClassTreeMatcher {
   private static final String COMPARABLE = Comparable.class.getCanonicalName();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ComparableType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ComparableType.java
@@ -14,7 +14,6 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.isSubtypeOf;
 
@@ -35,7 +34,6 @@ import com.sun.tools.javac.code.Type;
     name = "ComparableType",
     summary =
         " Implementing 'Comparable<T>' where T is not compatible with the implementing class.",
-    category = JDK,
     severity = ERROR)
 public class ComparableType extends BugChecker implements ClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CompareToZero.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CompareToZero.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -48,7 +47,6 @@ import com.sun.source.util.TreePath;
         "The result of #compareTo or #compare should only be compared to 0. It is an "
             + "implementation detail whether a given type returns strictly the values {-1, 0, +1} "
             + "or others.",
-    category = JDK,
     providesFix = REQUIRES_HUMAN_ATTENTION,
     severity = WARNING)
 public final class CompareToZero extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ComparisonContractViolated.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ComparisonContractViolated.java
@@ -26,7 +26,6 @@ import static com.google.errorprone.matchers.MethodVisibility.Visibility.PUBLIC;
 import static com.google.errorprone.suppliers.Suppliers.INT_TYPE;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
@@ -62,7 +61,6 @@ import java.util.Set;
     name = "ComparisonContractViolated",
     summary = "This comparison method violates the contract",
     severity = SeverityLevel.ERROR,
-    category = Category.JDK,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ComparisonContractViolated extends BugChecker implements MethodTreeMatcher {
   /** Matcher for the overriding method of 'int java.lang.Comparable.compareTo(T other)' */

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ComparisonOutOfRange.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ComparisonOutOfRange.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 
@@ -59,7 +58,6 @@ import java.util.List;
             + "outside that range will always evaluate to false and usually indicates an error in "
             + "the code.\n\n"
             + "This checker currently supports checking for bad byte and character comparisons.",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ComparisonOutOfRange extends BugChecker implements BinaryTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CompileTimeConstantChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CompileTimeConstantChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.GUAVA;
 import static com.google.errorprone.BugPattern.LinkType.NONE;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.CompileTimeConstantExpressionMatcher.hasCompileTimeConstantAnnotation;
@@ -72,7 +71,6 @@ import java.util.List;
         "Non-compile-time constant expression passed to parameter with "
             + "@CompileTimeConstant type annotation.",
     linkType = NONE,
-    category = GUAVA,
     severity = ERROR,
     disableable = false,
     suppressionAnnotations = {}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ComplexBooleanConstant.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ComplexBooleanConstant.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
@@ -36,7 +35,6 @@ import java.util.Objects;
 @BugPattern(
     name = "ComplexBooleanConstant",
     summary = "Non-trivial compile time constant boolean expressions shouldn't be used.",
-    category = JDK,
     severity = WARNING,
     providesFix = REQUIRES_HUMAN_ATTENTION)
 public class ComplexBooleanConstant extends BugChecker implements BinaryTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ConditionalExpressionNumericPromotion.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ConditionalExpressionNumericPromotion.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -42,7 +41,6 @@ import com.sun.tools.javac.code.Type;
             + "numeric promotion of the operands; when these operands are of reference types, "
             + "the expression's result may not be of the expected type.",
     severity = ERROR,
-    category = JDK,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ConditionalExpressionNumericPromotion extends BugChecker
     implements ConditionalExpressionTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ConstantField.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ConstantField.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 
 import com.google.common.base.Ascii;
@@ -41,7 +40,6 @@ import javax.lang.model.element.Modifier;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "ConstantField",
-    category = JDK,
     summary = "Field name is CONSTANT_CASE, but field is not static and final",
     severity = SUGGESTION,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ConstantOverflow.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ConstantOverflow.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getType;
@@ -54,7 +53,6 @@ import javax.lang.model.type.TypeKind;
 @BugPattern(
     name = "ConstantOverflow",
     summary = "Compile-time constant expression overflows",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ConstantOverflow extends BugChecker implements BinaryTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ConstructorInvokesOverridable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ConstructorInvokesOverridable.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
@@ -41,7 +40,6 @@ import javax.lang.model.element.Name;
 @BugPattern(
     name = "ConstructorInvokesOverridable",
     summary = "Constructors should not invoke overridable methods.",
-    category = JDK,
     severity = WARNING)
 public class ConstructorInvokesOverridable extends ConstructorLeakChecker {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ConstructorLeaksThis.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ConstructorLeaksThis.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
@@ -42,7 +41,6 @@ import javax.lang.model.element.Name;
     summary =
         "Constructors should not pass the 'this' reference out in method invocations,"
             + " since the object may not be fully constructed.",
-    category = JDK,
     severity = WARNING)
 public class ConstructorLeaksThis extends ConstructorLeakChecker {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DateFormatConstant.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DateFormatConstant.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.fixes.SuggestedFixes.renameVariable;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -46,7 +45,6 @@ import javax.lang.model.element.Modifier;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "DateFormatConstant",
-    category = JDK,
     summary = "DateFormat is not thread-safe, and should not be used as a constant field.",
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DeadException.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DeadException.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -53,7 +52,6 @@ import com.sun.source.tree.Tree;
     name = "DeadException",
     altNames = "ThrowableInstanceNeverThrown",
     summary = "Exception created but not thrown",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class DeadException extends BugChecker implements NewClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DefaultCharset.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DefaultCharset.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -73,7 +72,6 @@ import java.util.Scanner;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "DefaultCharset",
-    category = JDK,
     summary =
         "Implicit use of the platform default charset, which can result in differing behaviour"
             + " between JVM executions or incorrect behavior if the encoding of the data source"

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DepAnn.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DepAnn.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.sun.tools.javac.code.Flags.DEPRECATED;
 
@@ -44,7 +43,6 @@ import com.sun.tools.javac.code.Symbol;
     name = "DepAnn",
     altNames = "dep-ann",
     summary = "Deprecated item is not annotated with @Deprecated",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class DepAnn extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DivZero.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DivZero.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.kindIs;
@@ -46,7 +45,6 @@ import com.sun.source.tree.Tree.Kind;
     name = "DivZero",
     altNames = "divzero",
     summary = "Division by integer literal zero",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class DivZero extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DoNotCallChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DoNotCallChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.findSuperMethods;
@@ -46,7 +45,6 @@ import javax.lang.model.element.Modifier;
 // TODO(cushon): this should subsume ImmutableModification and LocalizableWrongToString
 @BugPattern(
     name = "DoNotCall",
-    category = JDK,
     summary = "This method should not be called.",
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DuplicateMapKeys.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DuplicateMapKeys.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -41,7 +40,6 @@ import java.util.Set;
     name = "DuplicateMapKeys",
     summary =
         "Map#ofEntries will throw an IllegalArgumentException if there are any duplicate keys",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.NO_FIX)
 public class DuplicateMapKeys extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EmptyIfStatement.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EmptyIfStatement.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.nextStatement;
 import static com.google.errorprone.matchers.Matchers.parentNode;
@@ -47,7 +46,6 @@ import com.sun.source.tree.Tree;
     name = "EmptyIf",
     altNames = {"empty"},
     summary = "Empty statement after if",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class EmptyIfStatement extends BugChecker implements EmptyStatementTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EmptyTopLevelDeclaration.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EmptyTopLevelDeclaration.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
@@ -34,7 +33,6 @@ import java.util.List;
 @BugPattern(
     name = "EmptyTopLevelDeclaration",
     summary = "Empty top-level type declaration",
-    category = JDK,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class EmptyTopLevelDeclaration extends BugChecker implements CompilationUnitTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EqualsHashCode.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EqualsHashCode.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.equalsMethodDeclaration;
@@ -49,7 +48,6 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "EqualsHashCode",
     summary = "Classes that override equals should also override hashCode.",
-    category = JDK,
     severity = ERROR,
     tags = StandardTags.FRAGILE_CODE)
 public class EqualsHashCode extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EqualsIncompatibleType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EqualsIncompatibleType.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.instanceEqualsInvocation;
@@ -55,7 +54,6 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "EqualsIncompatibleType",
     summary = "An equality test between objects with incompatible types always returns false",
-    category = JDK,
     severity = WARNING)
 public class EqualsIncompatibleType extends BugChecker implements MethodInvocationTreeMatcher {
   private static final Matcher<MethodInvocationTree> STATIC_EQUALS_MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EqualsNaN.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EqualsNaN.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -37,7 +36,6 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "EqualsNaN",
     summary = "== NaN always returns false; use the isNaN methods instead",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class EqualsNaN extends BugChecker implements BinaryTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EqualsReference.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EqualsReference.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -41,7 +40,6 @@ import java.util.Objects;
     summary =
         "== must be used in equals method to check equality to itself"
             + " or an infinite loop will occur.",
-    category = JDK,
     severity = ERROR)
 public class EqualsReference extends BugChecker implements MethodTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ExpectedExceptionChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ExpectedExceptionChecker.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -40,7 +39,6 @@ import javax.annotation.Nullable;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "ExpectedExceptionChecker",
-    category = JUNIT,
     summary =
         "Calls to ExpectedException#expect should always be followed by exactly one statement.",
     severity = WARNING,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ExpectedExceptionRefactoring.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ExpectedExceptionRefactoring.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.BugPattern.StandardTags.REFACTORING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -41,7 +40,6 @@ import javax.annotation.Nullable;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "ExpectedExceptionRefactoring",
-    category = JUNIT,
     summary = "Prefer assertThrows to ExpectedException",
     severity = SUGGESTION,
     tags = REFACTORING,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FallThrough.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FallThrough.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -38,7 +37,6 @@ import java.util.regex.Pattern;
 @BugPattern(
     name = "FallThrough",
     altNames = "fallthrough",
-    category = JDK,
     summary = "Switch case may fall through",
     severity = WARNING)
 public class FallThrough extends BugChecker implements SwitchTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeFinal.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeFinal.java
@@ -335,7 +335,6 @@ public class FieldCanBeFinal extends BugChecker implements CompilationUnitTreeMa
       return super.visitCompoundAssignment(node, init);
     }
 
-
     @Override
     public Void visitUnary(UnaryTree node, InitializationContext init) {
       if (UNARY_ASSIGNMENT.contains(node.getKind())) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeFinal.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeFinal.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 import static com.google.errorprone.util.ASTHelpers.hasAnnotation;
@@ -57,7 +56,6 @@ import javax.lang.model.element.Modifier;
 /** @author Liam Miller-Cushon (cushon@google.com) */
 @BugPattern(
     name = "FieldCanBeFinal",
-    category = JDK,
     summary = "This field is only assigned during initialization; consider making it final",
     severity = SUGGESTION,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/Finally.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Finally.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
@@ -61,7 +60,6 @@ import com.sun.tools.javac.util.Name;
     summary =
         "If you return or throw from a finally, then values returned or thrown from the"
             + " try-catch block will be ignored. Consider using try-with-resources instead.",
-    category = JDK,
     severity = WARNING,
     generateExamplesFromTestCases = false,
     tags = StandardTags.FRAGILE_CODE)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FloatingPointAssertionWithinEpsilon.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FloatingPointAssertionWithinEpsilon.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.TRUTH;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
@@ -55,7 +54,6 @@ import java.util.Optional;
     summary =
         "This fuzzy equality check is using a tolerance less than the gap to the next number. "
             + "You may want a less restrictive tolerance, or to assert equality.",
-    category = TRUTH,
     severity = WARNING,
     tags = StandardTags.SIMPLIFICATION,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FloatingPointLiteralPrecision.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FloatingPointLiteralPrecision.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.constValue;
@@ -37,7 +36,6 @@ import java.math.BigDecimal;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "FloatingPointLiteralPrecision",
-    category = JDK,
     summary = "Floating point literal loses precision",
     severity = WARNING,
     tags = StandardTags.STYLE,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ForOverrideChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ForOverrideChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.GUAVA;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -55,7 +54,6 @@ import javax.lang.model.element.Modifier;
     summary =
         "Method annotated @ForOverride must be protected or package-private and only invoked from "
             + "declaring class, or from an override of the method",
-    category = GUAVA,
     severity = ERROR)
 public class ForOverrideChecker extends BugChecker
     implements MethodInvocationTreeMatcher, MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FunctionalInterfaceClash.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FunctionalInterfaceClash.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
@@ -54,7 +53,6 @@ import java.util.Deque;
 @BugPattern(
     name = "FunctionalInterfaceClash",
     summary = "Overloads will be ambiguous when passing lambda arguments.",
-    category = JDK,
     severity = WARNING)
 public class FunctionalInterfaceClash extends BugChecker implements ClassTreeMatcher {
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FunctionalInterfaceMethodChanged.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FunctionalInterfaceMethodChanged.java
@@ -20,7 +20,6 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -48,7 +47,6 @@ import javax.lang.model.element.Modifier;
 
 /** @author Louis Wasserman */
 @BugPattern(
-    category = Category.JDK,
     name = "FunctionalInterfaceMethodChanged",
     summary =
         "Casting a lambda to this @FunctionalInterface can cause a behavior change from casting to"

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnored.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Multimaps.toMultimap;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -72,7 +71,6 @@ import javax.lang.model.type.TypeKind;
     summary =
         "Return value of methods returning Future must be checked. Ignoring returned Futures "
             + "suppresses exceptions thrown from the code that completes the Future.",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE)
 public final class FutureReturnValueIgnored extends AbstractReturnValueIgnored

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FuturesGetCheckedIllegalExceptionType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FuturesGetCheckedIllegalExceptionType.java
@@ -14,7 +14,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.GUAVA;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -57,7 +56,6 @@ import java.util.List;
 @BugPattern(
     name = "FuturesGetCheckedIllegalExceptionType",
     summary = "Futures.getChecked requires a checked exception type with a standard constructor.",
-    category = GUAVA,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public final class FuturesGetCheckedIllegalExceptionType extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FuzzyEqualsShouldNotBeUsedInEqualsMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FuzzyEqualsShouldNotBeUsedInEqualsMethod.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.GUAVA;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.enclosingMethod;
@@ -33,7 +32,6 @@ import com.sun.source.tree.MethodInvocationTree;
 @BugPattern(
     name = "FuzzyEqualsShouldNotBeUsedInEqualsMethod",
     summary = "DoubleMath.fuzzyEquals should never be used in an Object.equals() method",
-    category = GUAVA,
     severity = ERROR)
 public class FuzzyEqualsShouldNotBeUsedInEqualsMethod extends BugChecker
     implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnAnnotation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnAnnotation.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 
@@ -34,7 +33,6 @@ import java.lang.annotation.Annotation;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "GetClassOnAnnotation",
-    category = JDK,
     summary = "Calling getClass() on an annotation may return a proxy class",
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnClass.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
 
@@ -41,7 +40,6 @@ import com.sun.source.tree.MethodInvocationTree;
     summary =
         "Calling getClass() on an object of type Class returns the Class object for "
             + "java.lang.Class; you probably meant to operate on the object directly",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class GetClassOnClass extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnEnum.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnEnum.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 
@@ -34,7 +33,6 @@ import com.sun.source.tree.MethodInvocationTree;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "GetClassOnEnum",
-    category = JDK,
     summary = "Calling getClass() on an enum may return a subclass of the enum type",
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/HashtableContains.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/HashtableContains.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
@@ -44,7 +43,6 @@ import java.util.concurrent.ConcurrentHashMap;
 @BugPattern(
     name = "HashtableContains",
     summary = "contains() is a legacy method that is equivalent to containsValue()",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class HashtableContains extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/HidingField.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/HidingField.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static java.util.stream.Collectors.toCollection;
 
@@ -47,7 +46,6 @@ import javax.lang.model.element.Name;
  */
 @BugPattern(
     name = "HidingField",
-    category = JDK,
     summary = "Hiding fields of superclasses may cause confusion and errors",
     severity = WARNING,
     altNames = {"hiding", "OvershadowingSubclassFields"})

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IdentityBinaryExpression.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IdentityBinaryExpression.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.toType;
@@ -42,7 +41,6 @@ import java.util.Optional;
 @BugPattern(
     name = "IdentityBinaryExpression",
     altNames = "SelfEquality",
-    category = JDK,
     summary = "A binary expression where both operands are the same is usually incorrect.",
     severity = ERROR)
 public class IdentityBinaryExpression extends BugChecker implements BinaryTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ImmutableModification.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ImmutableModification.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.errorprone.BugPattern.Category.GUAVA;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
@@ -35,7 +34,6 @@ import com.sun.source.tree.MethodInvocationTree;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "ImmutableModification",
-    category = GUAVA,
     summary =
         "Modifying an immutable collection is guaranteed to throw an exception and leave the"
             + " collection unmodified",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IncompatibleModifiersChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IncompatibleModifiersChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.LinkType.NONE;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
@@ -46,7 +45,6 @@ import javax.lang.model.element.TypeElement;
         "This annotation has incompatible modifiers as specified by its "
             + "@IncompatibleModifiers annotation",
     linkType = NONE,
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.LIKELY_ERROR)
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InconsistentCapitalization.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InconsistentCapitalization.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.base.Ascii;
@@ -49,7 +48,6 @@ import javax.lang.model.element.ElementKind;
     summary =
         "It is confusing to have a field and a parameter under the same scope that differ only in "
             + "capitalization.",
-    category = JDK,
     severity = WARNING,
     generateExamplesFromTestCases = false,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IncrementInForLoopAndHeader.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IncrementInForLoopAndHeader.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.ImmutableList;
@@ -43,7 +42,6 @@ import java.util.stream.Collectors;
 @BugPattern(
     name = "IncrementInForLoopAndHeader",
     summary = "This for loop increments the same variable in the header and in the body",
-    category = JDK,
     severity = WARNING)
 public class IncrementInForLoopAndHeader extends BugChecker implements ForLoopTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IndexOfChar.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IndexOfChar.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getType;
@@ -40,7 +39,6 @@ import java.util.List;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "IndexOfChar",
-    category = JDK,
     summary =
         "The first argument to indexOf is a Unicode code point, and the second is the index to"
             + " start the search from",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InfiniteRecursion.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InfiniteRecursion.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.stripParentheses;
@@ -41,7 +40,6 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "InfiniteRecursion",
-    category = JDK,
     summary = "This method always recurses, and will cause a StackOverflowError",
     severity = ERROR)
 public class InfiniteRecursion extends BugChecker implements BugChecker.MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InputStreamSlowMultibyteRead.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InputStreamSlowMultibyteRead.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.hasAnnotation;
@@ -55,7 +54,6 @@ import javax.lang.model.element.ElementKind;
     summary =
         "Please also override int read(byte[], int, int), otherwise multi-byte reads from this "
             + "input stream are likely to be slow.",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.PERFORMANCE)
 public class InputStreamSlowMultibyteRead extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InsecureCipherMode.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InsecureCipherMode.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
@@ -37,7 +36,6 @@ import com.sun.tools.javac.tree.JCTree;
     altNames = {"InsecureCipherMode"},
     summary =
         "A standard cryptographic operation is used in a mode that is prone to vulnerabilities",
-    category = JDK,
     documentSuppression = false,
     severity = ERROR)
 public class InsecureCipherMode extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InstanceOfAndCastMatchWrongType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InstanceOfAndCastMatchWrongType.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.base.Objects;
@@ -54,7 +53,6 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "InstanceOfAndCastMatchWrongType",
     summary = "Casting inside an if block should be plausibly consistent with the instanceof type",
-    category = JDK,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class InstanceOfAndCastMatchWrongType extends BugChecker implements TypeCastTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IntLongMath.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IntLongMath.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.BugPattern.StandardTags.FRAGILE_CODE;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -46,7 +45,6 @@ import javax.lang.model.type.TypeKind;
     name = "IntLongMath",
     summary = "Expression of type int may overflow before being assigned to a long",
     severity = WARNING,
-    category = JDK,
     tags = FRAGILE_CODE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class IntLongMath extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InvalidPatternSyntax.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InvalidPatternSyntax.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -41,7 +40,6 @@ import java.util.regex.PatternSyntaxException;
 @BugPattern(
     name = "InvalidPatternSyntax",
     summary = "Invalid syntax used for a regular expression",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class InvalidPatternSyntax extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InvalidTimeZoneID.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InvalidTimeZoneID.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.common.collect.ImmutableSet;
@@ -41,7 +40,6 @@ import java.util.regex.Pattern;
     summary =
         "Invalid time zone identifier. TimeZone.getTimeZone(String) will silently return GMT"
             + " instead of the time zone you intended.",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class InvalidTimeZoneID extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InvalidZoneId.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InvalidZoneId.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -41,7 +40,6 @@ import java.time.ZoneId;
 @BugPattern(
     name = "InvalidZoneId",
     summary = "Invalid zone identifier. ZoneId.of(String) will throw exception at runtime.",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class InvalidZoneId extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IsInstanceOfClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IsInstanceOfClass.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.argument;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
@@ -43,7 +42,6 @@ import com.sun.tools.javac.tree.JCTree;
 @BugPattern(
     name = "IsInstanceOfClass",
     summary = "The argument to Class#isInstance(Object) should not be a Class",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class IsInstanceOfClass extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IterableAndIterator.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IterableAndIterator.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.isSubtypeOf;
@@ -37,7 +36,6 @@ import java.util.List;
 @BugPattern(
     name = "IterableAndIterator",
     summary = "Class should not implement both `Iterable` and `Iterator`",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE)
 public class IterableAndIterator extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IterablePathParameter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IterablePathParameter.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.isSameType;
@@ -44,7 +43,6 @@ import javax.lang.model.element.ElementKind;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "IterablePathParameter",
-    category = JDK,
     summary = "Path implements Iterable<Path>; prefer Collection<Path> for clarity",
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JMockTestWithoutRunWithOrRuleAnnotation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JMockTestWithoutRunWithOrRuleAnnotation.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JMOCK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.AT_LEAST_ONE;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -46,7 +45,6 @@ import com.sun.source.tree.VariableTree;
     summary =
         "jMock tests must have a @RunWith(JMock.class) annotation, or the Mockery field must "
             + "have a @Rule JUnit annotation",
-    category = JMOCK,
     severity = ERROR)
 public class JMockTestWithoutRunWithOrRuleAnnotation extends BugChecker
     implements VariableTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JUnit3FloatingPointComparisonWithoutDelta.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JUnit3FloatingPointComparisonWithoutDelta.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.Iterables;
@@ -50,7 +49,7 @@ import javax.lang.model.type.TypeKind;
     name = "JUnit3FloatingPointComparisonWithoutDelta",
     summary = "Floating-point comparison without error tolerance",
     // First sentence copied directly from JUnit 4.
-    category = JUNIT,
+
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class JUnit3FloatingPointComparisonWithoutDelta extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JUnit3TestNotRun.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JUnit3TestNotRun.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.fixes.SuggestedFixes.addModifiers;
 import static com.google.errorprone.fixes.SuggestedFixes.removeModifiers;
@@ -54,7 +53,6 @@ import javax.lang.model.element.Modifier;
     summary =
         "Test method will not be run; please correct method signature "
             + "(Should be public, non-static, and method name should begin with \"test\").",
-    category = JUNIT,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class JUnit3TestNotRun extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4ClassAnnotationNonStatic.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4ClassAnnotationNonStatic.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.AT_LEAST_ONE;
 import static com.google.errorprone.matchers.JUnitMatchers.JUNIT_AFTER_CLASS_ANNOTATION;
@@ -46,7 +45,6 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "JUnit4ClassAnnotationNonStatic",
     summary = "This method should be static",
-    category = JUNIT,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class JUnit4ClassAnnotationNonStatic extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4ClassUsedInJUnit3.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4ClassUsedInJUnit3.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.JUnitMatchers.isJUnit3TestClass;
@@ -42,7 +41,6 @@ import com.sun.source.tree.Tree;
     summary =
         "Some JUnit4 construct cannot be used in a JUnit3 context. Convert your class to JUnit4 "
             + "style to use them.",
-    category = JUNIT,
     severity = WARNING)
 public class JUnit4ClassUsedInJUnit3 extends BugChecker
     implements MethodInvocationTreeMatcher, AnnotationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4SetUpNotRun.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4SetUpNotRun.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.JUnitMatchers.JUNIT_AFTER_ANNOTATION;
 import static com.google.errorprone.matchers.JUnitMatchers.JUNIT_AFTER_CLASS_ANNOTATION;
@@ -44,7 +43,6 @@ import java.util.List;
 @BugPattern(
     name = "JUnit4SetUpNotRun",
     summary = "setUp() method will not be run; please add JUnit's @Before annotation",
-    category = JUNIT,
     severity = ERROR)
 public class JUnit4SetUpNotRun extends AbstractJUnit4InitMethodNotRun {
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4TearDownNotRun.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4TearDownNotRun.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.JUnitMatchers.JUNIT_AFTER_ANNOTATION;
 import static com.google.errorprone.matchers.JUnitMatchers.JUNIT_AFTER_CLASS_ANNOTATION;
@@ -44,7 +43,6 @@ import java.util.List;
 @BugPattern(
     name = "JUnit4TearDownNotRun",
     summary = "tearDown() method will not be run; please add JUnit's @After annotation",
-    category = JUNIT,
     severity = ERROR)
 public class JUnit4TearDownNotRun extends AbstractJUnit4InitMethodNotRun {
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4TestNotRun.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4TestNotRun.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.JUnitMatchers.containsTestMethod;
@@ -58,7 +57,6 @@ import javax.lang.model.element.Modifier;
     summary =
         "This looks like a test method but is not run; please add @Test and @Ignore, or, if this"
             + " is a helper method, reduce its visibility.",
-    category = JUNIT,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class JUnit4TestNotRun extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JUnitAmbiguousTestClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JUnitAmbiguousTestClass.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.JUnitMatchers.isAmbiguousJUnitVersion;
@@ -31,7 +30,6 @@ import com.sun.source.tree.ClassTree;
 @BugPattern(
     name = "JUnitAmbiguousTestClass",
     summary = "Test class inherits from JUnit 3's TestCase but has JUnit 4 @Test annotations.",
-    category = JUNIT,
     severity = WARNING)
 public class JUnitAmbiguousTestClass extends BugChecker implements ClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JUnitAssertSameCheck.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JUnitAssertSameCheck.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
 
@@ -38,7 +37,6 @@ import java.util.List;
 @BugPattern(
     name = "JUnitAssertSameCheck",
     summary = "An object is tested for reference equality to itself using JUnit library.",
-    category = JUNIT,
     severity = ERROR)
 public class JUnitAssertSameCheck extends BugChecker implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JavaLangClash.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JavaLangClash.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getFirst;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static javax.lang.model.element.Modifier.PUBLIC;
@@ -43,7 +42,6 @@ import com.sun.tools.javac.util.Names;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "JavaLangClash",
-    category = JDK,
     summary = "Never reuse class names from java.lang",
     severity = WARNING,
     tags = StandardTags.STYLE)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LambdaFunctionalInterface.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LambdaFunctionalInterface.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.util.ASTHelpers.getReceiver;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
@@ -52,7 +51,6 @@ import javax.lang.model.element.Modifier;
     name = "LambdaFunctionalInterface",
     summary =
         "Use Java's utility functional interfaces instead of Function<A, B> for primitive types.",
-    category = JDK,
     severity = SUGGESTION,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class LambdaFunctionalInterface extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LiteByteStringUtf8.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LiteByteStringUtf8.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.PROTOBUF;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
@@ -33,7 +32,6 @@ import com.sun.source.tree.MethodInvocationTree;
 /** @author glorioso@google.com (Nick Glorioso) */
 @BugPattern(
     name = "LiteByteStringUtf8",
-    category = PROTOBUF,
     summary =
         "This pattern will silently corrupt certain byte sequences from the serialized protocol "
             + "message. Use ByteString or byte[] directly",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LogicalAssignment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LogicalAssignment.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -42,7 +41,6 @@ import com.sun.tools.javac.tree.JCTree;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "LogicalAssignment",
-    category = JDK,
     summary =
         "Assignment where a boolean expression was expected;"
             + " use == if this assignment wasn't expected or add parentheses for clarity.",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LongLiteralLowerCaseSuffix.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LongLiteralLowerCaseSuffix.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -41,7 +40,6 @@ import java.util.regex.Pattern;
 @BugPattern(
     name = "LongLiteralLowerCaseSuffix",
     summary = "Prefer 'L' to 'l' for the suffix to long literals",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class LongLiteralLowerCaseSuffix extends BugChecker implements LiteralTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LoopConditionChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LoopConditionChecker.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -50,7 +49,6 @@ import com.sun.tools.javac.code.Symbol;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "LoopConditionChecker",
-    category = JDK,
     summary = "Loop condition is never modified in loop body.",
     severity = ERROR)
 public class LoopConditionChecker extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MethodCanBeStatic.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MethodCanBeStatic.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.fixes.SuggestedFixes.addModifiers;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -59,7 +58,6 @@ import javax.lang.model.element.Modifier;
     name = "MethodCanBeStatic",
     altNames = "static-method",
     summary = "A private method that does not reference the enclosing instance can be static",
-    category = JDK,
     severity = SUGGESTION,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class MethodCanBeStatic extends BugChecker implements CompilationUnitTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingCasesInEnumSwitch.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingCasesInEnumSwitch.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.ImmutableSet;
@@ -39,7 +38,6 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "MissingCasesInEnumSwitch",
     summary = "Switches on enum types should either handle all values, or have a default case.",
-    category = JDK,
     severity = WARNING)
 public class MissingCasesInEnumSwitch extends BugChecker implements SwitchTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingDefault.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingDefault.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -41,7 +40,6 @@ import javax.lang.model.element.ElementKind;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "MissingDefault",
-    category = JDK,
     summary =
         "The Google Java Style Guide requires that each switch statement includes a default"
             + " statement group, even if it contains no code. (This requirement is lifted for any"

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingFail.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingFail.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.JUnitMatchers.JUNIT_AFTER_ANNOTATION;
 import static com.google.errorprone.matchers.JUnitMatchers.JUNIT_BEFORE_ANNOTATION;
@@ -86,7 +85,6 @@ import javax.lang.model.element.Name;
     name = "MissingFail",
     altNames = "missing-fail",
     summary = "Not calling fail() when expecting an exception masks bugs",
-    category = JUNIT,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class MissingFail extends BugChecker implements TryTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingOverride.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingOverride.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
@@ -40,7 +39,6 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "MissingOverride",
     summary = "method overrides method in supertype; expected @Override",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.STYLE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MisusedWeekYear.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MisusedWeekYear.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.constructor;
@@ -56,7 +55,6 @@ import javax.lang.model.element.ElementKind;
     summary =
         "Use of \"YYYY\" (week year) in a date pattern without \"ww\" (week in year). "
             + "You probably meant to use \"yyyy\" (year) instead.",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class MisusedWeekYear extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MixedArrayDimensions.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MixedArrayDimensions.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -41,7 +40,6 @@ import com.sun.tools.javac.parser.Tokens.TokenKind;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "MixedArrayDimensions",
-    category = JDK,
     summary = "C-style array declarations should not be used",
     severity = SUGGESTION,
     linkType = CUSTOM,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MockitoCast.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MockitoCast.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.errorprone.BugPattern.Category.MOCKITO;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
@@ -57,7 +56,6 @@ import javax.lang.model.element.ElementKind;
 /** @author Liam Miller-Cushon (cushon@google.com) */
 @BugPattern(
     name = "MockitoCast",
-    category = MOCKITO,
     summary = "A bug in Mockito will cause this test to fail at runtime with a ClassCastException",
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MockitoInternalUsage.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MockitoInternalUsage.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.matchers.Matchers.packageStartsWith;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
@@ -38,7 +37,6 @@ import com.sun.tools.javac.code.Symbol;
 @BugPattern(
     name = "MockitoInternalUsage",
     summary = "org.mockito.internal.* is a private API and should not be used by clients",
-    category = Category.MOCKITO,
     severity = SeverityLevel.WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class MockitoInternalUsage extends BugChecker implements MemberSelectTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MockitoUsage.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MockitoUsage.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.MOCKITO;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
@@ -39,7 +38,6 @@ import java.util.List;
 @BugPattern(
     name = "MockitoUsage",
     summary = "Missing method call for verify(mock) here",
-    category = MOCKITO,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class MockitoUsage extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ModifiedButNotUsed.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ModifiedButNotUsed.java
@@ -17,7 +17,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -79,7 +78,6 @@ import java.util.stream.Stream;
 @BugPattern(
     name = "ModifiedButNotUsed",
     summary = "A collection or proto builder was created, but its values were never accessed.",
-    category = JDK,
     providesFix = REQUIRES_HUMAN_ATTENTION,
     severity = WARNING)
 public class ModifiedButNotUsed extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ModifyCollectionInEnhancedForLoop.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ModifyCollectionInEnhancedForLoop.java
@@ -15,7 +15,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
@@ -43,7 +42,6 @@ import java.util.List;
     summary =
         "Modifying a collection while iterating over it in a loop may cause a"
             + " ConcurrentModificationException to be thrown.",
-    category = JDK,
     severity = WARNING)
 public class ModifyCollectionInEnhancedForLoop extends BugChecker
     implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ModifyingCollectionWithItself.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ModifyingCollectionWithItself.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.bugpatterns.ReplacementVariableFinder.fixesByReplacingExpressionWithLocallyDeclaredField;
 import static com.google.errorprone.bugpatterns.ReplacementVariableFinder.fixesByReplacingExpressionWithMethodParameter;
@@ -53,7 +52,6 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "ModifyingCollectionWithItself",
     summary = "Using a collection function with itself as the argument.",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ModifyingCollectionWithItself extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MultiVariableDeclaration.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MultiVariableDeclaration.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -51,7 +50,6 @@ import java.util.List;
 @BugPattern(
     name = "MultiVariableDeclaration",
     summary = "Variable declarations should declare only one variable",
-    category = JDK,
     severity = SUGGESTION,
     linkType = CUSTOM,
     tags = StandardTags.STYLE,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MultipleParallelOrSequentialCalls.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MultipleParallelOrSequentialCalls.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
 
@@ -37,7 +36,6 @@ import com.sun.source.util.TreePath;
     name = "MultipleParallelOrSequentialCalls",
     summary =
         "Multiple calls to either parallel or sequential are unnecessary and cause confusion.",
-    category = JDK,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class MultipleParallelOrSequentialCalls extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MultipleTopLevelClasses.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MultipleTopLevelClasses.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 
@@ -38,7 +37,6 @@ import java.util.List;
     name = "MultipleTopLevelClasses",
     altNames = {"TopLevel"},
     summary = "Source files should not contain multiple top-level class declarations",
-    category = JDK,
     severity = SUGGESTION,
     documentSuppression = false,
     linkType = CUSTOM,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MultipleUnaryOperatorsInMethodCall.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MultipleUnaryOperatorsInMethodCall.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 
 import com.google.common.collect.ImmutableSet;
@@ -34,7 +33,6 @@ import java.util.stream.Collectors;
 @BugPattern(
     name = "MultipleUnaryOperatorsInMethodCall",
     summary = "Avoid having multiple unary operators acting on the same variable in a method call",
-    category = JDK,
     severity = SUGGESTION)
 public class MultipleUnaryOperatorsInMethodCall extends BugChecker
     implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MustBeClosedChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MustBeClosedChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -58,7 +57,6 @@ import java.util.List;
 @BugPattern(
     name = "MustBeClosedChecker",
     summary = "The result of this method must be closed.",
-    category = JDK,
     severity = ERROR,
     generateExamplesFromTestCases = false,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MutableConstantField.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MutableConstantField.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.AT_LEAST_ONE;
 import static com.google.errorprone.matchers.Matchers.annotations;
@@ -44,7 +43,6 @@ import javax.lang.model.element.Modifier;
 /** @author dorir@google.com (Dori Reuveni) */
 @BugPattern(
     name = "MutableConstantField",
-    category = JDK,
     summary =
         "Constant field declarations should use the immutable type (such as ImmutableList) instead"
             + " of the general collection interface type (such as List)",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MutableMethodReturnType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MutableMethodReturnType.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.ImmutableList;
@@ -48,7 +47,6 @@ import java.util.function.Predicate;
 /** @author dorir@google.com (Dori Reuveni) */
 @BugPattern(
     name = "MutableMethodReturnType",
-    category = JDK,
     summary =
         "Method return type should use the immutable type (such as ImmutableList) instead of"
             + " the general collection interface type (such as List)",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NCopiesOfChar.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NCopiesOfChar.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
@@ -38,7 +37,6 @@ import java.util.List;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "NCopiesOfChar",
-    category = JDK,
     summary =
         "The first argument to nCopies is the number of copies, and the second is the item to copy",
     severity = ERROR,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NarrowingCompoundAssignment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NarrowingCompoundAssignment.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.util.ASTHelpers.getType;
 import static com.google.errorprone.util.Signatures.prettyType;
@@ -43,7 +42,6 @@ import com.sun.tools.javac.tree.JCTree.JCBinary;
 @BugPattern(
     name = "NarrowingCompoundAssignment",
     summary = "Compound assignments may hide dangerous casts",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NestedInstanceOfConditions.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NestedInstanceOfConditions.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.contains;
 import static com.google.errorprone.util.ASTHelpers.stripParentheses;
@@ -40,7 +39,6 @@ import com.sun.tools.javac.code.Types;
  */
 @BugPattern(
     name = "NestedInstanceOfConditions",
-    category = JDK,
     summary =
         "Nested instanceOf conditions of disjoint types create blocks of code that never execute",
     severity = WARNING)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NoAllocationChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NoAllocationChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -125,7 +124,6 @@ import java.util.Set;
     summary =
         "@NoAllocation was specified on this method, but something was found that would"
             + " trigger an allocation",
-    category = JDK,
     severity = ERROR)
 public class NoAllocationChecker extends BugChecker
     implements AssignmentTreeMatcher,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NonAtomicVolatileUpdate.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NonAtomicVolatileUpdate.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -49,7 +48,6 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "NonAtomicVolatileUpdate",
     summary = "This update of a volatile variable is non-atomic",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE)
 public class NonAtomicVolatileUpdate extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NonCanonicalStaticImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NonCanonicalStaticImport.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -36,7 +35,6 @@ import com.sun.source.tree.ImportTree;
 @BugPattern(
     name = "NonCanonicalStaticImport",
     summary = "Static import of type uses non-canonical name",
-    category = JDK,
     severity = ERROR,
     documentSuppression = false,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NonCanonicalStaticMemberImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NonCanonicalStaticMemberImport.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
@@ -36,7 +35,6 @@ import com.sun.source.tree.ImportTree;
 @BugPattern(
     name = "NonCanonicalStaticMemberImport",
     summary = "Static import of member uses non-canonical name",
-    category = JDK,
     severity = WARNING,
     documentSuppression = false,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NonFinalCompileTimeConstant.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NonFinalCompileTimeConstant.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.sun.tools.javac.code.Flags.EFFECTIVELY_FINAL;
@@ -40,7 +39,6 @@ import com.sun.tools.javac.code.Symbol.VarSymbol;
 @BugPattern(
     name = "NonFinalCompileTimeConstant",
     summary = "@CompileTimeConstant parameters should be final or effectively final",
-    category = JDK,
     severity = ERROR)
 public class NonFinalCompileTimeConstant extends BugChecker implements MethodTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NonOverridingEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NonOverridingEquals.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -58,7 +57,6 @@ import com.sun.tools.javac.util.Name;
 @BugPattern(
     name = "NonOverridingEquals",
     summary = "equals method doesn't override Object.equals",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NonRuntimeAnnotation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NonRuntimeAnnotation.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
@@ -39,7 +38,6 @@ import com.sun.tools.javac.code.Type;
 @BugPattern(
     name = "NonRuntimeAnnotation",
     summary = "Calling getAnnotation on an annotation that is not retained at runtime.",
-    category = JDK,
     severity = ERROR)
 public class NonRuntimeAnnotation extends BugChecker implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NullableConstructor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NullableConstructor.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -36,7 +35,6 @@ import com.sun.tools.javac.code.Symbol;
 @BugPattern(
     name = "NullableConstructor",
     summary = "Constructors should not be annotated with @Nullable since they cannot return null",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.STYLE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NullablePrimitive.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NullablePrimitive.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -43,7 +42,6 @@ import java.util.List;
 @BugPattern(
     name = "NullablePrimitive",
     summary = "@Nullable should not be used for primitive types since they cannot be null",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.STYLE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NullableVoid.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NullableVoid.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -39,7 +38,6 @@ import javax.lang.model.type.TypeKind;
     summary =
         "void-returning methods should not be annotated with @Nullable,"
             + " since they cannot return null",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.STYLE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NumericEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NumericEquality.java
@@ -14,7 +14,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -28,7 +27,6 @@ import com.sun.tools.javac.code.Symbol;
 @BugPattern(
     name = "NumericEquality",
     summary = "Numeric comparison using reference equality instead of value equality",
-    category = JDK,
     severity = ERROR)
 public class NumericEquality extends AbstractReferenceEquality {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ObjectToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ObjectToString.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.base.Optional;
@@ -45,7 +44,6 @@ import com.sun.tools.javac.util.Names;
     summary =
         "Calling toString on Objects that don't override toString() doesn't"
             + " provide useful information",
-    category = JDK,
     severity = WARNING,
     providesFix = ProvidesFix.NO_FIX)
 public class ObjectToString extends AbstractToString {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OperatorPrecedence.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OperatorPrecedence.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -40,7 +39,6 @@ import java.util.EnumSet;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "OperatorPrecedence",
-    category = JDK,
     summary = "Use grouping parenthesis to make the operator precedence explicit",
     severity = WARNING,
     tags = StandardTags.STYLE,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OptionalEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OptionalEquality.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.GUAVA;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.common.collect.ImmutableSet;
@@ -30,7 +29,6 @@ import com.sun.tools.javac.code.Type;
 @BugPattern(
     name = "OptionalEquality",
     summary = "Comparison using reference equality instead of value equality",
-    category = GUAVA,
     severity = ERROR)
 public class OptionalEquality extends AbstractReferenceEquality {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OptionalNotPresent.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OptionalNotPresent.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
@@ -41,7 +40,6 @@ import java.util.Iterator;
 /** @author mariasam@google.com (Maria Sam) */
 @BugPattern(
     name = "OptionalNotPresent",
-    category = JDK,
     summary =
         "One should not call optional.get() inside an if statement that checks "
             + "!optional.isPresent",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OverrideThrowableToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OverrideThrowableToString.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.ImmutableList;
@@ -42,7 +41,6 @@ import com.sun.source.tree.MethodTree;
     summary =
         "To return a custom message with a Throwable class, one should "
             + "override getMessage() instead of toString().",
-    category = JDK,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public final class OverrideThrowableToString extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/Overrides.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Overrides.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
@@ -44,7 +43,6 @@ import java.util.Set;
     name = "Overrides",
     altNames = "overrides",
     summary = "Varargs doesn't agree for overridden method",
-    category = JDK,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class Overrides extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PackageInfo.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PackageInfo.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -29,7 +28,6 @@ import com.sun.source.tree.CompilationUnitTree;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "PackageInfo",
-    category = JDK,
     summary = "Declaring types inside package-info.java files is very bad form",
     severity = ERROR)
 public class PackageInfo extends BugChecker implements CompilationUnitTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PackageLocation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PackageLocation.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 
 import com.google.common.base.CharMatcher;
@@ -35,7 +34,6 @@ import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 @BugPattern(
     name = "PackageLocation",
     summary = "Package names should match the directory they are declared in",
-    category = JDK,
     severity = SUGGESTION,
     documentSuppression = false,
     suppressionAnnotations = SuppressPackageLocation.class,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ParameterComment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ParameterComment.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Streams.forEachPair;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -46,7 +45,6 @@ import java.util.stream.Stream;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "ParameterComment",
-    category = JDK,
     summary = "Non-standard parameter comment; prefer `/* paramName= */ arg`",
     severity = SUGGESTION,
     tags = StandardTags.STYLE,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNull.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.GUAVA;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.argument;
@@ -40,7 +39,6 @@ import java.util.List;
 @BugPattern(
     name = "PreconditionsCheckNotNull",
     summary = "Literal passed as first argument to Preconditions.checkNotNull() can never be null",
-    category = GUAVA,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class PreconditionsCheckNotNull extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullPrimitive.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullPrimitive.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.GUAVA;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.argument;
@@ -66,7 +65,6 @@ import java.util.Set;
     summary =
         "First argument to `Preconditions.checkNotNull()` is a primitive rather "
             + "than an object reference",
-    category = GUAVA,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class PreconditionsCheckNotNullPrimitive extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullRepeated.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullRepeated.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.GUAVA;
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -43,7 +42,6 @@ import java.util.List;
     summary =
         "Including the first argument of checkNotNull in the failure message is not useful, "
             + "as it will always be `null`.",
-    category = GUAVA,
     severity = WARNING,
     providesFix = REQUIRES_HUMAN_ATTENTION)
 public class PreconditionsCheckNotNullRepeated extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsInvalidPlaceholder.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsInvalidPlaceholder.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.GUAVA;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
 
@@ -39,7 +38,6 @@ import java.util.regex.Pattern;
 @BugPattern(
     name = "PreconditionsInvalidPlaceholder",
     summary = "Preconditions only accepts the %s placeholder in error message strings",
-    category = GUAVA,
     severity = WARNING,
     tags = StandardTags.LIKELY_ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PredicateIncompatibleType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PredicateIncompatibleType.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.Signatures.prettyType;
@@ -37,7 +36,6 @@ import com.sun.tools.javac.code.Type;
  */
 @BugPattern(
     name = "PredicateIncompatibleType",
-    category = JDK,
     summary =
         "Using ::equals or ::isInstance as an incompatible Predicate;"
             + " the predicate will always return false",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PrimitiveArrayPassedToVarargsMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PrimitiveArrayPassedToVarargsMethod.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -41,7 +40,6 @@ import com.sun.tools.javac.util.List;
 @BugPattern(
     name = "PrimitiveArrayPassedToVarargsMethod",
     summary = "Passing a primitive array to a varargs method is usually wrong",
-    category = JDK,
     severity = WARNING)
 public class PrimitiveArrayPassedToVarargsMethod extends BugChecker
     implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PrivateConstructorForUtilityClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PrivateConstructorForUtilityClass.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.fixes.SuggestedFixes.addMembers;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -48,7 +47,6 @@ import com.sun.source.util.TreePath;
     summary =
         "Utility classes (only static members) are not designed to be instantiated and should"
             + " be made noninstantiable with a default constructor.",
-    category = JDK,
     severity = SUGGESTION,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public final class PrivateConstructorForUtilityClass extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PrivateSecurityContractProtoAccess.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PrivateSecurityContractProtoAccess.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.ONE_OFF;
 import static com.google.errorprone.BugPattern.LinkType.NONE;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -40,7 +39,7 @@ import java.util.regex.Pattern;
         "Access to a private protocol buffer field is forbidden. This protocol buffer carries"
             + " a security contract, and can only be created using an approved library."
             + " Direct access to the fields is forbidden.",
-    category = ONE_OFF,
+
     severity = ERROR,
     linkType = NONE)
 public class PrivateSecurityContractProtoAccess extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ProtoFieldNullComparison.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ProtoFieldNullComparison.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.PROTOBUF;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -70,7 +69,6 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "ProtoFieldNullComparison",
     summary = "Protobuf fields cannot be null.",
-    category = PROTOBUF,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ProtoFieldNullComparison extends BugChecker implements CompilationUnitTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ProtoStringFieldReferenceEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ProtoStringFieldReferenceEquality.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.ONE_OFF;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -36,7 +35,6 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.Tree.Kind;
 
 @BugPattern(
-    category = ONE_OFF,
     name = "ProtoStringFieldReferenceEquality",
     severity = ERROR,
     summary = "Comparing protobuf fields of type String using reference equality",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ProtocolBufferOrdinal.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ProtocolBufferOrdinal.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.PROTOBUF;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
 
@@ -36,7 +35,6 @@ import com.sun.source.tree.MethodInvocationTree;
 @BugPattern(
     name = "ProtocolBufferOrdinal",
     summary = "To get the tag number of a protocol buffer enum, use getNumber() instead.",
-    category = PROTOBUF,
     severity = ERROR)
 public class ProtocolBufferOrdinal extends BugChecker implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RandomModInteger.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RandomModInteger.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
@@ -37,7 +36,6 @@ import com.sun.source.tree.Tree.Kind;
     name = "RandomModInteger",
     summary = "Use Random.nextInt(int).  Random.nextInt() % n can have negative results",
     severity = SeverityLevel.ERROR,
-    category = Category.JDK,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class RandomModInteger extends BugChecker implements BinaryTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RedundantThrows.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RedundantThrows.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
@@ -47,7 +46,6 @@ import java.util.Set;
 @BugPattern(
     name = "RedundantThrows",
     summary = "Thrown exception is a subtype of another",
-    category = JDK,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class RedundantThrows extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ReferenceEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ReferenceEquality.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
@@ -37,7 +36,6 @@ import com.sun.tools.javac.util.Name;
 @BugPattern(
     name = "ReferenceEquality",
     summary = "Comparison using reference equality instead of value equality",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE)
 public class ReferenceEquality extends AbstractReferenceEquality {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RemoveUnusedImports.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RemoveUnusedImports.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
@@ -53,7 +52,6 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "RemoveUnusedImports",
     summary = "Unused imports",
-    category = JDK,
     severity = SUGGESTION,
     documentSuppression = false,
     tags = StandardTags.STYLE,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RequiredModifiersChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RequiredModifiersChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.LinkType.NONE;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
@@ -42,7 +41,6 @@ import javax.lang.model.element.Modifier;
         "This annotation is missing required modifiers as specified by its "
             + "@RequiredModifiers annotation",
     linkType = NONE,
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.LIKELY_ERROR)
 public class RequiredModifiersChecker extends BugChecker implements AnnotationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RestrictedApiChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RestrictedApiChecker.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
@@ -45,7 +44,6 @@ import javax.lang.model.type.MirroredTypesException;
 @BugPattern(
     name = "RestrictedApiChecker",
     summary = " Check for non-whitelisted callers to RestrictedApiChecker.",
-    category = Category.ONE_OFF,
     severity = SeverityLevel.ERROR,
     suppressionAnnotations = {},
     disableable = false,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ReturnValueIgnored.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -44,7 +43,6 @@ import javax.lang.model.element.Modifier;
     name = "ReturnValueIgnored",
     altNames = {"ResultOfMethodCallIgnored", "CheckReturnValue"},
     summary = "Return value of this method must be used",
-    category = JDK,
     severity = ERROR)
 public class ReturnValueIgnored extends AbstractReturnValueIgnored {
   /**

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ReturnValueIgnored.java
@@ -20,6 +20,7 @@ import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.packageStartsWith;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 import static com.google.errorprone.util.ASTHelpers.isSameType;
@@ -35,6 +36,8 @@ import com.sun.tools.javac.code.Type;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
+import javax.lang.model.element.Modifier;
 
 /** @author alexeagle@google.com (Alex Eagle) */
 @BugPattern(
@@ -68,6 +71,57 @@ public class ReturnValueIgnored extends AbstractReturnValueIgnored {
       allOf(methodReceiverHasType(typesToCheck), methodReturnsSameTypeAsReceiver());
 
   /**
+   * This matcher allows the following methods in {@code java.time}:
+   *
+   * <ul>
+   *   <li>any methods named {@code parse}
+   *   <li>any static method named {@code of}
+   *   <li>any static method named {@code from}
+   *   <li>any instance method starting with {@code append} on {@link
+   *       java.time.format.DateTimeFormatterBuilder}
+   *   <li>{@link java.time.temporal.ChronoField#checkValidIntValue}
+   *   <li>{@link java.time.temporal.ChronoField#checkValidValue}
+   * </ul>
+   */
+  private static final Matcher<ExpressionTree> ALLOWED_JAVA_TIME_METHODS =
+      anyOf(
+          staticMethod().anyClass().named("parse"),
+          instanceMethod().anyClass().named("parse"),
+          staticMethod().anyClass().named("of"),
+          staticMethod().anyClass().named("from"),
+          staticMethod().onClass("java.time.ZoneId").named("ofOffset"),
+          instanceMethod()
+              .onExactClass("java.time.format.DateTimeFormatterBuilder")
+              .withNameMatching(Pattern.compile("^append.*")),
+          instanceMethod()
+              .onExactClass("java.time.temporal.ChronoField")
+              .named("checkValidIntValue"),
+          instanceMethod().onExactClass("java.time.temporal.ChronoField").named("checkValidValue"));
+
+  /**
+   * {@link java.time} types are immutable. The only methods we allow ignoring the return value on
+   * are the {@code parse}-style APIs since folks often use it for validation.
+   */
+  private static final Matcher<ExpressionTree> JAVA_TIME_TYPES =
+      (tree, state) -> {
+        if (packageStartsWith("java.time").matches(tree, state)) {
+          return false;
+        }
+        Symbol symbol = ASTHelpers.getSymbol(tree);
+        if (symbol instanceof MethodSymbol) {
+          MethodSymbol methodSymbol = (MethodSymbol) symbol;
+          if (methodSymbol.owner.packge().getQualifiedName().toString().startsWith("java.time")
+              && methodSymbol.getModifiers().contains(Modifier.PUBLIC)) {
+            if (ALLOWED_JAVA_TIME_METHODS.matches(tree, state)) {
+              return false;
+            }
+            return true;
+          }
+        }
+        return false;
+      };
+
+  /**
    * Methods in {@link java.util.function} are pure, and their returnvalues should not be discarded.
    */
   private static final Matcher<ExpressionTree> FUNCTIONAL_METHOD =
@@ -97,7 +151,8 @@ public class ReturnValueIgnored extends AbstractReturnValueIgnored {
 
   @Override
   public Matcher<? super ExpressionTree> specializedMatcher() {
-    return anyOf(RETURNS_SAME_TYPE, FUNCTIONAL_METHOD, STREAM_METHOD, ARRAYS_METHODS);
+    return anyOf(
+        RETURNS_SAME_TYPE, FUNCTIONAL_METHOD, STREAM_METHOD, ARRAYS_METHODS, JAVA_TIME_TYPES);
   }
 
   /** Matches method invocations that return the same type as the receiver object. */

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RxReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RxReturnValueIgnored.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.Category.JDK;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.isSubtypeOf;
+import static com.google.errorprone.matchers.Matchers.not;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.google.errorprone.util.ASTHelpers.hasAnnotation;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MemberReferenceTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree.Kind;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+
+/** See {@link BugPattern} annotation. */
+@BugPattern(
+    name = "RxReturnValueIgnored",
+    summary =
+        "Returned Rx objects must be checked. Ignoring a returned Rx value means it is never "
+            + "scheduled for execution",
+    explanation =
+        "Methods that return an ignored [Observable | Single | Flowable | Maybe ] generally "
+            + "indicate errors.\n\nIf you don’t check the return value of these methods, the "
+            + "observables may never execute. It also means the error case is not being handled",
+    category = JDK,
+    severity = WARNING)
+public final class RxReturnValueIgnored extends AbstractReturnValueIgnored {
+  private static final Matcher<ExpressionTree> HAS_CIRV_ANNOTATION =
+      (tree, state) -> {
+        Symbol untypedSymbol = getSymbol(tree);
+        if (!(untypedSymbol instanceof MethodSymbol)) {
+          return false;
+        }
+
+        MethodSymbol sym = (MethodSymbol) untypedSymbol;
+        // Directly has @CanIgnoreReturnValue
+        if (ASTHelpers.hasAnnotation(sym, CanIgnoreReturnValue.class, state)) {
+          return true;
+        }
+
+        // If a super-class's method is annotated with @CanIgnoreReturnValue, we only honor that
+        // if the super-type returned the exact same type. This lets us catch issues where a
+        // superclass was annotated with @CanIgnoreReturnValue but the parent did not intend to
+        // return an Rx type
+        return ASTHelpers.findSuperMethods(sym, state.getTypes()).stream()
+            .anyMatch(
+                superSym ->
+                    hasAnnotation(superSym, CanIgnoreReturnValue.class, state)
+                        && superSym.getReturnType().tsym.equals(sym.getReturnType().tsym));
+      };
+
+  private static final Matcher<ExpressionTree> MATCHER =
+      allOf(
+          Matchers.kindIs(Kind.METHOD_INVOCATION),
+          anyOf(
+              // RxJava2
+              isSubtypeOf("io.reactivex.Observable"),
+              isSubtypeOf("io.reactivex.Flowable"),
+              isSubtypeOf("io.reactivex.Single"),
+              isSubtypeOf("io.reactivex.Maybe"),
+              isSubtypeOf("io.reactivex.Completable"),
+              // RxJava1
+              isSubtypeOf("rx.Observable"),
+              isSubtypeOf("rx.Single"),
+              isSubtypeOf("rx.Completable")),
+          not(HAS_CIRV_ANNOTATION));
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    Description description = super.matchMethodInvocation(tree, state);
+    return description.equals(Description.NO_MATCH) ? Description.NO_MATCH : describeMatch(tree);
+  }
+
+  @Override
+  public Description matchMemberReference(MemberReferenceTree tree, VisitorState state) {
+    Description description = super.matchMemberReference(tree, state);
+    return description.equals(Description.NO_MATCH) ? Description.NO_MATCH : describeMatch(tree);
+  }
+
+  @Override
+  public Matcher<? super ExpressionTree> specializedMatcher() {
+    return MATCHER;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RxReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RxReturnValueIgnored.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -48,7 +47,6 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
         "Methods that return an ignored [Observable | Single | Flowable | Maybe ] generally "
             + "indicate errors.\n\nIf you don’t check the return value of these methods, the "
             + "observables may never execute. It also means the error case is not being handled",
-    category = JDK,
     severity = WARNING)
 public final class RxReturnValueIgnored extends AbstractReturnValueIgnored {
   private static final Matcher<ExpressionTree> HAS_CIRV_ANNOTATION =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SelfAssignment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SelfAssignment.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
@@ -57,7 +56,6 @@ import com.sun.tools.javac.code.Type;
 @BugPattern(
     name = "SelfAssignment",
     summary = "Variable assigned to itself",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class SelfAssignment extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SelfComparison.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SelfComparison.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
@@ -34,11 +33,7 @@ import com.sun.source.tree.MethodInvocationTree;
  *
  * @author bhagwani@google.com (Sumit Bhagwani)
  */
-@BugPattern(
-    name = "SelfComparison",
-    summary = "An object is compared to itself",
-    category = JDK,
-    severity = ERROR)
+@BugPattern(name = "SelfComparison", summary = "An object is compared to itself", severity = ERROR)
 public class SelfComparison extends BugChecker implements MethodInvocationTreeMatcher {
 
   /**

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SelfEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SelfEquals.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -54,7 +53,6 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "SelfEquals",
     summary = "Testing an object for equality with itself will always be true.",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class SelfEquals extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ShortCircuitBoolean.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ShortCircuitBoolean.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getType;
@@ -43,7 +42,6 @@ import java.util.Iterator;
  */
 @BugPattern(
     name = "ShortCircuitBoolean",
-    category = JDK,
     summary = "Prefer the short-circuiting boolean operators && and || to & and |.",
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ShouldHaveEvenArgs.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ShouldHaveEvenArgs.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.Category.TRUTH;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
@@ -42,7 +41,6 @@ import java.util.List;
 @BugPattern(
     name = "ShouldHaveEvenArgs",
     summary = "This method must be called with an even number of arguments.",
-    category = TRUTH,
     severity = ERROR)
 public class ShouldHaveEvenArgs extends BugChecker implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SizeGreaterThanOrEqualsZero.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SizeGreaterThanOrEqualsZero.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
@@ -63,7 +62,6 @@ import java.util.regex.Pattern;
     name = "SizeGreaterThanOrEqualsZero",
     summary =
         "Comparison of a size >= 0 is always true, did you intend to check for " + "non-emptiness?",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class SizeGreaterThanOrEqualsZero extends BugChecker implements BinaryTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpression.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpression.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.fixes.SuggestedFixes.qualifyType;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -42,7 +41,6 @@ import java.util.Objects;
 @BugPattern(
     name = "StaticQualifiedUsingExpression",
     summary = "A static variable or method should be qualified with a class name, not expression",
-    category = JDK,
     severity = WARNING,
     altNames = {"static", "static-access", "StaticAccessedFromInstance"},
     generateExamplesFromTestCases = false,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StreamResourceLeak.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StreamResourceLeak.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -50,7 +49,6 @@ import java.util.Objects;
 @BugPattern(
     name = "StreamResourceLeak",
     altNames = "FilesLinesLeak",
-    category = JDK,
     summary =
         "Streams that encapsulate a closeable resource should be closed using"
             + " try-with-resources",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StreamToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StreamToString.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.common.base.Optional;
@@ -33,7 +32,6 @@ import com.sun.tools.javac.code.Type;
 @BugPattern(
     name = "StreamToString",
     summary = "Calling toString on a Stream does not provide useful information",
-    category = JDK,
     severity = ERROR)
 public class StreamToString extends AbstractToString {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StringBuilderInitWithChar.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StringBuilderInitWithChar.java
@@ -17,7 +17,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
@@ -35,7 +34,6 @@ import javax.lang.model.type.TypeKind;
 
 /** @author lowasser@google.com (Louis Wasserman) */
 @BugPattern(
-    category = Category.JDK,
     name = "StringBuilderInitWithChar",
     severity = ERROR,
     summary = "StringBuilder does not have a char constructor; this invokes the int constructor.",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StringEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StringEquality.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
@@ -28,7 +27,6 @@ import com.sun.source.tree.ExpressionTree;
 @BugPattern(
     name = "StringEquality",
     summary = "String comparison using reference equality instead of value equality",
-    category = JDK,
     severity = WARNING)
 public class StringEquality extends AbstractReferenceEquality {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SuppressWarningsDeprecated.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SuppressWarningsDeprecated.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.hasArgumentWithValue;
@@ -39,7 +38,6 @@ import java.util.List;
 @BugPattern(
     name = "SuppressWarningsDeprecated",
     summary = "Suppressing \"deprecated\" is probably a typo for \"deprecation\"",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class SuppressWarningsDeprecated extends AbstractSuppressWarningsMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SwigMemoryLeak.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SwigMemoryLeak.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -35,7 +34,6 @@ import javax.lang.model.element.Name;
 @BugPattern(
     name = "SwigMemoryLeak",
     summary = "SWIG generated code that can't call a C++ destructor will leak memory",
-    category = JDK,
     severity = WARNING)
 public class SwigMemoryLeak extends BugChecker implements LiteralTreeMatcher {
   private static final Matcher<MethodTree> ENCLOSING_CLASS_HAS_FINALIZER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TestExceptionChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TestExceptionChecker.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -39,7 +38,6 @@ import java.util.List;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "TestExceptionChecker",
-    category = JUNIT,
     summary =
         "Using @Test(expected=...) is discouraged, since the test will pass if *any* statement in"
             + " the test method throws the expected exception",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TestExceptionRefactoring.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TestExceptionRefactoring.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.BugPattern.StandardTags.REFACTORING;
 
@@ -31,7 +30,6 @@ import com.sun.tools.javac.tree.JCTree.JCExpression;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "TestExceptionRefactoring",
-    category = JUNIT,
     summary = "Prefer assertThrows to @Test(expected=...)",
     severity = SUGGESTION,
     tags = REFACTORING,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThreadJoinLoop.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThreadJoinLoop.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
 import static com.google.errorprone.util.ASTHelpers.getType;
 import static com.google.errorprone.util.ASTHelpers.isSubtype;
@@ -50,7 +49,6 @@ import java.util.concurrent.atomic.AtomicInteger;
     summary =
         "Thread.join needs to be surrounded by a loop until it succeeds, "
             + "as in Uninterruptibles.joinUninterruptibly.",
-    category = JDK,
     severity = SeverityLevel.WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ThreadJoinLoop extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThreeLetterTimeZoneID.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThreeLetterTimeZoneID.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -41,7 +40,6 @@ import java.util.TimeZone;
 @BugPattern(
     name = "ThreeLetterTimeZoneID",
     summary = ThreeLetterTimeZoneID.SUMMARY,
-    category = JDK,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ThreeLetterTimeZoneID extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThrowIfUncheckedKnownChecked.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThrowIfUncheckedKnownChecked.java
@@ -14,7 +14,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.GUAVA;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.fixes.SuggestedFix.delete;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -43,7 +42,6 @@ import javax.lang.model.type.UnionType;
 @BugPattern(
     name = "ThrowIfUncheckedKnownChecked",
     summary = "throwIfUnchecked(knownCheckedException) is a no-op.",
-    category = GUAVA,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ThrowIfUncheckedKnownChecked extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThrowNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThrowNull.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.sun.source.tree.Tree.Kind.NULL_LITERAL;
@@ -32,7 +31,6 @@ import com.sun.source.tree.ThrowTree;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "ThrowNull",
-    category = JDK,
     summary = "Throwing 'null' always results in a NullPointerException being thrown.",
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThrowsUncheckedException.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThrowsUncheckedException.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getType;
@@ -42,7 +41,6 @@ import java.util.List;
 @BugPattern(
     name = "ThrowsUncheckedException",
     summary = "Unchecked exceptions do not need to be declared in the method signature.",
-    category = JDK,
     severity = SUGGESTION,
     generateExamplesFromTestCases = false,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ToStringReturnsNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ToStringReturnsNull.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.sun.source.tree.Tree.Kind.NULL_LITERAL;
 
@@ -40,7 +39,6 @@ import com.sun.source.util.TreeScanner;
 @BugPattern(
     name = "ToStringReturnsNull",
     summary = "An implementation of Object.toString() should never return null.",
-    category = JDK,
     severity = WARNING)
 public class ToStringReturnsNull extends BugChecker implements MethodTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TruthAssertExpected.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TruthAssertExpected.java
@@ -58,7 +58,6 @@ import javax.annotation.Nullable;
     summary =
         "The actual and expected values appear to be swapped, which results in poor assertion "
             + "failure messages. The actual value should come first.",
-    category = TRUTH,
     severity = WARNING,
     tags = StandardTags.STYLE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TruthConstantAsserts.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TruthConstantAsserts.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.TRUTH;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
@@ -43,7 +42,6 @@ import java.util.regex.Pattern;
 @BugPattern(
     name = "TruthConstantAsserts",
     summary = "Truth Library assert is called on a constant.",
-    category = TRUTH,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TruthSelfEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TruthSelfEquals.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.TRUTH;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -47,7 +46,6 @@ import java.util.regex.Pattern;
     summary =
         "isEqualTo should not be used to test an object for equality with itself; the"
             + " assertion will never fail.",
-    category = TRUTH,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class TruthSelfEquals extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TryFailRefactoring.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TryFailRefactoring.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.BugPattern.StandardTags.REFACTORING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -42,7 +41,6 @@ import java.util.Optional;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "TryFailRefactoring",
-    category = JUNIT,
     summary = "Prefer assertThrows to try/fail",
     severity = SUGGESTION,
     tags = REFACTORING,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TryFailThrowable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TryFailThrowable.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.bugpatterns.TryFailThrowable.CaughtType.JAVA_LANG_ERROR;
 import static com.google.errorprone.bugpatterns.TryFailThrowable.CaughtType.JAVA_LANG_THROWABLE;
@@ -94,7 +93,6 @@ import java.util.List;
 @BugPattern(
     name = "TryFailThrowable",
     summary = "Catching Throwable/Error masks failures from fail() or assert*() in the try block",
-    category = JUNIT,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class TryFailThrowable extends BugChecker implements TryTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeNameShadowing.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeNameShadowing.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.ImmutableList;
@@ -61,7 +60,6 @@ import java.util.stream.Collectors;
 @BugPattern(
     name = "TypeNameShadowing",
     summary = "Type parameter declaration shadows another named type",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.STYLE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterNaming.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterNaming.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 
 import com.google.common.base.Ascii;
@@ -57,7 +56,6 @@ import javax.lang.model.element.Name;
     summary =
         "Type parameters must be a single letter with an optional numeric suffix,"
             + " or an UpperCamelCase name followed by the letter 'T'.",
-    category = JDK,
     severity = SUGGESTION,
     tags = StandardTags.STYLE,
     linkType = LinkType.CUSTOM,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -37,7 +36,6 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "TypeParameterQualifier",
     summary = "Type parameter used as type qualifier",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class TypeParameterQualifier extends BugChecker implements MemberSelectTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterShadowing.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterShadowing.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.base.Objects;
@@ -57,7 +56,6 @@ import javax.lang.model.element.Name;
 @BugPattern(
     name = "TypeParameterShadowing",
     summary = "Type parameter declaration overrides another type parameter already declared",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.STYLE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterUnusedInFormals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterUnusedInFormals.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
@@ -41,7 +40,6 @@ import java.util.Set;
         "Declaring a type parameter that is only used in the return type is a misuse of"
             + " generics: operations on the type parameter are unchecked, it hides unsafe casts at"
             + " invocations of the method, and it interacts badly with method overload resolution.",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE)
 public class TypeParameterUnusedInFormals extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/URLEqualsHashCode.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/URLEqualsHashCode.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -57,7 +56,6 @@ import java.util.List;
     summary =
         "Avoid hash-based containers of java.net.URL--the containers rely on equals() and"
             + " hashCode(), which cause java.net.URL to make blocking internet connections.",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE)
 public class URLEqualsHashCode extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UngroupedOverloads.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UngroupedOverloads.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.BugPattern.StandardTags.STYLE;
@@ -54,7 +53,6 @@ import javax.lang.model.element.Name;
         "Constructors and methods with the same name should appear sequentially"
             + " with no other code in between. Please re-order or re-name methods.",
     generateExamplesFromTestCases = false,
-    category = JDK,
     severity = SUGGESTION,
     linkType = CUSTOM,
     tags = STYLE,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryDefaultInEnumSwitch.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryDefaultInEnumSwitch.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.Reachability.canCompleteNormally;
@@ -52,7 +51,6 @@ import javax.lang.model.element.ElementKind;
     summary =
         "Switch handles all enum values: an explicit default case is unnecessary and defeats error"
             + " checking for non-exhaustive switches.",
-    category = JDK,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class UnnecessaryDefaultInEnumSwitch extends BugChecker implements SwitchTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryStaticImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryStaticImport.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 
 import com.google.errorprone.BugPattern;
@@ -33,7 +32,7 @@ import com.sun.source.tree.ImportTree;
 @BugPattern(
     name = "UnnecessaryStaticImport",
     summary = "Using static imports for types is unnecessary",
-    category = JDK,
+
     severity = SUGGESTION,
     documentSuppression = false,
     tags = StandardTags.STYLE,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryTypeArgument.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryTypeArgument.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.base.Verify.verify;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -41,7 +40,6 @@ import java.util.List;
 @BugPattern(
     name = "UnnecessaryTypeArgument",
     summary = "Non-generic methods should not be invoked with type arguments",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class UnnecessaryTypeArgument extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnsafeReflectiveConstructionCast.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnsafeReflectiveConstructionCast.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
@@ -51,7 +50,6 @@ import java.lang.reflect.Constructor;
             + " to detect classes of incorrect type before invoking their constructors."
             + "This way, if the class is of the incorrect type,"
             + "it will throw an exception before invoking its constructor.",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnsynchronizedOverridesSynchronized.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnsynchronizedOverridesSynchronized.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -48,7 +47,6 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "UnsynchronizedOverridesSynchronized",
     summary = "Unsynchronized method overrides a synchronized method.",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE,
     providesFix = REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedAnonymousClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedAnonymousClass.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.common.collect.ImmutableList;
@@ -36,7 +35,6 @@ import com.sun.tools.javac.tree.JCTree;
 @BugPattern(
     name = "UnusedAnonymousClass",
     summary = "Instance created but never used",
-    category = JDK,
     severity = ERROR)
 public class UnusedAnonymousClass extends BugChecker implements NewClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedCollectionModifiedInPlace.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedCollectionModifiedInPlace.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -36,7 +35,6 @@ import com.sun.source.tree.Tree.Kind;
 @BugPattern(
     name = "UnusedCollectionModifiedInPlace",
     summary = "Collection is modified in place, but the result is not used",
-    category = JDK,
     severity = ERROR)
 public class UnusedCollectionModifiedInPlace extends BugChecker
     implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UseCorrectAssertInTests.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UseCorrectAssertInTests.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.matchers.Matchers.contains;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 import static com.sun.source.tree.Tree.Kind.LOGICAL_COMPLEMENT;
@@ -52,7 +51,6 @@ import com.sun.tools.javac.tree.TreeInfo;
 @BugPattern(
     name = "UseCorrectAssertInTests",
     summary = "Java assert is used in test. For testing purposes Assert.* matchers should be used.",
-    category = JDK,
     severity = SeverityLevel.WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class UseCorrectAssertInTests extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/VarChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/VarChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
@@ -47,7 +46,6 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "Var",
     summary = "Non-constant variable missing @Var annotation",
-    category = JDK,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class VarChecker extends BugChecker implements VariableTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/WaitNotInLoop.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/WaitNotInLoop.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.inLoop;
@@ -44,7 +43,6 @@ import com.sun.tools.javac.tree.JCTree.JCIf;
     summary =
         "Because of spurious wakeups, Object.wait() and Condition.await() must always be "
             + "called in a loop",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/WildcardImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/WildcardImport.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -55,7 +54,6 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "WildcardImport",
     summary = "Wildcard imports, static or otherwise, should not be used",
-    category = JDK,
     severity = SUGGESTION,
     linkType = CUSTOM,
     documentSuppression = false,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/WrongParameterPackage.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/WrongParameterPackage.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -40,7 +39,6 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "ParameterPackage",
     summary = "Method parameter has wrong package",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class WrongParameterPackage extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/BinderIdentityRestoredDangerously.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/BinderIdentityRestoredDangerously.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.findEnclosingNode;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.BugPattern.StandardTags;
@@ -43,7 +42,6 @@ import com.sun.source.tree.TryTree;
             + "Binder.restoreCallingIdentity() in a finally block. Otherwise the wrong Binder "
             + "identity may be used by subsequent code.",
     severity = SeverityLevel.WARNING,
-    category = Category.ANDROID,
     providesFix = ProvidesFix.NO_FIX)
 public class BinderIdentityRestoredDangerously extends BugChecker
     implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/BundleDeserializationCast.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/BundleDeserializationCast.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.android;
 
-import static com.google.errorprone.BugPattern.Category.ANDROID;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -46,7 +45,6 @@ import com.sun.tools.javac.code.Types;
 @BugPattern(
     name = "BundleDeserializationCast",
     summary = "Object serialized in Bundle may have been flattened to base type.",
-    category = ANDROID,
     severity = ERROR)
 public class BundleDeserializationCast extends BugChecker implements TypeCastTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/FragmentInjection.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/FragmentInjection.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.android;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.errorprone.BugPattern.Category.ANDROID;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -59,7 +58,6 @@ import javax.lang.model.element.Modifier;
         "Classes extending PreferenceActivity must implement isValidFragment such that it does not"
             + " unconditionally return true to prevent vulnerability to fragment injection"
             + " attacks.",
-    category = ANDROID,
     severity = WARNING,
     tags = StandardTags.LIKELY_ERROR)
 public class FragmentInjection extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/FragmentNotInstantiable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/FragmentNotInstantiable.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.android;
 
-import static com.google.errorprone.BugPattern.Category.ANDROID;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -50,7 +49,6 @@ import java.util.stream.Collectors;
     summary =
         "Subclasses of Fragment must be instantiable via Class#newInstance():"
             + " the class must be public, static and have a public nullary constructor",
-    category = ANDROID,
     severity = WARNING,
     tags = StandardTags.LIKELY_ERROR)
 public class FragmentNotInstantiable extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/HardCodedSdCardPath.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/HardCodedSdCardPath.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.android;
 
-import static com.google.errorprone.BugPattern.Category.ANDROID;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.sun.source.tree.Tree.Kind.STRING_LITERAL;
 
@@ -42,7 +41,6 @@ import java.util.Map;
     name = "HardCodedSdCardPath",
     altNames = {"SdCardPath"},
     summary = "Hardcoded reference to /sdcard",
-    category = ANDROID,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class HardCodedSdCardPath extends BugChecker implements LiteralTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/IsLoggableTagLength.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/IsLoggableTagLength.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.android;
 
-import static com.google.errorprone.BugPattern.Category.ANDROID;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.anything;
@@ -52,7 +51,6 @@ import com.sun.tools.javac.code.Symbol.VarSymbol;
 @BugPattern(
     name = "IsLoggableTagLength",
     summary = "Log tag too long, cannot exceed 23 characters.",
-    category = ANDROID,
     severity = ERROR)
 public class IsLoggableTagLength extends BugChecker implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/MislabeledAndroidString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/MislabeledAndroidString.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.android;
 
-import static com.google.errorprone.BugPattern.Category.ANDROID;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -43,7 +42,6 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "MislabeledAndroidString",
     summary = "Certain resources in `android.R.string` have names that do not match their content",
-    category = ANDROID,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class MislabeledAndroidString extends BugChecker implements MemberSelectTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/ParcelableCreator.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/ParcelableCreator.java
@@ -23,7 +23,6 @@ import static com.google.errorprone.matchers.Matchers.not;
 
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
@@ -53,7 +52,6 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "ParcelableCreator",
     summary = "Detects classes which implement Parcelable but don't have CREATOR",
-    category = Category.ANDROID,
     severity = SeverityLevel.ERROR,
     providesFix = ProvidesFix.NO_FIX)
 public class ParcelableCreator extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/RectIntersectReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/RectIntersectReturnValueIgnored.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.android;
 
-import static com.google.errorprone.BugPattern.Category.ANDROID;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
 
@@ -32,7 +31,6 @@ import com.sun.source.tree.MethodInvocationTree;
 @BugPattern(
     name = "RectIntersectReturnValueIgnored",
     summary = "Return value of android.graphics.Rect.intersect() must be checked",
-    category = ANDROID,
     severity = ERROR)
 public final class RectIntersectReturnValueIgnored extends AbstractReturnValueIgnored {
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/StaticOrDefaultInterfaceMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/StaticOrDefaultInterfaceMethod.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.android;
 
-import static com.google.errorprone.BugPattern.Category.ANDROID;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -41,7 +40,6 @@ import com.sun.source.tree.Tree;
     name = "StaticOrDefaultInterfaceMethod",
     summary =
         "Static and default interface methods are not natively supported on older Android devices. ",
-    category = ANDROID,
     severity = ERROR,
     documentSuppression = false // for slightly customized suppression documentation
     )

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/WakelockReleasedDangerously.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/WakelockReleasedDangerously.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableMultimap.Builder;
 import com.google.common.collect.Streams;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.BugPattern.StandardTags;
@@ -66,7 +65,6 @@ import com.sun.tools.javac.code.Types;
             + " `release`, even after checking `isHeld()`. If so, it will throw a RuntimeException."
             + " Please wrap in a try/catch block.",
     severity = SeverityLevel.WARNING,
-    category = Category.ANDROID,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class WakelockReleasedDangerously extends BugChecker implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/apidiff/AndroidJdkLibsChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/apidiff/AndroidJdkLibsChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.apidiff;
 
-import static com.google.errorprone.BugPattern.Category.ANDROID;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.common.collect.HashMultimap;
@@ -41,7 +40,6 @@ import java.util.TreeSet;
     explanation =
         "Code that needs to be compatible with Android cannot use types or members that "
             + "only the latest or unreleased devices can handle",
-    category = ANDROID,
     severity = ERROR)
 // TODO(b/32513850): Allow Android N+ APIs, e.g., by computing API diff using android.jar
 public class AndroidJdkLibsChecker extends ApiDiffChecker {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/apidiff/Java7ApiChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/apidiff/Java7ApiChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.apidiff;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.common.io.Resources;
@@ -31,7 +30,6 @@ import java.io.UncheckedIOException;
     explanation =
         "Code that needs to be compatible with Java 7 cannot use types or members"
             + " that are only present in the JDK 8 class libraries",
-    category = JDK,
     severity = ERROR,
     suppressionAnnotations = {
       SuppressWarnings.class

--- a/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/ArgumentSelectionDefectChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/ArgumentSelectionDefectChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.argumentselectiondefects;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -56,7 +55,6 @@ import java.util.function.Function;
 @BugPattern(
     name = "ArgumentSelectionDefectChecker",
     summary = "Arguments are in the wrong order or could be commented for clarity.",
-    category = JDK,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ArgumentSelectionDefectChecker extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/AssertEqualsArgumentOrderChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/AssertEqualsArgumentOrderChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.argumentselectiondefects;
 
-import static com.google.errorprone.BugPattern.Category.JUNIT;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
@@ -46,7 +45,6 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "AssertEqualsArgumentOrderChecker",
     summary = "Arguments are swapped in assertEquals-like call",
-    category = JUNIT,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class AssertEqualsArgumentOrderChecker extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/AutoValueConstructorOrderChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/AutoValueConstructorOrderChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.argumentselectiondefects;
 
-import static com.google.errorprone.BugPattern.Category.GUAVA;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -43,7 +42,6 @@ import java.util.function.Function;
 @BugPattern(
     name = "AutoValueConstructorOrderChecker",
     summary = "Arguments to AutoValue constructor are in the wrong order",
-    category = GUAVA,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class AutoValueConstructorOrderChecker extends BugChecker implements NewClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionIncompatibleType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionIncompatibleType.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.collectionincompatibletype;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.fixes.SuggestedFixes.addSuppressWarnings;
 
@@ -64,7 +63,6 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "CollectionIncompatibleType",
     summary = "Incompatible type as argument to Object-accepting Java collections method",
-    category = JDK,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class CollectionIncompatibleType extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/IncompatibleArgumentType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/IncompatibleArgumentType.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.collectionincompatibletype;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.bugpatterns.collectionincompatibletype.AbstractCollectionIncompatibleTypeMatcher.extractTypeArgAsMemberOfSupertype;
 
@@ -50,7 +49,6 @@ import javax.lang.model.element.TypeParameterElement;
 @BugPattern(
     name = "IncompatibleArgumentType",
     summary = "Passing argument to a generic method with an incompatible type.",
-    category = JDK,
     severity = ERROR)
 public class IncompatibleArgumentType extends BugChecker implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatString.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.formatstring;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
@@ -37,11 +36,7 @@ import java.util.Deque;
 import java.util.Locale;
 
 /** @author cushon@google.com (Liam Miller-Cushon) */
-@BugPattern(
-    name = "FormatString",
-    summary = "Invalid printf-style format string",
-    category = JDK,
-    severity = ERROR)
+@BugPattern(name = "FormatString", summary = "Invalid printf-style format string", severity = ERROR)
 public class FormatString extends BugChecker implements MethodInvocationTreeMatcher {
 
   // TODO(cushon): add support for additional printf methods, maybe with an annotation

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringAnnotationChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringAnnotationChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.formatstring;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -43,7 +42,6 @@ import java.util.List;
 @BugPattern(
     name = "FormatStringAnnotation",
     summary = "Invalid format string passed to formatting method.",
-    category = JDK,
     severity = ERROR
     )
 public final class FormatStringAnnotationChecker extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/AssistedInjectAndInjectOnConstructors.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/AssistedInjectAndInjectOnConstructors.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject;
 
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.AT_LEAST_ONE;
 import static com.google.errorprone.matchers.InjectMatchers.ASSISTED_INJECT_ANNOTATION;
@@ -39,7 +38,6 @@ import com.sun.source.tree.ClassTree;
     summary =
         "@AssistedInject and @Inject should not be used on different constructors in the same"
             + " class.",
-    category = INJECT,
     severity = WARNING)
 public class AssistedInjectAndInjectOnConstructors extends BugChecker implements ClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/AssistedInjectAndInjectOnSameConstructor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/AssistedInjectAndInjectOnSameConstructor.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject;
 
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.InjectMatchers.ASSISTED_INJECT_ANNOTATION;
 import static com.google.errorprone.matchers.InjectMatchers.GUICE_INJECT_ANNOTATION;
@@ -43,7 +42,6 @@ import com.sun.source.tree.Tree;
 @BugPattern(
     name = "AssistedInjectAndInjectOnSameConstructor",
     summary = "@AssistedInject and @Inject cannot be used on the same constructor.",
-    category = INJECT,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class AssistedInjectAndInjectOnSameConstructor extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/AutoFactoryAtInject.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/AutoFactoryAtInject.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject;
 
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.InjectMatchers.IS_APPLICATION_OF_AT_INJECT;
 import static com.google.errorprone.matchers.Matchers.hasAnnotation;
@@ -44,7 +43,6 @@ import com.sun.source.tree.Tree;
 @BugPattern(
     name = "AutoFactoryAtInject",
     summary = "@AutoFactory and @Inject should not be used in the same type.",
-    category = INJECT,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class AutoFactoryAtInject extends BugChecker implements AnnotationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/CloseableProvides.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/CloseableProvides.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject;
 
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.methodReturns;
@@ -37,7 +36,6 @@ import com.sun.source.tree.MethodTree;
 @BugPattern(
     name = "CloseableProvides",
     summary = "Providing Closeable resources makes their lifecycle unclear",
-    category = INJECT,
     severity = WARNING,
     providesFix = ProvidesFix.NO_FIX)
 public class CloseableProvides extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectOnConstructorOfAbstractClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectOnConstructorOfAbstractClass.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject;
 
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.fixes.SuggestedFix.delete;
 import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.AT_LEAST_ONE;
@@ -49,7 +48,6 @@ import com.sun.source.tree.MethodTree;
     summary =
         "Constructors on abstract classes are never directly @Injected, only the constructors"
             + " of their subclasses can be @Inject'ed.",
-    category = INJECT,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class InjectOnConstructorOfAbstractClass extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectOnMemberAndConstructor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectOnMemberAndConstructor.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns.inject;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.AT_LEAST_ONE;
 import static com.google.errorprone.matchers.InjectMatchers.hasInjectAnnotation;
@@ -60,7 +59,6 @@ import javax.lang.model.element.ElementKind;
     name = "InjectOnMemberAndConstructor",
     summary =
         "Members shouldn't be annotated with @Inject if constructor is already annotated @Inject",
-    category = INJECT,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class InjectOnMemberAndConstructor extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectedConstructorAnnotations.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectedConstructorAnnotations.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject;
 
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.InjectMatchers.GUICE_BINDING_ANNOTATION;
 import static com.google.errorprone.matchers.InjectMatchers.GUICE_INJECT_ANNOTATION;
@@ -43,7 +42,6 @@ import com.sun.source.tree.MethodTree;
 @BugPattern(
     name = "InjectedConstructorAnnotations",
     summary = "Injected constructors cannot be optional nor have binding annotations",
-    category = INJECT,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class InjectedConstructorAnnotations extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/InvalidTargetingOnScopingAnnotation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/InvalidTargetingOnScopingAnnotation.java
@@ -15,7 +15,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import static com.google.common.collect.Sets.immutableEnumSet;
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.AT_LEAST_ONE;
 import static com.google.errorprone.matchers.InjectMatchers.GUICE_SCOPE_ANNOTATION;
@@ -57,7 +56,6 @@ import java.util.Set;
 @BugPattern(
     name = "InjectInvalidTargetingOnScopingAnnotation",
     summary = "A scoping annotation's Target should include TYPE and METHOD.",
-    category = INJECT,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class InvalidTargetingOnScopingAnnotation extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/JavaxInjectOnAbstractMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/JavaxInjectOnAbstractMethod.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject;
 
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.fixes.SuggestedFix.delete;
 import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.AT_LEAST_ONE;
@@ -44,7 +43,6 @@ import com.sun.source.tree.MethodTree;
 @BugPattern(
     name = "JavaxInjectOnAbstractMethod",
     summary = "Abstract and default methods are not injectable with javax.inject.Inject",
-    category = INJECT,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class JavaxInjectOnAbstractMethod extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/JavaxInjectOnFinalField.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/JavaxInjectOnFinalField.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject;
 
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.bugpatterns.inject.ElementPredicates.isFinalField;
 import static com.google.errorprone.matchers.InjectMatchers.IS_APPLICATION_OF_JAVAX_INJECT;
@@ -35,7 +34,6 @@ import com.sun.source.tree.AnnotationTree;
 @BugPattern(
     name = "JavaxInjectOnFinalField",
     summary = "@javax.inject.Inject cannot be put on a final field.",
-    category = INJECT,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class JavaxInjectOnFinalField extends BugChecker implements AnnotationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/MoreThanOneInjectableConstructor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/MoreThanOneInjectableConstructor.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject;
 
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.bugpatterns.inject.ElementPredicates.isFirstConstructorOfMultiInjectedClass;
 import static com.google.errorprone.matchers.InjectMatchers.IS_APPLICATION_OF_GUICE_INJECT;
@@ -45,7 +44,6 @@ import com.sun.source.tree.Tree;
     summary =
         "This class has more than one @Inject-annotated constructor. Please remove the @Inject"
             + " annotation from all but one of them.",
-    category = INJECT,
     severity = ERROR,
     altNames = {"inject-constructors", "InjectMultipleAtInjectConstructors"})
 public class MoreThanOneInjectableConstructor extends BugChecker implements AnnotationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/MoreThanOneQualifier.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/MoreThanOneQualifier.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject;
 
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.InjectMatchers.GUICE_BINDING_ANNOTATION;
 import static com.google.errorprone.matchers.InjectMatchers.JAVAX_QUALIFIER_ANNOTATION;
@@ -39,7 +38,6 @@ import java.util.List;
 @BugPattern(
     name = "InjectMoreThanOneQualifier",
     summary = "Using more than one qualifier annotation on the same element is not allowed.",
-    category = INJECT,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class MoreThanOneQualifier extends BugChecker implements AnnotationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/MoreThanOneScopeAnnotationOnClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/MoreThanOneScopeAnnotationOnClass.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject;
 
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.AT_LEAST_ONE;
 import static com.google.errorprone.matchers.InjectMatchers.IS_DAGGER_COMPONENT;
@@ -47,7 +46,6 @@ import java.util.List;
     name = "InjectMoreThanOneScopeAnnotationOnClass",
     altNames = "MoreThanOneScopeAnnotationOnClass",
     summary = "A class can be annotated with at most one scope annotation.",
-    category = INJECT,
     severity = ERROR)
 public class MoreThanOneScopeAnnotationOnClass extends BugChecker implements ClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/OverlappingQualifierAndScopeAnnotation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/OverlappingQualifierAndScopeAnnotation.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject;
 
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.InjectMatchers.GUICE_BINDING_ANNOTATION;
 import static com.google.errorprone.matchers.InjectMatchers.GUICE_SCOPE_ANNOTATION;
@@ -42,7 +41,6 @@ import com.sun.source.tree.ClassTree;
     summary =
         "Annotations cannot be both Scope annotations and Qualifier annotations: this causes "
             + "confusion when trying to use them.",
-    category = INJECT,
     severity = ERROR)
 public class OverlappingQualifierAndScopeAnnotation extends BugChecker implements ClassTreeMatcher {
   private static final Matcher<ClassTree> ANNOTATION_WITH_BOTH_TYPES =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/QualifierOrScopeOnInjectMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/QualifierOrScopeOnInjectMethod.java
@@ -25,7 +25,6 @@ import static com.google.errorprone.matchers.Matchers.annotations;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.BugPattern.StandardTags;
@@ -48,7 +47,6 @@ import java.util.List;
 /** @author Nick Glorioso (glorioso@google.com) */
 @BugPattern(
     name = "QualifierOrScopeOnInjectMethod",
-    category = Category.INJECT,
     summary =
         "Qualifiers/Scope annotations on @Inject methods don't have any effect."
             + " Move the qualifier annotation to the binding location.",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/QualifierWithTypeUse.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/QualifierWithTypeUse.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject;
 
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.AT_LEAST_ONE;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -57,7 +56,6 @@ import java.util.Set;
     summary =
         "Injection frameworks currently don't understand Qualifiers in TYPE_PARAMETER or"
             + " TYPE_USE contexts.",
-    category = INJECT,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/ScopeAnnotationOnInterfaceOrAbstractClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/ScopeAnnotationOnInterfaceOrAbstractClass.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject;
 
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.InjectMatchers.GUICE_SCOPE_ANNOTATION;
 import static com.google.errorprone.matchers.InjectMatchers.IS_DAGGER_COMPONENT;
@@ -43,7 +42,6 @@ import com.sun.tools.javac.code.Flags;
 @BugPattern(
     name = "InjectScopeAnnotationOnInterfaceOrAbstractClass",
     summary = "Scope annotation on an interface or abstact class is not allowed",
-    category = INJECT,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ScopeAnnotationOnInterfaceOrAbstractClass extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/ScopeOrQualifierAnnotationRetention.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/ScopeOrQualifierAnnotationRetention.java
@@ -14,7 +14,6 @@
 
 package com.google.errorprone.bugpatterns.inject;
 
-import static com.google.errorprone.BugPattern.Category.INJECT;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.bugpatterns.inject.ElementPredicates.doesNotHaveRuntimeRetention;
 import static com.google.errorprone.bugpatterns.inject.ElementPredicates.hasSourceRetention;
@@ -48,7 +47,6 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "InjectScopeOrQualifierAnnotationRetention",
     summary = "Scoping and qualifier annotations must have runtime retention.",
-    category = INJECT,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ScopeOrQualifierAnnotationRetention extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/AndroidInjectionBeforeSuper.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/AndroidInjectionBeforeSuper.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject.dagger;
 
 import static com.google.common.base.Predicates.notNull;
-import static com.google.errorprone.BugPattern.Category.DAGGER;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.enclosingClass;
@@ -50,7 +49,6 @@ import com.sun.source.util.SimpleTreeVisitor;
     name = "AndroidInjectionBeforeSuper",
     summary =
         "AndroidInjection.inject() should always be invoked before calling super.lifecycleMethod()",
-    category = DAGGER,
     severity = ERROR)
 public final class AndroidInjectionBeforeSuper extends BugChecker implements MethodTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/EmptySetMultibindingContributions.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/EmptySetMultibindingContributions.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.inject.dagger;
 
-import static com.google.errorprone.BugPattern.Category.DAGGER;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -70,7 +69,6 @@ import java.util.TreeSet;
     summary =
         "@Multibinds is a more efficient and declarative mechanism for ensuring that a set"
             + " multibinding is present in the graph.",
-    category = DAGGER,
     severity = SUGGESTION,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public final class EmptySetMultibindingContributions extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/PrivateConstructorForNoninstantiableModule.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/PrivateConstructorForNoninstantiableModule.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.inject.dagger;
 
-import static com.google.errorprone.BugPattern.Category.DAGGER;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.bugpatterns.inject.dagger.DaggerAnnotations.isBindingDeclarationMethod;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -45,7 +44,6 @@ import com.sun.source.tree.Tree;
 @BugPattern(
     name = "PrivateConstructorForNoninstantiableModule",
     summary = "Add a private constructor to modules that will not be instantiated by Dagger.",
-    category = DAGGER,
     severity = SUGGESTION,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class PrivateConstructorForNoninstantiableModule extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/ProvidesNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/ProvidesNull.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject.dagger;
 
-import static com.google.errorprone.BugPattern.Category.DAGGER;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -44,7 +43,6 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
 @BugPattern(
     name = "DaggerProvidesNull",
     summary = "Dagger @Provides methods may not return null unless annotated with @Nullable",
-    category = DAGGER,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ProvidesNull extends BugChecker implements ReturnTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/ScopeOnModule.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/ScopeOnModule.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject.dagger;
 
-import static com.google.errorprone.BugPattern.Category.DAGGER;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 import static com.google.errorprone.util.ASTHelpers.hasAnnotation;
@@ -38,7 +37,6 @@ import java.util.List;
 @BugPattern(
     name = "ScopeOnModule",
     summary = "Scopes on modules have no function and will soon be an error.",
-    category = DAGGER,
     severity = SUGGESTION,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public final class ScopeOnModule extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/UseBinds.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/UseBinds.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns.inject.dagger;
 
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.errorprone.BugPattern.Category.DAGGER;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.bugpatterns.inject.dagger.DaggerAnnotations.ELEMENTS_INTO_SET_CLASS_NAME;
 import static com.google.errorprone.bugpatterns.inject.dagger.DaggerAnnotations.INTO_MAP_CLASS_NAME;
@@ -68,7 +67,6 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "UseBinds",
     summary = "@Binds is a more efficient and declarative mechanism for delegating a binding.",
-    category = DAGGER,
     severity = SUGGESTION,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class UseBinds extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/AssistedInjectScoping.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/AssistedInjectScoping.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject.guice;
 
-import static com.google.errorprone.BugPattern.Category.GUICE;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.AT_LEAST_ONE;
 import static com.google.errorprone.matchers.InjectMatchers.ASSISTED_ANNOTATION;
@@ -56,7 +55,6 @@ import com.sun.source.tree.MethodTree;
 @BugPattern(
     name = "GuiceAssistedInjectScoping",
     summary = "Scope annotation on implementation class of AssistedInject factory is not allowed",
-    category = GUICE,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class AssistedInjectScoping extends BugChecker implements ClassTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/AssistedParameters.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/AssistedParameters.java
@@ -14,7 +14,6 @@
 
 package com.google.errorprone.bugpatterns.inject.guice;
 
-import static com.google.errorprone.BugPattern.Category.GUICE;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.InjectMatchers.ASSISTED_ANNOTATION;
 import static com.google.errorprone.matchers.InjectMatchers.ASSISTED_INJECT_ANNOTATION;
@@ -64,7 +63,6 @@ import javax.lang.model.element.TypeElement;
     summary =
         "A constructor cannot have two @Assisted parameters of the same type unless they are "
             + "disambiguated with named @Assisted annotations.",
-    category = GUICE,
     severity = ERROR)
 public class AssistedParameters extends BugChecker implements MethodTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/BindingToUnqualifiedCommonType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/BindingToUnqualifiedCommonType.java
@@ -14,7 +14,6 @@
 
 package com.google.errorprone.bugpatterns.inject.guice;
 
-import static com.google.errorprone.BugPattern.Category.GUICE;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.AT_LEAST_ONE;
 import static com.google.errorprone.matchers.InjectMatchers.GUICE_PROVIDES_ANNOTATION;
@@ -54,7 +53,6 @@ import java.math.BigDecimal;
     name = "BindingToUnqualifiedCommonType",
     summary =
         "This code declares a binding for a common value type without a Qualifier annotation.",
-    category = GUICE,
     severity = WARNING)
 public class BindingToUnqualifiedCommonType extends BugChecker
     implements MethodTreeMatcher, MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/InjectOnFinalField.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/InjectOnFinalField.java
@@ -14,7 +14,6 @@
 
 package com.google.errorprone.bugpatterns.inject.guice;
 
-import static com.google.errorprone.BugPattern.Category.GUICE;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.InjectMatchers.GUICE_INJECT_ANNOTATION;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -39,7 +38,6 @@ import com.sun.source.tree.VariableTree;
     summary =
         "Although Guice allows injecting final fields, doing so is disallowed because the injected "
             + "value may not be visible to other threads.",
-    category = GUICE,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class InjectOnFinalField extends BugChecker implements VariableTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/OverridesGuiceInjectableMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/OverridesGuiceInjectableMethod.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject.guice;
 
-import static com.google.errorprone.BugPattern.Category.GUICE;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.InjectMatchers.GUICE_INJECT_ANNOTATION;
 import static com.google.errorprone.matchers.InjectMatchers.JAVAX_INJECT_ANNOTATION;
@@ -46,7 +45,6 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
         "This method is not annotated with @Inject, but it overrides a "
             + "method that is annotated with @com.google.inject.Inject. Guice will inject this "
             + "method, and it is recommended to annotate it explicitly.",
-    category = GUICE,
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class OverridesGuiceInjectableMethod extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/OverridesJavaxInjectableMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/OverridesJavaxInjectableMethod.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.inject.guice;
 
-import static com.google.errorprone.BugPattern.Category.GUICE;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.InjectMatchers.GUICE_INJECT_ANNOTATION;
 import static com.google.errorprone.matchers.InjectMatchers.JAVAX_INJECT_ANNOTATION;
@@ -45,7 +44,6 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
     summary =
         "This method is not annotated with @Inject, but it overrides a method that is "
             + " annotated with @javax.inject.Inject. The method will not be Injected.",
-    category = GUICE,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class OverridesJavaxInjectableMethod extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/ProvidesMethodOutsideOfModule.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/ProvidesMethodOutsideOfModule.java
@@ -14,7 +14,6 @@
 
 package com.google.errorprone.bugpatterns.inject.guice;
 
-import static com.google.errorprone.BugPattern.Category.GUICE;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.InjectMatchers.GUICE_PROVIDES_ANNOTATION;
 import static com.google.errorprone.matchers.InjectMatchers.INSIDE_GUICE_MODULE;
@@ -36,7 +35,6 @@ import com.sun.source.tree.AnnotationTree;
 @BugPattern(
     name = "ProvidesMethodOutsideOfModule",
     summary = "@Provides methods need to be declared in a Module to have any effect.",
-    category = GUICE,
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ProvidesMethodOutsideOfModule extends BugChecker implements AnnotationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/FieldMissingNullable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/FieldMissingNullable.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.nullness;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 
@@ -52,7 +51,6 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "FieldMissingNullable",
     summary = "Fields that can be null should be annotated @Nullable",
-    category = JDK,
     severity = SUGGESTION,
     providesFix = REQUIRES_HUMAN_ATTENTION)
 public class FieldMissingNullable extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/NullableDereference.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/NullableDereference.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.nullness;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 
@@ -57,7 +56,6 @@ import javax.lang.model.type.TypeKind;
 @BugPattern(
     name = "NullableDereference",
     summary = "Dereference of possibly-null value",
-    category = JDK,
     severity = WARNING,
     providesFix = ProvidesFix.NO_FIX)
 public class NullableDereference extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/ParameterNotNullable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/ParameterNotNullable.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.nullness;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 
 import com.google.errorprone.BugPattern;
@@ -47,7 +46,6 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "ParameterNotNullable",
     summary = "Method parameters that aren't checked for null shouldn't be annotated @Nullable",
-    category = JDK,
     severity = SUGGESTION,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ParameterNotNullable extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/ReturnMissingNullable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/ReturnMissingNullable.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.nullness;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 
 import com.google.errorprone.BugPattern;
@@ -41,7 +40,6 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "ReturnMissingNullable",
     summary = "Methods that can return null should be annotated @Nullable",
-    category = JDK,
     severity = SUGGESTION,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ReturnMissingNullable extends BugChecker implements ReturnTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/overloading/InconsistentOverloads.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/overloading/InconsistentOverloads.java
@@ -25,7 +25,6 @@ import static java.util.stream.Collectors.groupingBy;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -66,7 +65,6 @@ import java.util.Optional;
         "The ordering of parameters in overloaded methods should be as consistent as possible (when"
             + " viewed from left to right)",
     generateExamplesFromTestCases = false,
-    category = Category.JDK,
     severity = SeverityLevel.WARNING)
 public final class InconsistentOverloads extends BugChecker implements ClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/DoubleCheckedLocking.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/DoubleCheckedLocking.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.threadsafety;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.util.ASTHelpers.stripParentheses;
 
@@ -59,7 +58,6 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "DoubleCheckedLocking",
     summary = "Double-checked locking on non-volatile fields is unsafe",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.threadsafety;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -46,7 +45,6 @@ import com.sun.tools.javac.code.Type;
     name = "GuardedBy",
     altNames = "GuardedByChecker",
     summary = "Checks for unguarded accesses to fields and methods with @GuardedBy annotations",
-    category = JDK,
     severity = ERROR)
 public class GuardedByChecker extends BugChecker
     implements VariableTreeMatcher, MethodTreeMatcher, LambdaExpressionTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableAnnotationChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableAnnotationChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.threadsafety;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getGeneratedBy;
@@ -47,7 +46,6 @@ import java.util.Optional;
 @BugPattern(
     name = "ImmutableAnnotationChecker",
     altNames = "Immutable",
-    category = JDK,
     summary = "Annotations should always be immutable",
     severity = WARNING,
     tags = StandardTags.LIKELY_ERROR,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableChecker.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.threadsafety;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -64,7 +63,6 @@ import java.util.Optional;
 @BugPattern(
     name = "Immutable",
     summary = "Type declaration annotated with @Immutable is not immutable",
-    category = JDK,
     severity = ERROR,
     documentSuppression = false,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableEnumChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableEnumChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.threadsafety;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
@@ -46,7 +45,6 @@ import java.util.stream.Stream;
 @BugPattern(
     name = "ImmutableEnumChecker",
     altNames = "Immutable",
-    category = JDK,
     summary = "Enums should always be immutable",
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/LockMethodChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/LockMethodChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.threadsafety;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.common.collect.ImmutableList;
@@ -33,7 +32,6 @@ import java.util.Set;
     name = "LockMethodChecker",
     altNames = {"GuardedBy"},
     summary = "This method does not acquire the locks specified by its @LockMethod annotation",
-    category = JDK,
     severity = ERROR)
 public class LockMethodChecker extends AbstractLockMethodChecker {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/StaticGuardedByInstance.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/StaticGuardedByInstance.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.util.ASTHelpers.stripParentheses;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
@@ -44,7 +43,6 @@ import java.util.Map.Entry;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
     name = "StaticGuardedByInstance",
-    category = Category.JDK,
     summary = "Writes to static fields should not be guarded by instance locks",
     severity = SeverityLevel.WARNING,
     tags = StandardTags.FRAGILE_CODE)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/SynchronizeOnNonFinalField.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/SynchronizeOnNonFinalField.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.threadsafety;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.stripParentheses;
@@ -41,7 +40,6 @@ import javax.lang.model.element.Name;
     summary =
         "Synchronizing on non-final fields is not safe: if the field is ever updated,"
             + " different threads may end up locking on different objects.",
-    category = JDK,
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE)
 public class SynchronizeOnNonFinalField extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/UnlockMethodChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/UnlockMethodChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.threadsafety;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.common.collect.ImmutableList;
@@ -33,7 +32,6 @@ import java.util.Set;
     name = "UnlockMethod",
     altNames = {"GuardedBy"},
     summary = "This method does not acquire the locks specified by its @UnlockMethod annotation",
-    category = JDK,
     severity = ERROR)
 public class UnlockMethodChecker extends AbstractLockMethodChecker {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/TimeUnitMismatch.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/TimeUnitMismatch.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns.time;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -78,7 +77,6 @@ import javax.annotation.Nullable;
     summary =
         "An value that appears to be represented in one unit is used where another appears to be "
             + "required (e.g., seconds where nanos are needed)",
-    category = JDK,
     severity = WARNING,
     providesFix = REQUIRES_HUMAN_ATTENTION)
 public final class TimeUnitMismatch extends BugChecker

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -233,6 +233,7 @@ import com.google.errorprone.bugpatterns.RemoveUnusedImports;
 import com.google.errorprone.bugpatterns.RequiredModifiersChecker;
 import com.google.errorprone.bugpatterns.RestrictedApiChecker;
 import com.google.errorprone.bugpatterns.ReturnValueIgnored;
+import com.google.errorprone.bugpatterns.RxReturnValueIgnored;
 import com.google.errorprone.bugpatterns.SelfAssignment;
 import com.google.errorprone.bugpatterns.SelfComparison;
 import com.google.errorprone.bugpatterns.SelfEquals;
@@ -694,6 +695,7 @@ public class BuiltInCheckerSuppliers {
           ReachabilityFenceUsage.class,
           ReferenceEquality.class,
           RequiredModifiersChecker.class,
+          RxReturnValueIgnored.class,
           ShortCircuitBoolean.class,
           StringSplitter.class,
           StaticGuardedByInstance.class,

--- a/core/src/test/java/com/google/errorprone/CommandLineFlagTest.java
+++ b/core/src/test/java/com/google/errorprone/CommandLineFlagTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.errorprone.BugPattern.Category.ONE_OFF;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static org.junit.Assert.assertThrows;
@@ -51,7 +50,6 @@ public class CommandLineFlagTest {
       altNames = "foo",
       summary = "Disableable checker that flags all return statements as errors",
       explanation = "Disableable checker that flags all return statements as errors",
-      category = ONE_OFF,
       severity = ERROR)
   public static class DisableableChecker extends BugChecker implements ReturnTreeMatcher {
     @Override
@@ -65,7 +63,6 @@ public class CommandLineFlagTest {
       summary = "NondisableableChecker checker that flags all return statements as errors",
       explanation = "NondisableableChecker checker that flags all return statements as errors",
       disableable = false,
-      category = ONE_OFF,
       severity = ERROR)
   public static class NondisableableChecker extends BugChecker implements ReturnTreeMatcher {
     @Override
@@ -78,7 +75,6 @@ public class CommandLineFlagTest {
       name = "WarningChecker",
       summary = "Checker that flags all return statements as warnings",
       explanation = "Checker that flags all return statements as warningss",
-      category = ONE_OFF,
       severity = WARNING)
   public static class WarningChecker extends BugChecker implements ReturnTreeMatcher {
     @Override
@@ -91,7 +87,6 @@ public class CommandLineFlagTest {
       name = "ErrorChecker",
       summary = "Checker that flags all return statements as errors",
       explanation = "Checker that flags all return statements as errors",
-      category = ONE_OFF,
       severity = ERROR)
   public static class ErrorChecker extends BugChecker implements ReturnTreeMatcher {
     @Override

--- a/core/src/test/java/com/google/errorprone/DiagnosticKindTest.java
+++ b/core/src/test/java/com/google/errorprone/DiagnosticKindTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.errorprone.BugPattern.Category.JDK;
 
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -62,7 +61,6 @@ public class DiagnosticKindTest {
       name = "ErrorChecker",
       summary = "This is an error!",
       explanation = "Don't do this!",
-      category = JDK,
       severity = SeverityLevel.ERROR)
   public static class ErrorChecker extends BugChecker implements ReturnTreeMatcher {
     @Override
@@ -89,7 +87,6 @@ public class DiagnosticKindTest {
       name = "WarningChecker",
       summary = "This is a warning!",
       explanation = "Please don't do this!",
-      category = JDK,
       severity = SeverityLevel.WARNING)
   public static class WarningChecker extends BugChecker implements ReturnTreeMatcher {
     @Override
@@ -117,7 +114,6 @@ public class DiagnosticKindTest {
       name = "SuggestionChecker",
       summary = "This is a suggestion!",
       explanation = "Don't do this. Or do it. I'm a suggestion, not a cop.",
-      category = JDK,
       severity = SeverityLevel.SUGGESTION)
   public static class SuggestionChecker extends BugChecker implements ReturnTreeMatcher {
     @Override

--- a/core/src/test/java/com/google/errorprone/ErrorProneCompilerIntegrationTest.java
+++ b/core/src/test/java/com/google/errorprone/ErrorProneCompilerIntegrationTest.java
@@ -241,12 +241,7 @@ public class ErrorProneCompilerIntegrationTest {
     assertThat(outputStream.toString(), exitCode, is(Result.OK));
   }
 
-  @BugPattern(
-      name = "ConstructorMatcher",
-      explanation = "",
-      category = ONE_OFF,
-      severity = ERROR,
-      summary = "")
+  @BugPattern(name = "ConstructorMatcher", explanation = "", severity = ERROR, summary = "")
   public static class ConstructorMatcher extends BugChecker implements MethodTreeMatcher {
     @Override
     public Description matchMethod(MethodTree tree, VisitorState state) {
@@ -272,12 +267,7 @@ public class ErrorProneCompilerIntegrationTest {
     assertThat(outputStream.toString(), exitCode, is(Result.OK));
   }
 
-  @BugPattern(
-      name = "SuperCallMatcher",
-      explanation = "",
-      category = ONE_OFF,
-      severity = ERROR,
-      summary = "")
+  @BugPattern(name = "SuperCallMatcher", explanation = "", severity = ERROR, summary = "")
   static class SuperCallMatcher extends BugChecker implements MethodInvocationTreeMatcher {
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
@@ -589,7 +579,6 @@ public class ErrorProneCompilerIntegrationTest {
       name = "CPSChecker",
       summary = "Using 'return' is considered harmful",
       explanation = "Please refactor your code into continuation passing style.",
-      category = ONE_OFF,
       severity = ERROR)
   public static class CPSChecker extends BugChecker implements ReturnTreeMatcher {
     @Override
@@ -628,7 +617,6 @@ public class ErrorProneCompilerIntegrationTest {
   @BugPattern(
       name = "ForbiddenString",
       summary = "Please don't return this const value",
-      category = ONE_OFF,
       severity = ERROR)
   public static class ForbiddenString extends BugChecker implements ReturnTreeMatcher {
     private final String forbiddenString;

--- a/core/src/test/java/com/google/errorprone/ErrorProneCompilerIntegrationTest.java
+++ b/core/src/test/java/com/google/errorprone/ErrorProneCompilerIntegrationTest.java
@@ -621,7 +621,6 @@ public class ErrorProneCompilerIntegrationTest {
     assertThat(output).doesNotContain("Using 'return' is considered harmful");
   }
 
-
   /**
    * Trivial bug checker for testing command line flags. Forbids methods from returning the string
    * provided by "-XepOpt:Forbidden=<VALUE>" flag.

--- a/core/src/test/java/com/google/errorprone/ErrorProneJavaCompilerTest.java
+++ b/core/src/test/java/com/google/errorprone/ErrorProneJavaCompilerTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.DiagnosticTestHelper.diagnosticMessage;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -239,7 +238,6 @@ public class ErrorProneJavaCompilerTest {
       name = "ArrayEquals",
       summary = "Reference equality used to compare arrays",
       explanation = "",
-      category = JDK,
       severity = ERROR,
       disableable = false)
   public static class UnsuppressibleArrayEquals extends ArrayEquals {}
@@ -368,7 +366,6 @@ public class ErrorProneJavaCompilerTest {
           "You appear to be using methods; prefer to implement all program logic inside the main"
               + " function by flipping bits in a single long[].",
       explanation = "",
-      category = JDK,
       severity = ERROR,
       disableable = false,
       providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ReturnValueIgnoredTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ReturnValueIgnoredTest.java
@@ -120,6 +120,32 @@ public class ReturnValueIgnoredTest {
   }
 
   @Test
+  public void javaTime() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.time.Duration;",
+            "import java.time.LocalDate;",
+            "import java.time.ZoneId;",
+            "class Test {",
+            "  void f() {",
+            "    // BUG: Diagnostic contains: ReturnValueIgnored",
+            "    Duration.ZERO.plusDays(2);",
+            "    // BUG: Diagnostic contains: ReturnValueIgnored",
+            "    Duration.ZERO.toDays();",
+            // We ignore parse() methods on java.time types
+            "    Duration.parse(\"PT20.345S\");",
+            "    LocalDate.parse(\"2007-12-03\");",
+            // We ignore of() methods on java.time types
+            "    LocalDate.of(1985, 5, 31);",
+            // We ignore ZoneId.of() -- it's effectively a parse() method
+            "    ZoneId.of(\"America/New_York\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void issue876() {
     compilationHelper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/RxReturnValueIgnoredTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/RxReturnValueIgnoredTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** @author friedj@google.com (Jake Fried) */
+@RunWith(JUnit4.class)
+public class RxReturnValueIgnoredTest {
+
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(RxReturnValueIgnored.class, getClass())
+          // Rx1 stubs
+          .addSourceLines(
+              "rx1/Observable.java", //
+              "package rx;", //
+              "public class Observable<T> {}" //
+              )
+          .addSourceLines(
+              "rx1/Single.java", //
+              "package rx;", //
+              "public class Single<T> {}" //
+              )
+          .addSourceLines(
+              "rx1/Completable.java", //
+              "package rx;", //
+              "public class Completable<T> {}" //
+              )
+          // Rx2 stubs
+          .addSourceLines(
+              "rx2/Observable.java", //
+              "package io.reactivex;", //
+              "public class Observable<T> {}" //
+              )
+          .addSourceLines(
+              "rx2/Single.java", //
+              "package io.reactivex;", //
+              "public class Single<T> {}" //
+              )
+          .addSourceLines(
+              "rx2/Completable.java", //
+              "package io.reactivex;", //
+              "public class Completable<T> {}" //
+              )
+          .addSourceLines(
+              "rx2/Maybe.java", //
+              "package io.reactivex;", //
+              "public class Maybe<T> {}" //
+              )
+          .addSourceLines(
+              "rx2/Flowable.java", //
+              "package io.reactivex;", //
+              "public class Flowable<T> {}" //
+              );
+
+  @Test
+  public void positiveCases() {
+    compilationHelper.addSourceFile("RxReturnValueIgnoredPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void negativeCases() {
+    compilationHelper.addSourceFile("RxReturnValueIgnoredNegativeCases.java").doTest();
+  }
+
+  @Test
+  public void rx2Observable() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import io.reactivex.Observable;",
+            "class Test {",
+            "  Observable getObservable() { return null; }",
+            "  void f() {",
+            "    // BUG: Diagnostic contains: Rx objects must be checked.",
+            "    getObservable();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void rx2Single() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import io.reactivex.Single;",
+            "class Test {",
+            "  Single getSingle() { return null; }",
+            "  void f() {",
+            "    // BUG: Diagnostic contains: Rx objects must be checked.",
+            "    getSingle();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void rx2Completable() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import io.reactivex.Completable;",
+            "class Test {",
+            "  Completable getCompletable() { return null; } ",
+            "  void f() {",
+            "    // BUG: Diagnostic contains: Rx objects must be checked.",
+            "    getCompletable();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void rx2Flowable() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import io.reactivex.Flowable;",
+            "class Test {",
+            "  Flowable getFlowable() { return null; } ",
+            "  void f() {",
+            "    // BUG: Diagnostic contains: Rx objects must be checked.",
+            "    getFlowable();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void rx2Maybe() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import io.reactivex.Maybe;",
+            "class Test {",
+            "  Maybe getMaybe() { return null; }",
+            "  void f() {",
+            "    // BUG: Diagnostic contains: Rx objects must be checked.",
+            "    getMaybe();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void rx1Observable() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import rx.Observable;",
+            "class Test {",
+            "  Observable getObservable() { return null; }",
+            "  void f() {",
+            "    // BUG: Diagnostic contains: Rx objects must be checked.",
+            "    getObservable();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void rx1Single() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import rx.Single;",
+            "class Test {",
+            "  Single getSingle() { return null; }",
+            "  void f() {",
+            "    // BUG: Diagnostic contains: Rx objects must be checked.",
+            "    getSingle();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void rx1Completable() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import rx.Completable;",
+            "class Test {",
+            "  Completable getCompletable() { return null; } ",
+            "  void f() {",
+            "    // BUG: Diagnostic contains: Rx objects must be checked.",
+            "    getCompletable();",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/android/FragmentNotInstantiableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/android/FragmentNotInstantiableTest.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.android;
 
-import static com.google.errorprone.BugPattern.Category.ANDROID;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.ImmutableSet;
@@ -35,7 +34,6 @@ public class FragmentNotInstantiableTest {
       summary =
           "Subclasses of CustomFragment must be instantiable via Class#newInstance():"
               + " the class must be public, static and have a public nullary constructor",
-      category = ANDROID,
       severity = WARNING)
   public static class CustomFragmentNotInstantiable extends FragmentNotInstantiable {
     public CustomFragmentNotInstantiable() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/ArgumentSelectionDefectCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/ArgumentSelectionDefectCheckerTest.java
@@ -17,7 +17,6 @@ package com.google.errorprone.bugpatterns.argumentselectiondefects;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.VisitorState;
@@ -45,7 +44,6 @@ public class ArgumentSelectionDefectCheckerTest {
    */
   @BugPattern(
       name = "ArgumentSelectionDefectWithStringEquality",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary =
           "Run the ArgumentSelectionDefectChecker checker using string equality for edit distance")
@@ -142,7 +140,6 @@ public class ArgumentSelectionDefectCheckerTest {
    */
   @BugPattern(
       name = "ArgumentSelectionDefectWithIgnoredFormalsHeuristic",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary =
           "Run the ArgumentSelectionDefectChecker checker with a heuristic that ignores formal "
@@ -208,7 +205,6 @@ public class ArgumentSelectionDefectCheckerTest {
    */
   @BugPattern(
       name = "ArgumentSelectionDefectWithPenaltyThreshold",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary =
           "Run the ArgumentSelectionDefectChecker checker with the penalty threshold heuristic")
@@ -260,7 +256,6 @@ public class ArgumentSelectionDefectCheckerTest {
    */
   @BugPattern(
       name = "ArgumentSelectionDefectWithNameInCommentsHeuristic",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary =
           "Run the ArgumentSelectionDefectChecker checker using string equality for edit distance")
@@ -303,7 +298,6 @@ public class ArgumentSelectionDefectCheckerTest {
   /** A {@link BugChecker} which returns true if parameter names are available */
   @BugPattern(
       name = "ParameterNamesAvailableChecker",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary = "Returns true if parameter names are available on a method call")
   public static class ParameterNamesAvailableChecker extends BugChecker

--- a/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/CreatesDuplicateCallHeuristicTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/CreatesDuplicateCallHeuristicTest.java
@@ -21,7 +21,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.VisitorState;
@@ -46,7 +45,6 @@ public class CreatesDuplicateCallHeuristicTest {
   /** A {@link BugChecker} which runs the CreatesDuplicateCallHeuristic and prints the result */
   @BugPattern(
       name = "CreatesDuplicateCallHeuristicChecker",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary = "Runs CreateDuplicateCallHeursitic and prints the result")
   public static class CreatesDuplicateCallHeuristicChecker extends BugChecker

--- a/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/EnclosedByReverseHeuristicTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/EnclosedByReverseHeuristicTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns.argumentselectiondefects;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.VisitorState;
@@ -42,7 +41,6 @@ public class EnclosedByReverseHeuristicTest {
   /** A {@link BugChecker} which runs the EnclosedByReverseHeuristic and prints the result */
   @BugPattern(
       name = "EnclosedByReverseHeuristic",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary = "Run the EnclosedByReverseHeuristic and print result")
   public static class EnclosedByReverseHeuristicChecker extends BugChecker

--- a/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/NameInCommentHeuristicTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/NameInCommentHeuristicTest.java
@@ -21,7 +21,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.VisitorState;
@@ -46,7 +45,6 @@ public class NameInCommentHeuristicTest {
   /** A {@link BugChecker} which runs the NameInCommentHeuristic and prints the result */
   @BugPattern(
       name = "NameInCommentHeuristicChecker",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary = "Runs NameInCommentHeuristic and prints the result")
   public static class NameInCommentHeuristicChecker extends BugChecker

--- a/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/ParameterTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/ParameterTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns.argumentselectiondefects;
 
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.VisitorState;
@@ -46,7 +45,6 @@ public class ParameterTest {
    */
   @BugPattern(
       name = "IsFirstAssignableToSecond",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary = "Print whether the type of the first argument is assignable to the second one")
   public static class IsFirstAssignableToSecond extends BugChecker
@@ -109,7 +107,6 @@ public class ParameterTest {
   /** A {@link BugChecker} that prints the name extracted for the first argument */
   @BugPattern(
       name = "PrintNameOfFirstArgument",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary = "Print the name of the first argument")
   public static class PrintNameOfFirstArgument extends BugChecker
@@ -304,7 +301,6 @@ public class ParameterTest {
   /** A {@link BugChecker} that prints whether the first argument is constant */
   @BugPattern(
       name = "PrintIsConstantFirstArgument",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary = "Print whether the first argument is constant")
   public static class PrintIsConstantFirstArgument extends BugChecker

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/RxReturnValueIgnoredNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/RxReturnValueIgnoredNegativeCases.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+
+/** @author friedj@google.com (Jake Fried) */
+public class RxReturnValueIgnoredNegativeCases {
+  interface CanIgnoreMethod {
+    @CanIgnoreReturnValue
+    Observable<Object> getObservable();
+
+    @CanIgnoreReturnValue
+    Single<Object> getSingle();
+
+    @CanIgnoreReturnValue
+    Flowable<Object> getFlowable();
+
+    @CanIgnoreReturnValue
+    Maybe<Object> getMaybe();
+  }
+
+  public static class CanIgnoreImpl implements CanIgnoreMethod {
+    @Override
+    public Observable<Object> getObservable() {
+      return null;
+    }
+
+    @Override
+    public Single<Object> getSingle() {
+      return null;
+    }
+
+    @Override
+    public Flowable<Object> getFlowable() {
+      return null;
+    }
+
+    @Override
+    public Maybe<Object> getMaybe() {
+      return null;
+    }
+  }
+
+  static void callIgnoredInterfaceMethod() {
+    new CanIgnoreImpl().getObservable();
+    new CanIgnoreImpl().getSingle();
+    new CanIgnoreImpl().getFlowable();
+    new CanIgnoreImpl().getMaybe();
+  }
+
+  @CanIgnoreReturnValue
+  Observable<Object> getObservable() {
+    return null;
+  }
+
+  @CanIgnoreReturnValue
+  Single<Object> getSingle() {
+    return null;
+  }
+
+  @CanIgnoreReturnValue
+  Flowable<Object> getFlowable() {
+    return null;
+  }
+
+  @CanIgnoreReturnValue
+  Maybe<Object> getMaybe() {
+    return null;
+  }
+
+  void checkIgnore() {
+    getObservable();
+    getSingle();
+    getFlowable();
+    getMaybe();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/RxReturnValueIgnoredPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/RxReturnValueIgnoredPositiveCases.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import java.util.Arrays;
+
+/** @author friedj@google.com (Jake Fried) */
+public class RxReturnValueIgnoredPositiveCases {
+  private static Observable getObservable() {
+    return null;
+  }
+
+  private static Single getSingle() {
+    return null;
+  }
+
+  private static Flowable getFlowable() {
+    return null;
+  }
+
+  private static Maybe getMaybe() {
+    return null;
+  }
+
+  {
+    new Observable();
+    new Single();
+    new Flowable();
+    new Maybe();
+
+    // BUG: Diagnostic contains: Rx objects must be checked.
+    getObservable();
+    // BUG: Diagnostic contains: Rx objects must be checked.
+    getSingle();
+    // BUG: Diagnostic contains: Rx objects must be checked.
+    getFlowable();
+    // BUG: Diagnostic contains: Rx objects must be checked.
+    getMaybe();
+
+    // BUG: Diagnostic contains: Rx objects must be checked.
+    Arrays.asList(1, 2, 3).forEach(n -> getObservable());
+    // BUG: Diagnostic contains: Rx objects must be checked.
+    Arrays.asList(1, 2, 3).forEach(n -> getSingle());
+    // BUG: Diagnostic contains: Rx objects must be checked.
+    Arrays.asList(1, 2, 3).forEach(n -> getFlowable());
+    // BUG: Diagnostic contains: Rx objects must be checked.
+    Arrays.asList(1, 2, 3).forEach(n -> getMaybe());
+  }
+
+  private abstract static class IgnoringParent<T> {
+    @CanIgnoreReturnValue
+    abstract T ignoringFunction();
+  }
+
+  private class NonIgnoringObservableChild extends IgnoringParent<Observable<Integer>> {
+    @Override
+    Observable<Integer> ignoringFunction() {
+      return null;
+    }
+  }
+
+  private class NonIgnoringSingleChild extends IgnoringParent<Single<Integer>> {
+    @Override
+    Single<Integer> ignoringFunction() {
+      return null;
+    }
+  }
+
+  private class NonIgnoringFlowableChild extends IgnoringParent<Flowable<Integer>> {
+    @Override
+    Flowable<Integer> ignoringFunction() {
+      return null;
+    }
+  }
+
+  private class NonIgnoringMaybeChild extends IgnoringParent<Maybe<Integer>> {
+    @Override
+    Maybe<Integer> ignoringFunction() {
+      return null;
+    }
+  }
+
+  public void inheritenceTest() {
+    NonIgnoringObservableChild observableChild = new NonIgnoringObservableChild();
+    NonIgnoringSingleChild singleChild = new NonIgnoringSingleChild();
+    NonIgnoringFlowableChild flowableChild = new NonIgnoringFlowableChild();
+    NonIgnoringMaybeChild maybeChild = new NonIgnoringMaybeChild();
+
+    // BUG: Diagnostic contains: Rx objects must be checked.
+    observableChild.ignoringFunction();
+    // BUG: Diagnostic contains: Rx objects must be checked.
+    singleChild.ignoringFunction();
+    // BUG: Diagnostic contains: Rx objects must be checked.
+    flowableChild.ignoringFunction();
+    // BUG: Diagnostic contains: Rx objects must be checked.
+    maybeChild.ignoringFunction();
+  }
+
+  public void conditional() {
+    if (false) {
+      // BUG: Diagnostic contains: Rx objects must be checked.
+      getObservable();
+      // BUG: Diagnostic contains: Rx objects must be checked.
+      getSingle();
+      // BUG: Diagnostic contains: Rx objects must be checked.
+      getFlowable();
+      // BUG: Diagnostic contains: Rx objects must be checked.
+      getMaybe();
+    }
+
+    return;
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/HeldLockAnalyzerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/HeldLockAnalyzerTest.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.threadsafety;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -250,12 +249,7 @@ public class HeldLockAnalyzerTest {
   }
 
   /** A customized {@link GuardedByChecker} that prints more test-friendly diagnostics. */
-  @BugPattern(
-      name = "GuardedByLockSet",
-      summary = "",
-      explanation = "",
-      category = JDK,
-      severity = ERROR)
+  @BugPattern(name = "GuardedByLockSet", summary = "", explanation = "", severity = ERROR)
   public static class GuardedByLockSetAnalyzer extends GuardedByChecker {
 
     @Override

--- a/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
+++ b/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
@@ -18,8 +18,6 @@ package com.google.errorprone.fixes;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH;
-import static com.google.errorprone.BugPattern.Category.JDK;
-import static com.google.errorprone.BugPattern.Category.ONE_OFF;
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -32,7 +30,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.VisitorState;
@@ -88,7 +85,6 @@ public class SuggestedFixesTest {
   /** Test checker that adds or removes modifiers. */
   @BugPattern(
       name = "EditModifiers",
-      category = ONE_OFF,
       summary = "Edits modifiers",
       severity = ERROR,
       providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
@@ -259,7 +255,6 @@ public class SuggestedFixesTest {
 
   /** Test checker that casts returned expression. */
   @BugPattern(
-      category = ONE_OFF,
       name = "CastReturn",
       severity = ERROR,
       summary = "Adds casts to returned expressions",
@@ -283,7 +278,6 @@ public class SuggestedFixesTest {
 
   /** Test checker that casts returned expression. */
   @BugPattern(
-      category = ONE_OFF,
       name = "CastReturn",
       severity = ERROR,
       summary = "Adds casts to returned expressions",
@@ -422,7 +416,6 @@ public class SuggestedFixesTest {
   /** A test check that adds an annotation to all return types. */
   @BugPattern(
       name = "AddAnnotation",
-      category = Category.JDK,
       summary = "Add an annotation",
       severity = ERROR,
       providesFix = REQUIRES_HUMAN_ATTENTION)
@@ -583,7 +576,6 @@ public class SuggestedFixesTest {
   /** A test check that replaces all methods' return types with a given type. */
   @BugPattern(
       name = "ReplaceReturnType",
-      category = Category.JDK,
       summary = "Change the method return type",
       severity = ERROR,
       providesFix = REQUIRES_HUMAN_ATTENTION)
@@ -617,7 +609,6 @@ public class SuggestedFixesTest {
   /** A test check that replaces all methods' return types with a given type. */
   @BugPattern(
       name = "ReplaceReturnTypeString",
-      category = Category.JDK,
       summary = "Change the method return type",
       severity = ERROR,
       providesFix = REQUIRES_HUMAN_ATTENTION)
@@ -699,7 +690,6 @@ public class SuggestedFixesTest {
   /** A test check that qualifies javadoc link. */
   @BugPattern(
       name = "JavadocQualifier",
-      category = Category.JDK,
       summary = "all javadoc links should be qualified",
       severity = ERROR,
       providesFix = REQUIRES_HUMAN_ATTENTION)
@@ -753,7 +743,6 @@ public class SuggestedFixesTest {
 
   @BugPattern(
       name = "SuppressMe",
-      category = ONE_OFF,
       summary = "",
       severity = ERROR,
       providesFix = REQUIRES_HUMAN_ATTENTION)
@@ -809,7 +798,6 @@ public class SuggestedFixesTest {
 
   @BugPattern(
       name = "SuppressMeWithComment",
-      category = ONE_OFF,
       summary = "",
       severity = ERROR,
       providesFix = REQUIRES_HUMAN_ATTENTION)
@@ -903,7 +891,6 @@ public class SuggestedFixesTest {
   /** A test bugchecker that deletes any field whose removal doesn't break the compilation. */
   @BugPattern(
       name = "CompilesWithFixChecker",
-      category = JDK,
       summary = "",
       severity = ERROR,
       providesFix = REQUIRES_HUMAN_ATTENTION)
@@ -943,7 +930,6 @@ public class SuggestedFixesTest {
   /** A test bugchecker that deletes an exception from throws. */
   @BugPattern(
       name = "RemovesExceptionChecker",
-      category = JDK,
       summary = "",
       severity = ERROR,
       providesFix = REQUIRES_HUMAN_ATTENTION)
@@ -1045,7 +1031,6 @@ public class SuggestedFixesTest {
   /** Test checker that renames variables. */
   @BugPattern(
       name = "RenamesVariableChecker",
-      category = JDK,
       summary = "",
       severity = ERROR,
       providesFix = REQUIRES_HUMAN_ATTENTION)
@@ -1248,7 +1233,6 @@ public class SuggestedFixesTest {
   /** Test checker that removes and adds modifiers in the same fix. */
   @BugPattern(
       name = "RemoveAddModifier",
-      category = JDK,
       summary = "",
       severity = ERROR,
       providesFix = REQUIRES_HUMAN_ATTENTION)

--- a/core/src/test/java/com/google/errorprone/matchers/JUnitMatchersTest.java
+++ b/core/src/test/java/com/google/errorprone/matchers/JUnitMatchersTest.java
@@ -19,7 +19,6 @@ package com.google.errorprone.matchers;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.VisitorState;
@@ -188,7 +187,6 @@ public final class JUnitMatchersTest {
   @BugPattern(
       name = "JUnitVersionMatcher",
       summary = "Matches on JUnit test classes, emits description with its JUnit version.",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.WARNING)
   public static class JUnitVersionMatcher extends BugChecker implements ClassTreeMatcher {
 

--- a/core/src/test/java/com/google/errorprone/matchers/MatchersTest.java
+++ b/core/src/test/java/com/google/errorprone/matchers/MatchersTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.matchers;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.errorprone.BugPattern.Category.ONE_OFF;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.inLoop;
 import static com.google.errorprone.matchers.Matchers.isPrimitiveOrVoidType;
@@ -448,7 +447,6 @@ public class MatchersTest {
   @BugPattern(
       name = "InLoopChecker",
       summary = "Checker that flags the given expression statement if the given matcher matches",
-      category = ONE_OFF,
       severity = ERROR)
   public static class InLoopChecker extends MatcherChecker {
     public InLoopChecker() {
@@ -463,7 +461,6 @@ public class MatchersTest {
   @BugPattern(
       name = "MethodTreeChecker",
       summary = "Checker that flags the given method declaration if the given matcher matches",
-      category = ONE_OFF,
       severity = ERROR)
   static class MethodTreeChecker extends BugChecker implements MethodTreeMatcher {
     private final Matcher<MethodTree> matcher;
@@ -482,7 +479,6 @@ public class MatchersTest {
   @BugPattern(
       name = "MethodInvocationTreeChecker",
       summary = "Checker that flags the given method invocation if the given matcher matches",
-      category = ONE_OFF,
       severity = ERROR)
   public static class NoAnnotatedCallsChecker extends BugChecker
       implements MethodInvocationTreeMatcher {
@@ -499,7 +495,6 @@ public class MatchersTest {
   @BugPattern(
       name = "SameArgumentChecker",
       summary = "Checker that matches invocation if the first argument is repeated",
-      category = ONE_OFF,
       severity = ERROR)
   public static class SameArgumentChecker extends BugChecker
       implements MethodInvocationTreeMatcher {
@@ -519,7 +514,6 @@ public class MatchersTest {
   @BugPattern(
       name = "NoAnnotatedDeclarationCallsChecker",
       summary = "Checker that flags the given method invocation if the given matcher matches",
-      category = ONE_OFF,
       severity = ERROR)
   public static class NoAnnotatedDeclarationCallsChecker extends BugChecker
       implements MethodInvocationTreeMatcher {
@@ -536,7 +530,6 @@ public class MatchersTest {
   @BugPattern(
       name = "PackageNameChecker",
       summary = "Checks the name of the package",
-      category = ONE_OFF,
       severity = ERROR)
   public static class PackageNameChecker extends BugChecker implements ClassTreeMatcher {
     private static final Matcher<Tree> MATCHER = Matchers.packageStartsWith("test.foo");

--- a/core/src/test/java/com/google/errorprone/matchers/MethodMatchersTest.java
+++ b/core/src/test/java/com/google/errorprone/matchers/MethodMatchersTest.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.matchers;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
@@ -46,7 +45,6 @@ public class MethodMatchersTest {
   /** A bugchecker to test constructor matching. */
   @BugPattern(
       name = "ConstructorDeleter",
-      category = JDK,
       summary = "Deletes constructors",
       severity = ERROR,
       providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
@@ -132,11 +130,7 @@ public class MethodMatchersTest {
   }
 
   /** This is javadoc. */
-  @BugPattern(
-      name = "CrashyParameterMatcherTestChecker",
-      category = JDK,
-      summary = "",
-      severity = ERROR)
+  @BugPattern(name = "CrashyParameterMatcherTestChecker", summary = "", severity = ERROR)
   public static class CrashyerMatcherTestChecker extends BugChecker
       implements MethodInvocationTreeMatcher {
 

--- a/core/src/test/java/com/google/errorprone/matchers/NextStatementTest.java
+++ b/core/src/test/java/com/google/errorprone/matchers/NextStatementTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.matchers;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
@@ -39,7 +38,6 @@ public final class NextStatementTest {
   /** A bugchecker to test the ability to notice the 'next statement' */
   @BugPattern(
       name = "CompoundAssignmentBeforeReturn",
-      category = JDK,
       summary = "This is a compound assignment before another statement in the same block",
       severity = ERROR)
   public static class CompoundBeforeAnythingChecker extends BugChecker

--- a/core/src/test/java/com/google/errorprone/scanner/ScannerSupplierTest.java
+++ b/core/src/test/java/com/google/errorprone/scanner/ScannerSupplierTest.java
@@ -19,7 +19,6 @@ package com.google.errorprone.scanner;
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.scanner.BuiltInCheckerSuppliers.getSuppliers;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -616,7 +615,6 @@ public class ScannerSupplierTest {
   @BugPattern(
       name = "PackageLocation",
       summary = "",
-      category = JDK,
       severity = ERROR,
       suppressionAnnotations = {},
       disableable = false)

--- a/core/src/test/java/com/google/errorprone/scanner/ScannerTest.java
+++ b/core/src/test/java/com/google/errorprone/scanner/ScannerTest.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.scanner;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
@@ -103,7 +102,6 @@ public class ScannerTest {
   @BugPattern(
       name = "ShouldNotUseFoo",
       summary = "Code should not use Foo.",
-      category = JDK,
       severity = ERROR,
       suppressionAnnotations = OkToUseFoo.class)
   public static class ShouldNotUseFoo extends BugChecker implements IdentifierTreeMatcher {

--- a/core/src/test/java/com/google/errorprone/util/ASTHelpersTest.java
+++ b/core/src/test/java/com/google/errorprone/util/ASTHelpersTest.java
@@ -19,7 +19,6 @@ package com.google.errorprone.util;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.common.truth.Truth8.assertThat;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
@@ -32,7 +31,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Verify;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.CompilationTestHelper;
@@ -690,7 +688,6 @@ public class ASTHelpersTest extends CompilerBasedAbstractTest {
    */
   @BugPattern(
       name = "HasDirectAnnotationWithSimpleNameChecker",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary =
           "Test checker to ensure that ASTHelpers.hasDirectAnnotationWithSimpleName() "
@@ -817,7 +814,7 @@ public class ASTHelpersTest extends CompilerBasedAbstractTest {
   }
 
   /** A checker that reports the constant value of fields. */
-  @BugPattern(name = "ConstChecker", category = JDK, summary = "", severity = ERROR)
+  @BugPattern(name = "ConstChecker", summary = "", severity = ERROR)
   public static class ConstChecker extends BugChecker implements VariableTreeMatcher {
     @Override
     public Description matchVariable(VariableTree tree, VisitorState state) {
@@ -845,7 +842,6 @@ public class ASTHelpersTest extends CompilerBasedAbstractTest {
   /** A {@link BugChecker} that prints the result type of the first argument in method calls. */
   @BugPattern(
       name = "PrintResultTypeOfFirstArgument",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary = "Prints the type of the first argument in method calls")
   public static class PrintResultTypeOfFirstArgument extends BugChecker
@@ -942,7 +938,6 @@ public class ASTHelpersTest extends CompilerBasedAbstractTest {
   /** A {@link BugChecker} that prints the target type of matched method invocations. */
   @BugPattern(
       name = "TargetTypeChecker",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary = "Prints the target type")
   public static class TargetTypeChecker extends BugChecker implements MethodInvocationTreeMatcher {
@@ -990,7 +985,6 @@ public class ASTHelpersTest extends CompilerBasedAbstractTest {
   /** A {@link BugChecker} that prints the target type of a parameterized type. */
   @BugPattern(
       name = "TargetTypeCheckerParentTypeNotMatched",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary =
           "Prints the target type for ParameterizedTypeTree, which is not handled explicitly.")
@@ -1107,7 +1101,6 @@ public class ASTHelpersTest extends CompilerBasedAbstractTest {
   /** A {@link BugChecker} that prints if the method can be overridden. */
   @BugPattern(
       name = "MethodCanBeOverriddenChecker",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary = "Prints whether the method can be overridden.",
       providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)

--- a/core/src/test/java/com/google/errorprone/util/CommentsTest.java
+++ b/core/src/test/java/com/google/errorprone/util/CommentsTest.java
@@ -20,7 +20,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.VisitorState;
@@ -49,7 +48,6 @@ public class CommentsTest {
    */
   @BugPattern(
       name = "ComputeEndPosition",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary = "Calls computeEndPosition and prints results")
   public static class ComputeEndPosition extends BugChecker implements MethodInvocationTreeMatcher {
@@ -121,7 +119,6 @@ public class CommentsTest {
   /** A {@link BugChecker} that prints the contents of comments around arguments */
   @BugPattern(
       name = "PrintCommentsForArguments",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary =
           "Prints comments occurring around arguments. Matches calls to methods named "
@@ -468,7 +465,6 @@ public class CommentsTest {
   /** A {@link BugChecker} that prints the source code at comment positions */
   @BugPattern(
       name = "PrintTextAtCommentPosition",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary =
           "Prints the source code text which is under the comment position. Matches calls to "

--- a/core/src/test/java/com/google/errorprone/util/FindIdentifiersTest.java
+++ b/core/src/test/java/com/google/errorprone/util/FindIdentifiersTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.util;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.Category;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.VisitorState;
@@ -41,7 +40,6 @@ public class FindIdentifiersTest {
   /** A {@link BugChecker} that prints all identifiers in scope at a call to String.format(). */
   @BugPattern(
       name = "PrintIdents",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary = "Prints all identifiers in scope at a call to String.format()")
   public static class PrintIdents extends BugChecker implements MethodInvocationTreeMatcher {
@@ -630,7 +628,6 @@ public class FindIdentifiersTest {
    */
   @BugPattern(
       name = "PrintUnusedVariables",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary = "Prints all unused variabled in scope at a call to String.format()")
   public static class PrintUnusedVariables extends BugChecker
@@ -767,7 +764,6 @@ public class FindIdentifiersTest {
   /** A {@link BugChecker} that prints all fields in receiver class on method invocations. */
   @BugPattern(
       name = "PrintFields",
-      category = Category.ONE_OFF,
       severity = SeverityLevel.ERROR,
       summary = "Prints all fields in receivers of method invocations")
   public static class PrintFields extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/test/java/com/google/errorprone/util/ReachabilityTest.java
+++ b/core/src/test/java/com/google/errorprone/util/ReachabilityTest.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.util;
 
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static java.util.stream.Collectors.toList;
@@ -42,7 +41,7 @@ import org.junit.runners.Parameterized.Parameters;
 public class ReachabilityTest {
 
   /** Reports an error if the first case in a switch falls through to the second. */
-  @BugPattern(name = "FirstCaseFallsThrough", category = JDK, summary = "", severity = ERROR)
+  @BugPattern(name = "FirstCaseFallsThrough", summary = "", severity = ERROR)
   public static class FirstCaseFallsThrough extends BugChecker implements SwitchTreeMatcher {
 
     @Override

--- a/docs/bugpattern/AmbiguousMethodReference.md
+++ b/docs/bugpattern/AmbiguousMethodReference.md
@@ -7,10 +7,10 @@ static class A {
 }
 ```
 
-The method reference `A::c` of the instance method `c` has an implicit
-first parameter for the `this` pointer. So both methods that `A::c` could
-resolve to are compatible with `BiFunction<A, D, B>`, and the method
-reference is ambiguous.
+The method reference `A::c` of the instance method `c` has an implicit first
+parameter for the `this` pointer. So both methods that `A::c` could resolve to
+are compatible with `BiFunction<A, D, B>`, and the method reference is
+ambiguous.
 
 ```java
 void f(BiFunction<A, D, B> f) { ... }

--- a/docs/bugpattern/ArrayHashCode.md
+++ b/docs/bugpattern/ArrayHashCode.md
@@ -1,4 +1,4 @@
-Computing a hashcode for an array is tricky.  Typically you want a hashcode that
+Computing a hashcode for an array is tricky. Typically you want a hashcode that
 depends on the value of each element in the array, but many of the common ways
 to do this actually return a hashcode based on the _identity_ of the array
 rather than its contents.
@@ -6,18 +6,18 @@ rather than its contents.
 This check flags attempts to compute a hashcode from an array that do not take
 the contents of the array into account. There are several ways to mess this up:
 
-  * Call the instance `.hashCode()` method on an array.
+*   Call the instance `.hashCode()` method on an array.
 
-  * Call the JDK method `java.util.Objects#hashCode()` with an argument of array
+*   Call the JDK method `java.util.Objects#hashCode()` with an argument of array
     type.
 
-  * Call the JDK method `java.util.Objects#hash()` or the Guava method
+*   Call the JDK method `java.util.Objects#hash()` or the Guava method
     `com.google.common.base.Objects#hashCode()` with multiple arguments, at
     least one of which is an array.
 
-  * Call the JDK method `java.util.Objects#hash()` or the Guava method
+*   Call the JDK method `java.util.Objects#hash()` or the Guava method
     `com.google.common.base.Objects#hashCode()` with a single argument of
-    _primitive_ array type. Because these are varags methods that take 
+    _primitive_ array type. Because these are varags methods that take
     `Object...`, the primitive array is autoboxed into a single-element Object
     array, and these methods use the identity hashcode of the primitive array
     rather than examining its contents. Note that calling these methods on an

--- a/docs/bugpattern/AssertThrowsMultipleStatements.md
+++ b/docs/bugpattern/AssertThrowsMultipleStatements.md
@@ -6,7 +6,7 @@ This means that:
 
 *   Any set-up logic in the lambda will cause the test to incorrectly pass if it
     throws the expected exception.
-*   Any assertions that run after the statement that throws will never be 
+*   Any assertions that run after the statement that throws will never be
     executed.
 
 Don't do this:

--- a/docs/bugpattern/AutoValueFinalMethods.md
+++ b/docs/bugpattern/AutoValueFinalMethods.md
@@ -4,6 +4,9 @@ implementation class. If you mark your concrete methods final, they won't have
 to wonder whether the generated subclass might be overriding them. This is
 especially helpful if you are underriding equals, hashCode or toString!
 
-Reference: https://github.com/google/auto/blob/master/value/userguide/practices.md#mark-all-concrete-methods-final
+Reference:
+https://github.com/google/auto/blob/master/value/userguide/practices.md#mark-all-concrete-methods-final
 
-NOTE: [Since `@Memoized` methods can't be final](https://github.com/google/auto/blob/master/value/userguide/howto.md#memoize_hash_tostring), the check doesn't flag them.
+NOTE:
+[Since `@Memoized` methods can't be final](https://github.com/google/auto/blob/master/value/userguide/howto.md#memoize_hash_tostring),
+the check doesn't flag them.

--- a/docs/bugpattern/BadShiftAmount.md
+++ b/docs/bugpattern/BadShiftAmount.md
@@ -1,7 +1,7 @@
 For shift operations on int types, only the five lowest-order bits of the shift
-amount are used as the shift distance.  This means that shift amounts that are
+amount are used as the shift distance. This means that shift amounts that are
 not in the range 0 to 31, inclusive, are silently mapped to values in that
-range.  For example, a shift of an int by 32 is equivalent to shifting by 0,
+range. For example, a shift of an int by 32 is equivalent to shifting by 0,
 i.e., a no-op.
 
 See JLS 15.19, "Shift Operators", for more details.

--- a/docs/bugpattern/BindingToUnqualifiedCommonType.md
+++ b/docs/bugpattern/BindingToUnqualifiedCommonType.md
@@ -10,8 +10,8 @@ bind(CoffeeMaker.class).to(RealCoffeeMaker.class);
 ```
 
 However, in other circumstances, you want to bind a simple value (an integer,
-String, double, etc.). You should use a Qualifier annotation to allow you to
-get the *right* Integer back:
+String, double, etc.). You should use a Qualifier annotation to allow you to get
+the *right* Integer back:
 
 ```java
 bindConstant().annotatedWith(HttpPort.class).to(80);

--- a/docs/bugpattern/BoxedPrimitiveConstructor.md
+++ b/docs/bugpattern/BoxedPrimitiveConstructor.md
@@ -1,16 +1,15 @@
 Constructors of primitive wrapper objects (e.g. `new Boolean(true)` will be
-[deprecated][8145468] in Java 9. The `valueOf` factory methods
-(e.g. `Boolean.valueOf(true)`) should always be preferred. Those methods are
-called implicitly by autoboxing, which is often more convenient than an
-explicit call. `Integer x = Integer.valueOf(23);` and `Integer x = 23;` are
-equivalent.
+[deprecated][8145468] in Java 9. The `valueOf` factory methods (e.g.
+`Boolean.valueOf(true)`) should always be preferred. Those methods are called
+implicitly by autoboxing, which is often more convenient than an explicit call.
+`Integer x = Integer.valueOf(23);` and `Integer x = 23;` are equivalent.
 
 [8145468]: https://bugs.openjdk.java.net/browse/JDK-8145468
 
-The explicit constructors always return a fresh instance, resulting
-in unnecessary allocations. The `valueOf` methods return cached
-instances for frequently requested values, offering significantly better space
-and time performance.
+The explicit constructors always return a fresh instance, resulting in
+unnecessary allocations. The `valueOf` methods return cached instances for
+frequently requested values, offering significantly better space and time
+performance.
 
 Relying on the unique reference identity of the instances returned by the
 explicit constructors is extremely bad practice. Primitives should always be

--- a/docs/bugpattern/CheckReturnValue.md
+++ b/docs/bugpattern/CheckReturnValue.md
@@ -1,6 +1,7 @@
-The `@CheckReturnValue` annotation (available in JSR-305[^jsr] or in [Error
-Prone][epcrv]) marks methods whose return values should be checked. This error
-is triggered when one of these methods is called but the result is not used.
+The `@CheckReturnValue` annotation (available in JSR-305[^jsr] or in
+[Error Prone][epcrv]) marks methods whose return values should be checked. This
+error is triggered when one of these methods is called but the result is not
+used.
 
 [^jsr]: Of note, the JSR-305 project was [never fully approved][jsr305], so the
     JSR-305 version of the annotation is not actually official and causes

--- a/docs/bugpattern/CloseableProvides.md
+++ b/docs/bugpattern/CloseableProvides.md
@@ -28,8 +28,8 @@ There are a number of issues with this approach as it relates to resource
 management:
 
 *   If multiple Client classes are constructed, multiple output streams are
-    opened against the same file, and writes to the file may clash with
-    each other.
+    opened against the same file, and writes to the file may clash with each
+    other.
 *   It's not clear which class has the responsibility of closing the
     `FileOutputStream` resource:
 

--- a/docs/bugpattern/CollectionIncompatibleType.md
+++ b/docs/bugpattern/CollectionIncompatibleType.md
@@ -50,8 +50,8 @@ static analysis.
 The specific restriction we would like to express for the two types is not
 assignability, but "compatibility". Informally, we mean that it must at least be
 *possible* for some instance to be of both types. Formally, we require that a
-"casting conversion" exist between the types as defined by [JLS 5.5.1]
-(https://docs.oracle.com/javase/specs/jls/se7/html/jls-5.html#jls-5.5.1).
+"casting conversion" exist between the types as defined by
+[JLS 5.5.1](https://docs.oracle.com/javase/specs/jls/se7/html/jls-5.html#jls-5.5.1).
 
 The result is that the method can be defined as `contains(Object)`, permitting
 the "good" call above, but that Error Prone will give errors for incompatible

--- a/docs/bugpattern/CompileTimeConstant.md
+++ b/docs/bugpattern/CompileTimeConstant.md
@@ -4,8 +4,8 @@ with corresponding actual parameters that are computed as compile-time constant
 expressions, such as a literal or static final constant.
 
 Getting Java 8 references to methods with `@CompileTimeConstant` parameters is
-disallowed because we couldn't check if the method reference is later applied
-to a compile-time constant. Use the methods directly instead.
+disallowed because we couldn't check if the method reference is later applied to
+a compile-time constant. Use the methods directly instead.
 
 
 For the same reason, it's also disallowed to create lambda expressions with

--- a/docs/bugpattern/ConditionalExpressionNumericPromotion.md
+++ b/docs/bugpattern/ConditionalExpressionNumericPromotion.md
@@ -12,8 +12,8 @@ For example:
 Despite the apparent intent to get a `Double` in one case, and an `Integer` in
 the other, the result is a `Double` in both cases.
 
-This is because the rules in [JLS §
-15.25.2](https://docs.oracle.com/javase/specs/jls/se9/html/jls-15.html#jls-15.25.2)
+This is because the rules in
+[JLS § 15.25.2](https://docs.oracle.com/javase/specs/jls/se9/html/jls-15.html#jls-15.25.2)
 state that differing numeric types will undergo binary numeric promotion. As
 such, the latter case is evaluated as:
 

--- a/docs/bugpattern/ConstantOverflow.md
+++ b/docs/bugpattern/ConstantOverflow.md
@@ -1,16 +1,16 @@
 Compile-time constant expressions that overflow are a potential source of bugs.
 
 Literals without an explicit `L` suffix have type `int`, so the following
-multiplication expression is evaluated as an integer before being widened
-to `long`. The value is greater than `Integer.MAX_VALUE`, so it wraps around
-to `-1857093632`.
+multiplication expression is evaluated as an integer before being widened to
+`long`. The value is greater than `Integer.MAX_VALUE`, so it wraps around to
+`-1857093632`.
 
 ```java
 static final long NANOS_PER_DAY = 24  * 60 * 60 * 1000 * 1000 * 1000;
 ```
 
-The intent was probably for the multiplication expression to be evaluated as
-a `long` instead of an `int`.
+The intent was probably for the multiplication expression to be evaluated as a
+`long` instead of an `int`.
 
 ```java
 static final long NANOS_PER_DAY = 24L * 60 * 60 * 1000 * 1000 * 1000;

--- a/docs/bugpattern/DefaultCharset.md
+++ b/docs/bugpattern/DefaultCharset.md
@@ -1,6 +1,6 @@
-A [`Charset`][charset] is a mapping between sequences of [16-bit Unicode code
-units][codeunit] and sequences of bytes. Charsets are used when encoding
-characters into bytes and decoding bytes into characters.
+A [`Charset`][charset] is a mapping between sequences of
+[16-bit Unicode code units][codeunit] and sequences of bytes. Charsets are used
+when encoding characters into bytes and decoding bytes into characters.
 
 [charset]: https://docs.oracle.com/javase/8/docs/api/java/nio/charset/Charset.html
 [codeunit]: http://unicode.org/glossary/#code_unit

--- a/docs/bugpattern/DoubleBraceInitialization.md
+++ b/docs/bugpattern/DoubleBraceInitialization.md
@@ -15,8 +15,8 @@ which is also awfully strange). All this is completely nonobvious.
 Luckily, there are more readable and more performant alternatives in the factory
 methods and builders for `ImmutableList`, `ImmutableSet`, and `ImmutableMap`.
 
-The `List.of`, `Set.of`, and `Map.of` static factories [added in Java
-9](http://openjdk.java.net/jeps/269) are also a good choice.
+The `List.of`, `Set.of`, and `Map.of` static factories
+[added in Java 9](http://openjdk.java.net/jeps/269) are also a good choice.
 
 That is, prefer this:
 

--- a/docs/bugpattern/DoubleCheckedLocking.md
+++ b/docs/bugpattern/DoubleCheckedLocking.md
@@ -84,9 +84,9 @@ static Object get() {
 
 If the object being initialized with double-checked locking is
 [immutable](http://jeremymanson.blogspot.com/2008/04/immutability-in-java.html),
-then it is safe for the field to be non-volatile. *However*, the use of
-volatile is still encouraged because it is almost free on x86 and makes the
-code more obviously correct.
+then it is safe for the field to be non-volatile. *However*, the use of volatile
+is still encouraged because it is almost free on x86 and makes the code more
+obviously correct.
 
 Note that immutable has a very specific meaning in this context:
 

--- a/docs/bugpattern/EqualsGetClass.md
+++ b/docs/bugpattern/EqualsGetClass.md
@@ -29,12 +29,12 @@ But also because of a few concrete advantages:
 1.  You get the `x` and `y` fields/accessors for free.
 2.  You get any other methods defined on `Point` for free.
 3.  Users can pass a `ColoredPoint` to anything that expects a `Point`. (This is
-    by far the primary advantage, since the first two are just one-time-only 
+    by far the primary advantage, since the first two are just one-time-only
     implementation helpers for the `Point` authors themselves.)
 
-Although these same advantages *can* be achieved via composition, it's no
-longer quite "for free"; the frequent need to call `myColoredPoint.asPoint()` is
-a pain that feels unjustified, and thus subclassing is often chosen.
+Although these same advantages *can* be achieved via composition, it's no longer
+quite "for free"; the frequent need to call `myColoredPoint.asPoint()` is a pain
+that feels unjustified, and thus subclassing is often chosen.
 
 Unfortunately, `equals` now creates a big problem. Two `Points` should be seen
 as interchangeable whenever they have the same `x` and `y` coordinates. But two

--- a/docs/bugpattern/EqualsIncompatibleType.md
+++ b/docs/bugpattern/EqualsIncompatibleType.md
@@ -19,9 +19,9 @@ This check detects circumstances where the equals method is called when the two
 objects in question can *never* be equal to each other. We check the following
 equality methods:
 
-* `java.lang.Object.equals(Object)`
-* `java.util.Objects.equals(Object, Object)`
-* `com.google.common.base.Objects.equal(Object, Object)`
+*   `java.lang.Object.equals(Object)`
+*   `java.util.Objects.equals(Object, Object)`
+*   `com.google.common.base.Objects.equal(Object, Object)`
 
 ## I'm trying to test to make sure my equals method works
 

--- a/docs/bugpattern/Finally.md
+++ b/docs/bugpattern/Finally.md
@@ -1,13 +1,12 @@
-Terminating a finally block abruptly preempts the outcome of the try and
-catch blocks, and will cause the result of any previously executed return or
-throw statements to be ignored. Finally blocks should be written so they always
+Terminating a finally block abruptly preempts the outcome of the try and catch
+blocks, and will cause the result of any previously executed return or throw
+statements to be ignored. Finally blocks should be written so they always
 complete normally.
 
-Consider the following code. In the case where `doWork` throws
-`SomeException`, the finally block will still be executed. If closing the
-input stream *also* fails, then the exception that was thrown in the catch
-block will be prempted by the exception thrown by `close()`, and the first
-exception will be lost.
+Consider the following code. In the case where `doWork` throws `SomeException`,
+the finally block will still be executed. If closing the input stream *also*
+fails, then the exception that was thrown in the catch block will be prempted by
+the exception thrown by `close()`, and the first exception will be lost.
 
 ```java
 InputStream in = openInputStream();
@@ -47,4 +46,3 @@ try {
   closer.close();
 }
 ```
-

--- a/docs/bugpattern/FunctionalInterfaceClash.md
+++ b/docs/bugpattern/FunctionalInterfaceClash.md
@@ -34,8 +34,7 @@ void doIt(Function<String, String> f);
 void doIt(Consumer<String> c);
 ```
 
-[JLS
-15.12.2.1](https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.12.2.1)
+[JLS 15.12.2.1](https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.12.2.1)
 says that lambdas whose body is a statement expression are compatible with
 functional interfaces whose function type is void-returning _or_ value
 returning:

--- a/docs/bugpattern/FutureReturnValueIgnored.md
+++ b/docs/bugpattern/FutureReturnValueIgnored.md
@@ -5,6 +5,6 @@ If you don’t check the return value of these methods, you will never find out 
 they threw an exception.
 
 Nested futures can also result in missed cancellation signals or suppressed
-exceptions - see [Avoiding Nested
-Futures](https://github.com/google/guava/wiki/ListenableFutureExplained#avoid-nested-futures)
+exceptions - see
+[Avoiding Nested Futures](https://github.com/google/guava/wiki/ListenableFutureExplained#avoid-nested-futures)
 for details.

--- a/docs/bugpattern/GetClassOnAnnotation.md
+++ b/docs/bugpattern/GetClassOnAnnotation.md
@@ -1,4 +1,6 @@
-Instances of an annotation interface generally return a random proxy class when `getClass()` is called on them; to get the actual annotation type use `annotationType()`.
+Instances of an annotation interface generally return a random proxy class when
+`getClass()` is called on them; to get the actual annotation type use
+`annotationType()`.
 
 In the following example, calling `getClass()` on the annotation instance
 returns a proxy class like `com.sun.proxy.$Proxy1`, while `annotationType()`

--- a/docs/bugpattern/GetClassOnEnum.md
+++ b/docs/bugpattern/GetClassOnEnum.md
@@ -1,6 +1,6 @@
 Enum values that declare methods are a subclass of the actual enum type, so
-calling `getClass()` returns a synthetic subclass of the enum. To retrieve
-the type of the enum, use `getDeclaringClass()`.
+calling `getClass()` returns a synthetic subclass of the enum. To retrieve the
+type of the enum, use `getDeclaringClass()`.
 
 In the following example, `Binop.MULT.getClass()` returns the anonymous class
 `Binop$2`, while `Binop.MULT.getDeclaringClass()` returns the class `Binop`.

--- a/docs/bugpattern/GuardedBy.md
+++ b/docs/bugpattern/GuardedBy.md
@@ -130,7 +130,7 @@ void m() {
 }
 ```
 
-Note: there are a couple more annotations called `@GuardedBy`, including 
+Note: there are a couple more annotations called `@GuardedBy`, including
 `javax.annotation.concurrent.GuardedBy` and
 `org.checkerframework.checker.lock.qual.GuardedBy`. The check recognizes those
 versions of the annotation, but we recommend using

--- a/docs/bugpattern/HashtableContains.md
+++ b/docs/bugpattern/HashtableContains.md
@@ -1,8 +1,8 @@
-`Hashtable.contains(Object)` and `ConcurrentHashMap.contains(Object)` are
-legacy methods for testing if the given object is a value in the hash table. 
-They are often mistaken for `containsKey`, which checks whether the given object
-is a *key* in the  hash table.
+`Hashtable.contains(Object)` and `ConcurrentHashMap.contains(Object)` are legacy
+methods for testing if the given object is a value in the hash table. They are
+often mistaken for `containsKey`, which checks whether the given object is a
+*key* in the hash table.
 
 If you intended to check whether the given object is a key in the hash table,
-use `containsKey` instead.  If you really intended to check whether the 
-given object is a value in the hash table, use `containsValue` for clarity.
+use `containsKey` instead. If you really intended to check whether the given
+object is a value in the hash table, use `containsValue` for clarity.

--- a/docs/bugpattern/HidingField.md
+++ b/docs/bugpattern/HidingField.md
@@ -1,7 +1,7 @@
 If a class has a field of the same name as any field visible to it on any of its
-superclasses or superinterfaces, the subclass' field is said to "[hide]
-(https://docs.oracle.com/javase/tutorial/java/IandI/hidevariables.html)" the
-superclass' field.
+superclasses or superinterfaces, the subclass' field is said to
+"[hide](https://docs.oracle.com/javase/tutorial/java/IandI/hidevariables.html)"
+the superclass' field.
 
 When this circumstance occurs, users of the class declaring the hiding field
 can't interact with the fields from the superclass.

--- a/docs/bugpattern/ImmutableEnumChecker.md
+++ b/docs/bugpattern/ImmutableEnumChecker.md
@@ -35,9 +35,9 @@ To make enums immutable, ensure:
 
     *   If the type you're using inside the enum is not considered immutable,
         and you can't annotate the type because it's outside the project,
-        consider using an immutable replacement of the type, or [suppress this
-        check on the enum](#suppression) with a comment about why the fields in
-        question are immutable.
+        consider using an immutable replacement of the type, or
+        [suppress this check on the enum](#suppression) with a comment about why
+        the fields in question are immutable.
 
 TIP: annotating the declaration of the enum class with `@Immutable` is
 unnecessary -- Error Prone assumes enums are immutable by default.

--- a/docs/bugpattern/InjectScopeOrQualifierAnnotationRetention.md
+++ b/docs/bugpattern/InjectScopeOrQualifierAnnotationRetention.md
@@ -1,6 +1,6 @@
-Qualifier and Scope annotations are used by dependency injection frameworks to adjust their
-behavior. Not having runtime retention on scoping or qualifier annotations will cause unexpected
-behavior in frameworks that use reflection:
+Qualifier and Scope annotations are used by dependency injection frameworks to
+adjust their behavior. Not having runtime retention on scoping or qualifier
+annotations will cause unexpected behavior in frameworks that use reflection:
 
 ```java
 class CreditCardProcessor { @Inject CreditCardProcessor(...) }
@@ -18,9 +18,10 @@ MyApp(CreditCardProcessor processor) {
   processor.issueCharge(...); // Issues a charge against a fake!
 }
 ```
-Since the Qualifier doesn't have runtime retention, the Guice provider method doesn't see the
-annotation, and will use the TestCreditCardProcessor for the normal CreditCardProcessor injection
-point.
+
+Since the Qualifier doesn't have runtime retention, the Guice provider method
+doesn't see the annotation, and will use the TestCreditCardProcessor for the
+normal CreditCardProcessor injection point.
 
 NOTE: Even for dependency injection frameworks traditionally considered to be
 compile-time dependent, the JSR-330 specification still requires runtime

--- a/docs/bugpattern/IsInstanceOfClass.md
+++ b/docs/bugpattern/IsInstanceOfClass.md
@@ -2,8 +2,8 @@ Passing an argument of type `Class` to `Class#instanceOf(Class)` is usually a
 mistake.
 
 Calling `clazz.instanceOf(obj)` for some `clazz` with type `Class<T>` is
-equivalent to `obj instanceof T`. The `instanceOf` method exists for cases
-where the type `T` is not known statically.
+equivalent to `obj instanceof T`. The `instanceOf` method exists for cases where
+the type `T` is not known statically.
 
 When a class literal is passed as the argument of `instanceOf`, the result will
 only be true if the class literal on left hand side is equal to `Class.class`.

--- a/docs/bugpattern/JavaLangClash.md
+++ b/docs/bugpattern/JavaLangClash.md
@@ -1,5 +1,5 @@
-Class names from `java.lang` should never be reused. From [Java
-Puzzlers](http://www.javapuzzlers.com/java-puzzlers-sampler.pdf):
+Class names from `java.lang` should never be reused. From
+[Java Puzzlers](http://www.javapuzzlers.com/java-puzzlers-sampler.pdf):
 
 > Avoid reusing the names of platform classes, and never reuse class names from
 > `java.lang`, because these names are automatically imported everywhere.

--- a/docs/bugpattern/JavaxInjectOnAbstractMethod.md
+++ b/docs/bugpattern/JavaxInjectOnAbstractMethod.md
@@ -1,11 +1,11 @@
-The [`Inject`] annotation cannot be applied to abstract methods, per the JSR-330 spec, since
-injectors will only inject those methods if the concrete implementer of the abstract method has
-the [`Inject`] annotation as well. See [OverridesJavaxInjectableMethod] for more examples of this
-interaction.
+The [`Inject`] annotation cannot be applied to abstract methods, per the JSR-330
+spec, since injectors will only inject those methods if the concrete implementer
+of the abstract method has the [`Inject`] annotation as well. See
+[OverridesJavaxInjectableMethod] for more examples of this interaction.
 
-Currently, default methods in interfaces are not injected if they have [`Inject`] for similar
-reasons, although future updates to dependency injection frameworks may allow this, since the
-default methods are not abstract.
+Currently, default methods in interfaces are not injected if they have
+[`Inject`] for similar reasons, although future updates to dependency injection
+frameworks may allow this, since the default methods are not abstract.
 
 See the [Guice wiki] page on JSR-330 for more.
 

--- a/docs/bugpattern/JdkObsolete.md
+++ b/docs/bugpattern/JdkObsolete.md
@@ -2,8 +2,8 @@ Some JDK APIs are obsolete and have preferred alternatives.
 
 ## `LinkedList`
 
-`LinkedList` almost never out-performs `ArrayList` or `ArrayDeque`[^1].
-If you are using `LinkedList` as a list, prefer `ArrayList`.  If you are using
+`LinkedList` almost never out-performs `ArrayList` or `ArrayDeque`[^1]. If you
+are using `LinkedList` as a list, prefer `ArrayList`. If you are using
 `LinkedList` as a stack or queue/deque, prefer `ArrayDeque`.
 
 Migration gotcha: `LinkedList` permits `null` elements; `ArrayDeque` rejects

--- a/docs/bugpattern/LiteByteStringUtf8.md
+++ b/docs/bugpattern/LiteByteStringUtf8.md
@@ -4,8 +4,9 @@ can be passed around and deserialized into a message using
 [`MyMessage.Builder.mergeFrom(ByteString)`][merge].
 
 [`ByteString#toStringUtf8`] copies UTF-8 encoded byte data living inside the
-`ByteString` to a `java.lang.String`, replacing any [invalid UTF-8 byte
-sequences][invalid-utf8-byte-sequences] with � (the Unicode replacement character).
+`ByteString` to a `java.lang.String`, replacing any
+[invalid UTF-8 byte sequences][invalid-utf8-byte-sequences] with � (the Unicode
+replacement character).
 
 In this circumstance, a protocol message is being serialized to a `ByteString`,
 then immediately turned into a Java `String` using the `toStringUtf8` method.

--- a/docs/bugpattern/MissingFail.md
+++ b/docs/bugpattern/MissingFail.md
@@ -26,11 +26,11 @@ percentages).
 Five methods were explored to detect missing `fail()` calls, triggering if no
 `fail()` is used in a `try/catch` statement within a JUnit test class:
 
-* Cases in which the caught exception is called "expected".
-* Cases in which there is a call to an `assert*()` method in the catch block.
-* Cases in which "expected" shows up in a comment inside the `catch` block.
-* Cases in which the `catch` block is empty.
-* Cases in which the `try` block contains only a single statement.
+*   Cases in which the caught exception is called "expected".
+*   Cases in which there is a call to an `assert*()` method in the catch block.
+*   Cases in which "expected" shows up in a comment inside the `catch` block.
+*   Cases in which the `catch` block is empty.
+*   Cases in which the `try` block contains only a single statement.
 
 Only the first three yield useful results and also required some more refinement
 to reduce false positives. In addition, the checker does not trigger on comments
@@ -38,25 +38,25 @@ in the `catch` block due to implementation complexity.
 
 To reduce false positives, no match is found if any of the following is true:
 
-* Any method with `fail` in its name is present in either catch or try block.
-* A `throw` statement or synonym (`assertTrue(false)`, etc.) is present in
-  either `catch` or `try` block.
-* The occurrence happens inside a `setUp`, `tearDown`, `@Before`, `@After`,
-  `suite` or`main` method.
-* The method returns from the `try` or `catch` block or immediately after.
-* The exception caught is of type `InterruptedException`, `AssertionError`,
-  `junit.framework.AssertionFailedError` or `Throwable`.
-* The occurrence is inside a loop.
-* The try block contains a `while(true)` loop.
-* The `try` or `catch` block contains a `continue;` statement.
-* The `try/catch` statement also contains a `finally` statement.
-* A logging call is present in the `catch` block.
+*   Any method with `fail` in its name is present in either catch or try block.
+*   A `throw` statement or synonym (`assertTrue(false)`, etc.) is present in
+    either `catch` or `try` block.
+*   The occurrence happens inside a `setUp`, `tearDown`, `@Before`, `@After`,
+    `suite` or`main` method.
+*   The method returns from the `try` or `catch` block or immediately after.
+*   The exception caught is of type `InterruptedException`, `AssertionError`,
+    `junit.framework.AssertionFailedError` or `Throwable`.
+*   The occurrence is inside a loop.
+*   The try block contains a `while(true)` loop.
+*   The `try` or `catch` block contains a `continue;` statement.
+*   The `try/catch` statement also contains a `finally` statement.
+*   A logging call is present in the `catch` block.
 
 In addition, for occurrences which matched because they have a call to an
 `assert*()` method in the catch block, no match is found if any of the following
 characteristics are present:
 
-* A field assignment in the catch block.
-* A call to `assertTrue/False(boolean variable or field)` in the catch block.
-* The last statement in the `try` block is an `assert*()` (that is not a noop:
-  `assertFalse(false)`, `assertTrue(true))` or `Mockito.verify()` call.
+*   A field assignment in the catch block.
+*   A call to `assertTrue/False(boolean variable or field)` in the catch block.
+*   The last statement in the `try` block is an `assert*()` (that is not a noop:
+    `assertFalse(false)`, `assertTrue(true))` or `Mockito.verify()` call.

--- a/docs/bugpattern/MissingOverride.md
+++ b/docs/bugpattern/MissingOverride.md
@@ -5,7 +5,7 @@ and an interface method respecifying a superinterface method.
 
 Exception: `@Override` may be omitted when the parent method is `@Deprecated`.
 If the flag `-XepOpt:MissingOverride:IgnoreInterfaceOverrides=true` is used,
-`@Override` can be omitted for an interface method respecifying a
-superinterface method.
+`@Override` can be omitted for an interface method respecifying a superinterface
+method.
 
 [style]: https://google.github.io/styleguide/javaguide.html#s6.1-override-annotation

--- a/docs/bugpattern/MockitoCast.md
+++ b/docs/bugpattern/MockitoCast.md
@@ -1,29 +1,26 @@
-The JDK9 javac fixes a bug ([JDK-8058199]
-(https://bugs.openjdk.java.net/browse/JDK-8058199)) that was causing checkcast
-instructions to sometimes be skipped. Previously javac used the parameter types
-of a method symbol's erased type as targets when translating the arguments. In
-JDK 9, javac has been fixed to use the inferred types as targets. The fix causes
-additional checkcasts to be generated if the inferred types do not have the same
-erasure.
+The JDK9 javac fixes a bug
+([JDK-8058199](https://bugs.openjdk.java.net/browse/JDK-8058199)) that was
+causing checkcast instructions to sometimes be skipped. Previously javac used
+the parameter types of a method symbol's erased type as targets when translating
+the arguments. In JDK 9, javac has been fixed to use the inferred types as
+targets. The fix causes additional checkcasts to be generated if the inferred
+types do not have the same erasure.
 
 The fix breaks Mockito answer strategies that pick types based on the erased
 method signature's return type, and causes tests to fail with
 ClassCastExceptions when compiled with the JDK 9 javac.
 
-This check is a work-around until the Mockito bug is fixed: [mockito#357]
-(https://github.com/mockito/mockito/issues/357)
+This check is a work-around until the Mockito bug is fixed:
+[mockito#357](https://github.com/mockito/mockito/issues/357)
 
 The affected answer strategies include:
 
-*   [`RETURNS_DEEP_STUBS`]
-    (http://site.mockito.org/mockito/docs/current/org/mockito/Mockito.html#RETURNS_DEEP_STUBS)
-*   [`RETURNS_MOCKS`]
-    (http://site.mockito.org/mockito/docs/current/org/mockito/Mockito.html#RETURNS_MOCKS)
-*   [`RETURNS_SMART_NULLS`]
-    (http://site.mockito.org/mockito/docs/current/org/mockito/Mockito.html#RETURNS_SMART_NULLS)
+*   [`RETURNS_DEEP_STUBS`](http://site.mockito.org/mockito/docs/current/org/mockito/Mockito.html#RETURNS_DEEP_STUBS)
+*   [`RETURNS_MOCKS`](http://site.mockito.org/mockito/docs/current/org/mockito/Mockito.html#RETURNS_MOCKS)
+*   [`RETURNS_SMART_NULLS`](http://site.mockito.org/mockito/docs/current/org/mockito/Mockito.html#RETURNS_SMART_NULLS)
 
-The [`RETURNS_DEFAULTS`]
-(http://site.mockito.org/mockito/docs/current/org/mockito/Mockito.html#RETURNS_DEFAULTS)
+The
+[`RETURNS_DEFAULTS`](http://site.mockito.org/mockito/docs/current/org/mockito/Mockito.html#RETURNS_DEFAULTS)
 strategy is usually unaffected, because it returns `null` as the default value
 of methods that return `Object`, and unbounded type parameters erase to
 `Object`.

--- a/docs/bugpattern/MockitoInternalUsage.md
+++ b/docs/bugpattern/MockitoInternalUsage.md
@@ -1,7 +1,7 @@
-Classes under `org.mockito.internal.*` are internal implementation details and are
-not part of Mockito's public API. Mockito team does not support them, and they
-may change at any time. Depending on them may break your code when you upgrade
-to new versions of Mockito.
+Classes under `org.mockito.internal.*` are internal implementation details and
+are not part of Mockito's public API. Mockito team does not support them, and
+they may change at any time. Depending on them may break your code when you
+upgrade to new versions of Mockito.
 
 This checker ensures that your code will not break with future Mockito upgrades.
 Mockito's public API is documented at

--- a/docs/bugpattern/MockitoUsage.md
+++ b/docs/bugpattern/MockitoUsage.md
@@ -1,5 +1,5 @@
-Calls to `Mockito.when` should always be accompanied by a call to a method
-like `thenReturn`.
+Calls to `Mockito.when` should always be accompanied by a call to a method like
+`thenReturn`.
 
 ```java
 when(mock.get()).thenReturn(answer); // correct

--- a/docs/bugpattern/MutableMethodReturnType.md
+++ b/docs/bugpattern/MutableMethodReturnType.md
@@ -1,7 +1,7 @@
 For method return type, you should use the immutable type (such as
 `ImmutableList`) instead of the general collection interface type (such as
-`List`). This communicates to your callers important [semantic
-guarantees][javadoc].
+`List`). This communicates to your callers important
+[semantic guarantees][javadoc].
 
 This is consistent with [Effective Java Item 52][ej52], which says to refer to
 objects by their interfaces. Guava's immutable collection classes offer

--- a/docs/bugpattern/NarrowingCompoundAssignment.md
+++ b/docs/bugpattern/NarrowingCompoundAssignment.md
@@ -4,10 +4,10 @@ automatically cast the result of the computation to the type on the left hand
 side. So `E1 op= E2` is actually equivalent to `E1 = (T) (E1 op E2)`, where `T`
 is the type of `E1`.
 
-If the type of the expression is wider than the type of the
-variable (i.e. the variable is a byte, char, short, or float), then the
-compound assignment will perform a narrowing primitive conversion. Attempting
-to perform the equivalent simple assignment would generate a compilation error.
+If the type of the expression is wider than the type of the variable (i.e. the
+variable is a byte, char, short, or float), then the compound assignment will
+perform a narrowing primitive conversion. Attempting to perform the equivalent
+simple assignment would generate a compilation error.
 
 For example, the following does not compile:
 
@@ -25,9 +25,9 @@ byte b = 0;
 b <<= 1;
 ```
 
-Similarly, if the expression is a floating point type (float or double),
-and the variable is an integral type (long, int, short, byte, or char), then
-an implicit conversion will be performed.
+Similarly, if the expression is a floating point type (float or double), and the
+variable is an integral type (long, int, short, byte, or char), then an implicit
+conversion will be performed.
 
 Example:
 

--- a/docs/bugpattern/NonCanonicalStaticImport.md
+++ b/docs/bugpattern/NonCanonicalStaticImport.md
@@ -1,21 +1,21 @@
-Types should always be imported by their canonical name. The canonical name of
-a top-level class is the fully-qualified name of the package, followed by a
-'.', followed by the name of the class. The canonical name of a member class is
-the canonical name of its declaring class, followed by a '.', followed by the
-name of the member class.
+Types should always be imported by their canonical name. The canonical name of a
+top-level class is the fully-qualified name of the package, followed by a '.',
+followed by the name of the class. The canonical name of a member class is the
+canonical name of its declaring class, followed by a '.', followed by the name
+of the member class.
 
-Fully-qualified member class names are not guaranteed to be canonical.
-Consider some member class M declared in a class C. There may be another class
-D that extends C and inherits M.  Therefore M can be accessed using the
-fully-qualified name of D, followed by a '.', followed by 'M'. Since M is not
-declared in D, this name is not canonical.
+Fully-qualified member class names are not guaranteed to be canonical. Consider
+some member class M declared in a class C. There may be another class D that
+extends C and inherits M. Therefore M can be accessed using the fully-qualified
+name of D, followed by a '.', followed by 'M'. Since M is not declared in D,
+this name is not canonical.
 
 The JLS §7.5.3 requires all single static imports to *start* with a canonical
 type name, but the fully-qualified name of the imported member is not required
 to be canonical.
 
-Importing types using non-canonical names is unnecessary and unclear, and
-should be avoided.
+Importing types using non-canonical names is unnecessary and unclear, and should
+be avoided.
 
 Example:
 

--- a/docs/bugpattern/NonCanonicalStaticMemberImport.md
+++ b/docs/bugpattern/NonCanonicalStaticMemberImport.md
@@ -6,10 +6,10 @@ followed by the name of the member class. The canonical name of a field or
 method is the canonical name of the type it is declared in, followed by a `.`,
 followed by the name of the field or method.
 
-Fully-qualified names are not necessarily canonical.  Consider some field `f`
+Fully-qualified names are not necessarily canonical. Consider some field `f`
 declared in a class `C`. There may be another class `D` that extends `C` and
-inherits `f`.  Therefore `f` can be accessed using the fully-qualified name `D.f`.
-Since `f` is not declared in `D`, this name is not canonical.
+inherits `f`. Therefore `f` can be accessed using the fully-qualified name
+`D.f`. Since `f` is not declared in `D`, this name is not canonical.
 
 The JLS §7.5.3 requires all single static imports to *start* with a canonical
 type name, but the fully-qualified name of the imported member is not required

--- a/docs/bugpattern/NonOverridingEquals.md
+++ b/docs/bugpattern/NonOverridingEquals.md
@@ -1,5 +1,5 @@
 Defining a method that looks like `Object#equals` but doesn't actually override
-`Object#equals` is dangerous.  The result of the comparison could differ
+`Object#equals` is dangerous. The result of the comparison could differ
 depending on the declared type of the argument passed into the `equals` call.
 
 For example, consider this code:
@@ -24,17 +24,16 @@ public class Example {
 }
 ```
 
-This will print `true`.  Suppose you refactor it so that the variable
-`exampleB` is declared as an `Object` instead.  Now this code will print 
-`false`, because Java's overload resolution will choose the default 
-`equals(Object)` implementation instead of the `equals(Example)` method defined 
-in this class.
+This will print `true`. Suppose you refactor it so that the variable `exampleB`
+is declared as an `Object` instead. Now this code will print `false`, because
+Java's overload resolution will choose the default `equals(Object)`
+implementation instead of the `equals(Example)` method defined in this class.
 
-If this equals method is intended to be a type-specific helper for an `equals` 
-method that *does* override `Object#equals`, either inline it into the 
-overriding `equals` method or rename it to something other than `equals` to 
+If this equals method is intended to be a type-specific helper for an `equals`
+method that *does* override `Object#equals`, either inline it into the
+overriding `equals` method or rename it to something other than `equals` to
 avoid ambiguity in overload resolution.
 
-If you don't want to write and maintain `equals` and `hashCode` methods 
-by hand, consider rewriting this class to use [AutoValue]
-(https://github.com/google/auto/tree/master/value).
+If you don't want to write and maintain `equals` and `hashCode` methods by hand,
+consider rewriting this class to use
+[AutoValue](https://github.com/google/auto/tree/master/value).

--- a/docs/bugpattern/ObjectsHashCodePrimitive.md
+++ b/docs/bugpattern/ObjectsHashCodePrimitive.md
@@ -4,10 +4,10 @@ Object reference.
 
 Passing a primitive value to `Objects.hashCode` function results in boxing the
 primitive, then calling the boxed object's `hashCode`. You can get the same
-result by using, e.g.: `Long.hashCode(long)` to get the effective hash code
-of a primitive `long`. If you're calling this method outside of your own 
-`hashCode()` implementation, prefer to use the `BoxedClass.hashCode(primitive)`
-functions to avoid unwanted boxed.
+result by using, e.g.: `Long.hashCode(long)` to get the effective hash code of a
+primitive `long`. If you're calling this method outside of your own `hashCode()`
+implementation, prefer to use the `BoxedClass.hashCode(primitive)` functions to
+avoid unwanted boxed.
 
 If you're implementing a `hashCode` function for your **own** class that
 consists of a single primitive value, you may want to consider some of these

--- a/docs/bugpattern/OverlappingQualifierAndScopeAnnotation.md
+++ b/docs/bugpattern/OverlappingQualifierAndScopeAnnotation.md
@@ -35,6 +35,6 @@ day, as the `@Provides` method applies the `DayScoped` scoping only to the
 `@DayScoped Allowance`. Instead, the default constructor of `Allowance` is used
 to create a new instance every time a `Spender` is created.
 
-If `@DayScope` wasn't a `Qualifier`, the provider method would do the
-right thing: the un-annotated `Announce` binding would be scoped to DayScope,
+If `@DayScope` wasn't a `Qualifier`, the provider method would do the right
+thing: the un-annotated `Announce` binding would be scoped to DayScope,
 implemented by a single `DailyAllowance` instance per day.

--- a/docs/bugpattern/PackageLocation.md
+++ b/docs/bugpattern/PackageLocation.md
@@ -18,5 +18,5 @@ for example:
 package com.google.my.pkg;
 ```
 
-Note that package annotations must be located in a `package-info.java` file
-that must be built together with the package.
+Note that package annotations must be located in a `package-info.java` file that
+must be built together with the package.

--- a/docs/bugpattern/QualifierWithTypeUse.md
+++ b/docs/bugpattern/QualifierWithTypeUse.md
@@ -12,5 +12,6 @@ type annotations in this context, so the above code is equivalent to:
 @Inject Foo(List<String> strings)
 ```
 
+
 [`TYPE_PARAMETER`]: https://docs.oracle.com/javase/8/docs/api/java/lang/annotation/ElementType.html#TYPE_PARAMETER
 [`TYPE_USE`]: https://docs.oracle.com/javase/8/docs/api/java/lang/annotation/ElementType.html#TYPE_USE

--- a/docs/bugpattern/ReferenceEquality.md
+++ b/docs/bugpattern/ReferenceEquality.md
@@ -80,4 +80,3 @@ using the normal `equals` method.
 ### So how can I put a special "nothing" value in my map?
 
 Use `Optional<V>` as the value type of your map instead.
-

--- a/docs/bugpattern/StaticGuardedByInstance.md
+++ b/docs/bugpattern/StaticGuardedByInstance.md
@@ -38,6 +38,5 @@ synchronized (Test.class) {
 ```
 
 To update a static counter from an instance method, consider using
-[`AtomicInteger`]
-(https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/AtomicInteger.html)
+[`AtomicInteger`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/AtomicInteger.html)
 instead of incrementing a static `int` field.

--- a/docs/bugpattern/StaticOrDefaultInterfaceMethod.md
+++ b/docs/bugpattern/StaticOrDefaultInterfaceMethod.md
@@ -1,7 +1,7 @@
 Static and default interface methods are not natively supported on Android
 versions earlier than 7.0. Enable this check for compatibility with older
-devices. See [Android Java 8
-Documentation](https://developer.android.com/guide/platform/j8-jack.html).
+devices. See
+[Android Java 8 Documentation](https://developer.android.com/guide/platform/j8-jack.html).
 
 
 ## Suppression

--- a/docs/bugpattern/StringSplit.md
+++ b/docs/bugpattern/StringSplit.md
@@ -27,8 +27,7 @@ Prefer either:
     handling of empty strings and the trimming of whitespace with `trimResults`
     and `omitEmptyStrings`.
 
-*   [`String.split(String,
-    int)`](https://docs.oracle.com/javase/9/docs/api/java/lang/String.html#split-java.lang.String-int-)
+*   [`String.split(String, int)`](https://docs.oracle.com/javase/9/docs/api/java/lang/String.html#split-java.lang.String-int-)
     and setting an explicit 'limit' to `-1` to match the behaviour of
     `Splitter`.
 

--- a/docs/bugpattern/StringSplitter.md
+++ b/docs/bugpattern/StringSplitter.md
@@ -27,8 +27,7 @@ Prefer either:
     handling of empty strings and the trimming of whitespace with `trimResults`
     and `omitEmptyStrings`.
 
-*   [`String.split(String,
-    int)`](https://docs.oracle.com/javase/9/docs/api/java/lang/String.html#split-java.lang.String-int-)
+*   [`String.split(String, int)`](https://docs.oracle.com/javase/9/docs/api/java/lang/String.html#split-java.lang.String-int-)
     and setting an explicit 'limit' to `-1` to match the behaviour of
     `Splitter`.
 

--- a/docs/bugpattern/TruthConstantAsserts.md
+++ b/docs/bugpattern/TruthConstantAsserts.md
@@ -1,3 +1,3 @@
 The arguments to assertThat method is a constant. It should be a variable or a
-method invocation. For eg. switch assertThat(1).isEqualTo(methodCall())
-to assertThat(methodCall()).isEqualTo(1).
+method invocation. For eg. switch assertThat(1).isEqualTo(methodCall()) to
+assertThat(methodCall()).isEqualTo(1).

--- a/docs/bugpattern/TruthSelfEquals.md
+++ b/docs/bugpattern/TruthSelfEquals.md
@@ -6,7 +6,7 @@ are the same instance.
 
 [`Objects#equals`]: https://google.github.io/guava/releases/21.0/api/docs/com/google/common/base/Objects.html#equal-java.lang.Object-java.lang.Object-
 
-To test the implementation of an `equals` method, use [Guava's
-EqualsTester][javadoc].
+To test the implementation of an `equals` method, use
+[Guava's EqualsTester][javadoc].
 
 [javadoc]: http://static.javadoc.io/com.google.guava/guava-testlib/21.0/com/google/common/testing/EqualsTester.html

--- a/docs/bugpattern/TypeEqualsChecker.md
+++ b/docs/bugpattern/TypeEqualsChecker.md
@@ -1,11 +1,11 @@
 [`TypeMirror`](https://docs.oracle.com/en/java/javase/11/docs/api/java.compiler/javax/lang/model/type/TypeMirror.html)
- doesn't override `Object.equals` and instances
-are not interned by javac, so testing types for equality should be done with
-[`Types#isSameType`](https://docs.oracle.com/en/java/javase/11/docs/api/java.compiler/javax/lang/model/util/Types.html#isSameType(javax.lang.model.type.TypeMirror,javax.lang.model.type.TypeMirror))
+doesn't override `Object.equals` and instances are not interned by javac, so
+testing types for equality should be done with
+[`Types#isSameType`](https://docs.oracle.com/en/java/javase/11/docs/api/java.compiler/javax/lang/model/util/Types.html#isSameType\(javax.lang.model.type.TypeMirror,javax.lang.model.type.TypeMirror\))
 instead.
 
 If you're implementing an Error Prone `BugChecker`, you can get a `Types`
 instance from `VisitorState`.
 
-If you're implementing `AnnotationProcessor`, you can get the `Types`
-instance from `javax.annotation.processing.ProcessingEnvironment`.
+If you're implementing `AnnotationProcessor`, you can get the `Types` instance
+from `javax.annotation.processing.ProcessingEnvironment`.

--- a/docs/bugpattern/TypeParameterQualifier.md
+++ b/docs/bugpattern/TypeParameterQualifier.md
@@ -13,5 +13,5 @@ Is identical to the following:
 static <T extends Message> T populate(Message.Builder builder) {}
 ```
 
-The use of `T.Builder` is unnecessary and misleading, so referring to the
-type by its canonical name should always be preferred.
+The use of `T.Builder` is unnecessary and misleading, so referring to the type
+by its canonical name should always be preferred.

--- a/docs/bugpattern/TypeParameterShadowing.md
+++ b/docs/bugpattern/TypeParameterShadowing.md
@@ -11,8 +11,9 @@ public class Foo<T> {
 }
 ```
 
-In some cases, the type variable being declared has no relation to the type variable being shadowed.
-It may be appropriate to rename the shadowing type variable:
+In some cases, the type variable being declared has no relation to the type
+variable being shadowed. It may be appropriate to rename the shadowing type
+variable:
 
 ```java
 class Logger<T> {
@@ -21,9 +22,9 @@ class Logger<T> {
 }
 ```
 
-Depending on the nature of the surrounding code, you might be able to remove the generic declaration
-on a method, or convert the generic method into a static method that doesn't inherit the surrounding
-type parameter:
+Depending on the nature of the surrounding code, you might be able to remove the
+generic declaration on a method, or convert the generic method into a static
+method that doesn't inherit the surrounding type parameter:
 
 ```java
 class Holder<T> {
@@ -37,8 +38,8 @@ class Holder<T> {
 }
 ```
 
-If an inner class declaration shadows a type variable, you may be able to remove the type variable,
-make it a static inner class, or rename the type variable:
+If an inner class declaration shadows a type variable, you may be able to remove
+the type variable, make it a static inner class, or rename the type variable:
 
 ```java
 class BoxingBox<T> {
@@ -54,4 +55,3 @@ class BoxingBox<T> {
   }
 }
 ```
-

--- a/docs/bugpattern/TypeParameterUnusedInFormals.md
+++ b/docs/bugpattern/TypeParameterUnusedInFormals.md
@@ -1,7 +1,7 @@
-A method's type parameters should always be referenced in the declaration of
-one or more formal parameters. Type parameters that are only used in the return
-type are a source of type-unsafety.  First, operations on the type will be
-unchecked after the type parameter is erased. For example:
+A method's type parameters should always be referenced in the declaration of one
+or more formal parameters. Type parameters that are only used in the return type
+are a source of type-unsafety. First, operations on the type will be unchecked
+after the type parameter is erased. For example:
 
     static <T> T doCast(Object o) {
       return (T) o; // this will always succeed, since T is erased

--- a/docs/bugpattern/UnnecessaryDefaultInEnumSwitch.md
+++ b/docs/bugpattern/UnnecessaryDefaultInEnumSwitch.md
@@ -4,10 +4,10 @@ below the switch from any of the non-default statement groups.
 
 TIP: Removing the unnecessary default allows Error Prone to enforce that the
 switch continues to handle all cases, even if new values are added to the enum,
-see: [MissingCasesInEnumSwitch](MissingCasesInEnumSwitch.md). After the unnecessary
-default is removed, Error Prone will report an error if new enum constants are
-added in the future, to remind you to either handle the cases explicitly or
-restore the default case.
+see: [MissingCasesInEnumSwitch](MissingCasesInEnumSwitch.md). After the
+unnecessary default is removed, Error Prone will report an error if new enum
+constants are added in the future, to remind you to either handle the cases
+explicitly or restore the default case.
 
 ## When the default can be removed
 

--- a/docs/bugpattern/UnsafeFinalization.md
+++ b/docs/bugpattern/UnsafeFinalization.md
@@ -37,9 +37,9 @@ public class GameLibrary {
 }
 ```
 
-During the execution of `GameRunner.run`, the call to `playGame` may not
-hold the `this` reference live, and its finalizer may run, cleaning up the
-native resources while the native code is still executing.
+During the execution of `GameRunner.run`, the call to `playGame` may not hold
+the `this` reference live, and its finalizer may run, cleaning up the native
+resources while the native code is still executing.
 
 You can fix this by making the `static native` method not `static`, or by
 changing the `static native` method so that it is passed the enclosing instance
@@ -66,8 +66,6 @@ object instead.
 
 ## References
 
-*   [Boehm, "Destructors, finalizers, and synchronization." POPL
-    2003.](http://www.hpl.hp.com/techreports/2002/HPL-2002-335.html) Section 3.4
-    discusses this problem.
-*   [Java Language Specification 12.6.2, "Interaction with the Memory
-    Model."](https://docs.oracle.com/javase/specs/jls/se9/html/jls-12.html#jls-12.6.2)
+*   [Boehm, "Destructors, finalizers, and synchronization." POPL 2003.](http://www.hpl.hp.com/techreports/2002/HPL-2002-335.html)
+    Section 3.4 discusses this problem.
+*   [Java Language Specification 12.6.2, "Interaction with the Memory Model."](https://docs.oracle.com/javase/specs/jls/se9/html/jls-12.html#jls-12.6.2)

--- a/docs/bugpattern/UnsynchronizedOverridesSynchronized.md
+++ b/docs/bugpattern/UnsynchronizedOverridesSynchronized.md
@@ -30,8 +30,8 @@ Note that there are many ways to implement a thread-safe method without using
 the `synchronized` modifier (e.g. `synchronized` statements using explicit
 locks, or other locking constructs). When overriding a `synchronized` method
 with a method that is thread-safe but does not have the `synchronized` modifier,
-consider adding `@SuppressWarnings("UnsynchronizedOverridesSynchronized")`
-and an explanation.
+consider adding `@SuppressWarnings("UnsynchronizedOverridesSynchronized")` and
+an explanation.
 
 ```java
 class MyCounter extends Counter {

--- a/docs/bugpattern/UnusedAnonymousClass.md
+++ b/docs/bugpattern/UnusedAnonymousClass.md
@@ -1,5 +1,5 @@
-Creating a side-effect-free anonymous class and never using it is usually
-a mistake.
+Creating a side-effect-free anonymous class and never using it is usually a
+mistake.
 
 For example:
 

--- a/docs/bugpattern/WaitNotInLoop.md
+++ b/docs/bugpattern/WaitNotInLoop.md
@@ -1,14 +1,14 @@
 `Object.wait()` is supposed to block until either another thread invokes the
-`Object.notify()` or `Object.notifyAll()` method, or a specified amount of 
-time has elapsed.  The various `Condition.await()` methods have similar 
-behavior.  However, it is possible for a thread to wake up without either of
-those occurring; these are called *spurious wakeups*.
+`Object.notify()` or `Object.notifyAll()` method, or a specified amount of time
+has elapsed. The various `Condition.await()` methods have similar behavior.
+However, it is possible for a thread to wake up without either of those
+occurring; these are called *spurious wakeups*.
 
-Because of spurious wakeups, `Object.wait()` and `Condition.await()` must 
-always be called in a loop.  The correct fix for this varies depending on what
-you are trying to do.
+Because of spurious wakeups, `Object.wait()` and `Condition.await()` must always
+be called in a loop. The correct fix for this varies depending on what you are
+trying to do.
 
-## Wait until a condition becomes true 
+## Wait until a condition becomes true
 
 The incorrect code for this typically looks like:
 
@@ -32,9 +32,9 @@ synchronized (this) {
 }
 ```
 
-If the call to `wait()` unblocks because of a spurious wakeup, then 
-`doStuffAssumingConditionIsTrue()` will be called even though `condition`
-is still false.  Instead of the `if`, you should use a `while`:
+If the call to `wait()` unblocks because of a spurious wakeup, then
+`doStuffAssumingConditionIsTrue()` will be called even though `condition` is
+still false. Instead of the `if`, you should use a `while`:
 
 Thread 1:
 
@@ -46,13 +46,13 @@ synchronized (this) {
   doStuffAssumingConditionIsTrue();
 }
 ```
- 
+
 This ensures that you only proceed to `doStuffAssumingConditionIsTrue()` if
-`condition` is true.  Note that the check of the condition variable must be
+`condition` is true. Note that the check of the condition variable must be
 inside the synchronized block; otherwise you will have a race condition between
 checking and setting the condition variable.
 
-## Wait until an event occurs 
+## Wait until an event occurs
 
 The incorrect code for this typically looks like:
 
@@ -74,13 +74,12 @@ synchronized (this) {
 }
 ```
 
-If the call to `wait()` unblocks because of a spurious wakeup, then 
-`doStuffAfterEvent()` will be called even though the event has not yet
-occurred.  You should rewrite this code so that the occurrence of the
-event sets a condition variable as well as calls `notify()`, and the
-`wait()` is wrapped in a while loop checking the condition variable.
-That is, it should look just like [the previous example]
-(#wait_until_a_condition_becomes_true).
+If the call to `wait()` unblocks because of a spurious wakeup, then
+`doStuffAfterEvent()` will be called even though the event has not yet occurred.
+You should rewrite this code so that the occurrence of the event sets a
+condition variable as well as calls `notify()`, and the `wait()` is wrapped in a
+while loop checking the condition variable. That is, it should look just like
+[the previous example](#wait_until_a_condition_becomes_true).
 
 ## Wait until either a condition becomes true or a timeout occurs
 
@@ -115,10 +114,10 @@ synchronized (this) {
 ## Wait for a fixed amount of time
 
 First, a warning: This type of waiting/sleeping is often done when the real
-intent is to wait until some operation completes, and then proceed.  If that's
-what you're trying to do, please consider rewriting your code to use one of
-the patterns above.  Otherwise you are depending on system-specific timing
-that *will* change when you run on different machines. 
+intent is to wait until some operation completes, and then proceed. If that's
+what you're trying to do, please consider rewriting your code to use one of the
+patterns above. Otherwise you are depending on system-specific timing that
+*will* change when you run on different machines.
 
 The incorrect code for this typically looks like:
 
@@ -129,8 +128,8 @@ synchronized (this) {
 }
 ```
 
-A spurious wakeup could cause this not to wait for a full 1000 ms.  Instead,
-you should use `Thread.sleep()`, which is not subject to spurious wakeups:
+A spurious wakeup could cause this not to wait for a full 1000 ms. Instead, you
+should use `Thread.sleep()`, which is not subject to spurious wakeups:
 
 ```java
 Thread.sleep(1000);
@@ -147,8 +146,8 @@ synchronized (this) {
 }
 ```
 
-A spurious wakeup could cause this not to wait forever.  You should wrap the
-call to `wait()` in a `while (true)` loop:
+A spurious wakeup could cause this not to wait forever. You should wrap the call
+to `wait()` in a `while (true)` loop:
 
 ```java
 synchronized (this) {
@@ -161,7 +160,7 @@ synchronized (this) {
 
 ## More information
 
-See Java Concurrency in Practice section 14.2.2, "Waking up too soon," [the Javadoc for 
-`Object.wait()`](http://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait-long-),
-and the "Implementation Considerations" section in [the Javadoc for `Condition`]
-(https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/locks/Condition.html).
+See Java Concurrency in Practice section 14.2.2, "Waking up too soon,"
+[the Javadoc for `Object.wait()`](http://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#wait-long-),
+and the "Implementation Considerations" section in
+[the Javadoc for `Condition`](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/locks/Condition.html).

--- a/docs/bugpattern/WildcardImport.md
+++ b/docs/bugpattern/WildcardImport.md
@@ -1,14 +1,13 @@
 Wildcard imports are forbidden by §3.3.1 of the Google Java Style Guide.
 
 They make code brittle and difficult to reason about, both for programmers and
-for tools. In the following example, the processing of the first import
-requires reasoning about the classes `Outer` and `Nested`, including their
-supertypes, and ends up depending on information in the second import
-statement. This code is (incorrectly) rejected by the latest version of javac.
-Also, note that `I` is actually being imported via the name `p.q.C.I` even
-though it's not declared in `C`! Its canonical name is `p.q.D.I`. Regular
-single-type imports require that all types are imported by their canonical
-name, but static imports do not.
+for tools. In the following example, the processing of the first import requires
+reasoning about the classes `Outer` and `Nested`, including their supertypes,
+and ends up depending on information in the second import statement. This code
+is (incorrectly) rejected by the latest version of javac. Also, note that `I` is
+actually being imported via the name `p.q.C.I` even though it's not declared in
+`C`! Its canonical name is `p.q.D.I`. Regular single-type imports require that
+all types are imported by their canonical name, but static imports do not.
 
 ```java
 package p;

--- a/docs/bugpattern/android/BinderIdentityRestoredDangerously.md
+++ b/docs/bugpattern/android/BinderIdentityRestoredDangerously.md
@@ -1,23 +1,13 @@
-Binder is Android's inter-process communication mechanism.
-Each call to `Binder.clearCallingIdentity()` should be followed by
-`Binder.restoreCallingIdentity()` in a finally block. Otherwise the wrong
-Binder identity may be used by subsequent code.
+Binder is Android's inter-process communication mechanism. Each call to
+`Binder.clearCallingIdentity()` should be followed by
+`Binder.restoreCallingIdentity()` in a finally block. Otherwise the wrong Binder
+identity may be used by subsequent code.
 
-For example:
-```java
-long token = Binder.clearCallingIdentity();
-// Issue a Binder call (may throw an Exception).
-someBinderInterface.makeCall();
-Binder.restoreCallingIdentity(token);
-```
+For example: `java long token = Binder.clearCallingIdentity(); // Issue a Binder
+call (may throw an Exception). someBinderInterface.makeCall();
+Binder.restoreCallingIdentity(token);`
 
-The above code should be rewritten as:
-```java
-long token = Binder.clearCallingIdentity();
-try {
-  // Issue a Binder call (may throw an Exception).
-  someBinderInterface.makeCall();
-} finally {
-  Binder.restoreCallingIdentity(token);
-}
-```
+The above code should be rewritten as: `java long token =
+Binder.clearCallingIdentity(); try { // Issue a Binder call (may throw an
+Exception). someBinderInterface.makeCall(); } finally {
+Binder.restoreCallingIdentity(token); }`

--- a/docs/bugpattern/android/FragmentNotInstantiable.md
+++ b/docs/bugpattern/android/FragmentNotInstantiable.md
@@ -1,17 +1,16 @@
-Every subclass of `Fragment` must be public and have a public, nullary 
-constructor. The Android framework will reflectively instantiate them after
-a configuration change, such as screen rotation, and if the class is not
+Every subclass of `Fragment` must be public and have a public, nullary
+constructor. The Android framework will reflectively instantiate them after a
+configuration change, such as screen rotation, and if the class is not
 instantiable by `Class#newInstance()`, an `InstantiationException` will be
 thrown.
 
 In addition, it is strongly recommended that subclasses not have other
-constructors with parameters, since these constructors will not be called 
-when the fragment is re-instantiated; instead, arguments should be supplied 
-with `setArguments(Bundle)` and retrieved with `getArguments()`.
- 
+constructors with parameters, since these constructors will not be called when
+the fragment is re-instantiated; instead, arguments should be supplied with
+`setArguments(Bundle)` and retrieved with `getArguments()`.
 
-For more information, please see the documentation for [Fragment]
-(http://developer.android.com/reference/android/app/Fragment.html#Fragment()).
+For more information, please see the documentation for
+[Fragment](http://developer.android.com/reference/android/app/Fragment.html#Fragment\(\)).
 
-This check is an adaptation of the `ValidFragment` rule of [Android Lint]
-(http://tools.android.com/tips/lint-checks).
+This check is an adaptation of the `ValidFragment` rule of
+[Android Lint](http://tools.android.com/tips/lint-checks).

--- a/docs/bugpattern/android/HardCodedSdCardPath.md
+++ b/docs/bugpattern/android/HardCodedSdCardPath.md
@@ -2,14 +2,13 @@ Your code should not reference the `/sdcard` path directly, which is
 platform-dependent. You should use
 `Environment.getExternalStorageDirectory().getPath()` instead.
 
-Similarly, do not reference the `/data/data/` path directly, as it can vary
-in multi-user scenarios. You should use `Context.getFilesDir().getPath()`
-instead.
+Similarly, do not reference the `/data/data/` path directly, as it can vary in
+multi-user scenarios. You should use `Context.getFilesDir().getPath()` instead.
 
-For more information, please see the documentation for [android.os.Environment]
-(http://developer.android.com/reference/android/os/Environment.html)
-and [android.content.Context]
-(http://developer.android.com/reference/android/content/Context.html).
+For more information, please see the documentation for
+[android.os.Environment](http://developer.android.com/reference/android/os/Environment.html)
+and
+[android.content.Context](http://developer.android.com/reference/android/content/Context.html).
 
-This check is an adaptation of the `SdCardPath` rule of [Android Lint]
-(http://tools.android.com/tips/lint-checks).
+This check is an adaptation of the `SdCardPath` rule of
+[Android Lint](http://tools.android.com/tips/lint-checks).

--- a/docs/bugpattern/android/ParcelableCreator.md
+++ b/docs/bugpattern/android/ParcelableCreator.md
@@ -1,11 +1,12 @@
-Classes implementing [`android.os.Parcelable`](https://developer.android.com/reference/android/os/Parcelable.html)
-must also have a non-`null` static field called `CREATOR` of a type that implements
-`Parcelable.Creator`.
+Classes implementing
+[`android.os.Parcelable`](https://developer.android.com/reference/android/os/Parcelable.html)
+must also have a non-`null` static field called `CREATOR` of a type that
+implements `Parcelable.Creator`.
 
-Classes which don't follow this spec will compile fine but might not work in Android runtime.
-Depending on platform, one will observe following crash at runtime :
-`android.os.BadParcelableException: Parcelable protocol requires a Parcelable.Creator object called
-CREATOR`
+Classes which don't follow this spec will compile fine but might not work in
+Android runtime. Depending on platform, one will observe following crash at
+runtime : `android.os.BadParcelableException: Parcelable protocol requires a
+Parcelable.Creator object called CREATOR`
 
 A typical example of correct implementation:
 

--- a/docs/bugpattern/android/WakelockReleasedDangerously.md
+++ b/docs/bugpattern/android/WakelockReleasedDangerously.md
@@ -25,8 +25,8 @@ ineffectual and misleading.
 To prevent crashes like this, `WakeLock`s acquired with timeout should be
 released *only in a `try/catch(RuntimeException)` block*.
 
-This does not hold for `WakeLock`s that are [not reference
-counted](https://android.googlesource.com/platform/frameworks/base/+/nougat-release/core/java/android/os/PowerManager.java#1267).
+This does not hold for `WakeLock`s that are
+[not reference counted](https://android.googlesource.com/platform/frameworks/base/+/nougat-release/core/java/android/os/PowerManager.java#1267).
 `WakeLock`s are reference counted by default, but if
 `setReferenceCounted(false)` has been called on the `WakeLock` in question, the
 OS does not check whether the `WakeLock` has been released too many times, and

--- a/docs/bugpattern/inject/InjectOnMemberAndConstructor.md
+++ b/docs/bugpattern/inject/InjectOnMemberAndConstructor.md
@@ -1,6 +1,6 @@
 When a class uses `@Inject` on a field, and that field is also assigned from an
-`@Inject` constructor, then the field is assigned twice from the DI Injector. This
-may result in 2 objects being created, where the first instance is assigned then
-thrown away after the second injection.
+`@Inject` constructor, then the field is assigned twice from the DI Injector.
+This may result in 2 objects being created, where the first instance is assigned
+then thrown away after the second injection.
 
 A simple solution is to remove the `@Inject` annotation from the injected field.

--- a/examples/plugin/bazel/java/com/google/errorprone/sample/MyCustomCheck.java
+++ b/examples/plugin/bazel/java/com/google/errorprone/sample/MyCustomCheck.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.sample;
 
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -49,7 +48,6 @@ import java.util.Objects;
 @AutoService(BugChecker.class)
 @BugPattern(
     name = "MyCustomCheck",
-    category = JDK,
     summary = "String formatting inside print method",
     severity = ERROR,
     linkType = CUSTOM,

--- a/examples/plugin/gradle/sample_plugin/src/main/java/com/google/errorprone/sample/MyCustomCheck.java
+++ b/examples/plugin/gradle/sample_plugin/src/main/java/com/google/errorprone/sample/MyCustomCheck.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.sample;
 
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -49,7 +48,6 @@ import java.util.Objects;
 @AutoService(BugChecker.class)
 @BugPattern(
     name = "MyCustomCheck",
-    category = JDK,
     summary = "String formatting inside print method",
     severity = ERROR,
     linkType = CUSTOM,

--- a/examples/plugin/maven/sample_plugin/src/main/java/com/google/errorprone/sample/MyCustomCheck.java
+++ b/examples/plugin/maven/sample_plugin/src/main/java/com/google/errorprone/sample/MyCustomCheck.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.sample;
 
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -49,7 +48,6 @@ import java.util.Objects;
 @AutoService(BugChecker.class)
 @BugPattern(
     name = "MyCustomCheck",
-    category = JDK,
     summary = "String formatting inside print method",
     severity = ERROR,
     linkType = CUSTOM,

--- a/test_helpers/src/test/java/com/google/errorprone/BugCheckerRefactoringTestHelperTest.java
+++ b/test_helpers/src/test/java/com/google/errorprone/BugCheckerRefactoringTestHelperTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static org.junit.Assert.fail;
 
@@ -192,7 +191,6 @@ public class BugCheckerRefactoringTestHelperTest {
       name = "ReturnNullRefactoring",
       summary = "Mock refactoring that replaces all returns with 'return null;' statement.",
       explanation = "For test purposes only.",
-      category = JDK,
       severity = SUGGESTION,
       providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
   public static class ReturnNullRefactoring extends BugChecker implements ReturnTreeMatcher {
@@ -206,7 +204,6 @@ public class BugCheckerRefactoringTestHelperTest {
       name = "RemoveAnnotationRefactoring",
       summary = "Mock refactoring that removes all annotations declared in package bar ",
       explanation = "For test purposes only.",
-      category = JDK,
       severity = SUGGESTION,
       providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
   public static class RemoveAnnotationRefactoring extends BugChecker
@@ -255,7 +252,6 @@ public class BugCheckerRefactoringTestHelperTest {
       name = "ImportArrayList",
       summary = "Mock refactoring that imports an ArrayList",
       explanation = "For test purposes only.",
-      category = JDK,
       severity = SUGGESTION,
       providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
   public static class ImportArrayList extends BugChecker implements CompilationUnitTreeMatcher {

--- a/test_helpers/src/test/java/com/google/errorprone/CompilationTestHelperTest.java
+++ b/test_helpers/src/test/java/com/google/errorprone/CompilationTestHelperTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.errorprone.BugPattern.Category.JDK;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static org.junit.Assert.assertThrows;
@@ -382,7 +381,6 @@ public class CompilationTestHelperTest {
       name = "ReturnTreeChecker",
       summary = "Method may return normally.",
       explanation = "Consider mutating some global state instead.",
-      category = JDK,
       severity = ERROR)
   public static class ReturnTreeChecker extends BugChecker implements ReturnTreeMatcher {
     @Override
@@ -407,7 +405,6 @@ public class CompilationTestHelperTest {
       name = "PackageTreeChecker",
       summary = "Package declaration found",
       explanation = "Prefer to use the default package for everything.",
-      category = JDK,
       severity = ERROR)
   public static class PackageTreeChecker extends BugChecker implements CompilationUnitTreeMatcher {
     @Override
@@ -422,7 +419,6 @@ public class CompilationTestHelperTest {
   @BugPattern(
       name = "ThisCheckerCannotBeInstantiated",
       summary = "A checker that Error Prone can't instantiate.",
-      category = JDK,
       severity = ERROR)
   public static class ThisCheckerCannotBeInstantiated extends BugChecker
       implements CompilationUnitTreeMatcher {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Format documentation

RELNOTES: N/A

459a72be57a290376579977f381c1724bf2ac687

-------

<p> More tests around inferring generic type parameters and their instantiations
RELNOTES: None

d73698b33c81e828f1a4dc308d033dfa288aa350

-------

<p> Ensure that Rx return values are not ignored. If it were to be ignored, it would 99% of the time be a bug.

Initially I had the fix as the default "delete the line", but realistically that isn't the usual fix. It is possible that:

They are using it validly and should add a @CanIgnoreReturnValue if:
- The function does some synchronous before returning an Observable
- The function may return an observable and schedule it itself (via connect() etc)

And then even if it is a bug then the programmer probably would want to keep the line and perform some operation onError/onSuccess.

In no situation is deleting likely the right call.

Here is a CL generated via flume with the delete fix just to show that the bugpattern works properly: []

37de3600bea03a280d7cdb0dccac54da45318f76

-------

<p> Add common java.time types to ReturnValueIgnored.

RELNOTES: Add common java.time types to ReturnValueIgnored.

4abbdb42bca0c20c14ad64e1a44a784181700fd6

-------

<p> Reformat bug checkers

NOW_PROD_CHANGES=N/A
RELNOTES: N/A

af9cfe5b565a32b5a6e6df7cda9b1b13c37a25d9

-------

<p> Remove uses of @BugPattern.category

NOW_PROD_CHANGES=N/A
RELNOTES: N/A

b5adf02cae0edd283921227d42ade3427124d5d9

-------

<p> Make InvalidInlineTag match uses of () to create inline tags rather than {}.

RELNOTES: N/A

108c17e1e5d478794e0744851ef27ec9638e81c1