### PR TITLE
Bundle Guava's failureaccess in the with-dependencies JAR

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -367,6 +367,7 @@
                   <include>com.github.stephenc.jcip:jcip-annotations</include>
                   <include>org.pcollections:pcollections</include>
                   <include>com.google.guava:guava</include>
+                  <include>com.google.guava:failureaccess</include>
                   <include>com.google.auto:auto-common</include>
                   <include>com.google.code.findbugs:jsr305</include>
                   <include>com.google.protobuf:protobuf-java</include>


### PR DESCRIPTION
Fixes #1238