### PR TITLE
Moe Sync

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.39</version>
+      <version>0.44</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -1182,6 +1182,17 @@ public class ASTHelpers {
     }
   }
 
+  /** Returns the value of the {@code @Generated} annotation on the top-level class, if present. */
+  public static ImmutableSet<String> getGeneratedBy(VisitorState state) {
+    ClassTree outerClass = null;
+    for (Tree enclosing : state.getPath()) {
+      if (enclosing instanceof ClassTree) {
+        outerClass = (ClassTree) enclosing;
+      }
+    }
+    return getGeneratedBy(getSymbol(outerClass), state);
+  }
+
   /**
    * Returns the values of the given symbol's {@code javax.annotation.Generated} or {@code
    * javax.annotation.processing.Generated} annotation, if present.

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LiteEnumValueOf.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LiteEnumValueOf.java
@@ -25,6 +25,7 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Type;
@@ -52,6 +53,12 @@ public class LiteEnumValueOf extends BugChecker implements MethodInvocationTreeM
   public Description matchMethodInvocation(
       MethodInvocationTree methodInvocationTree, VisitorState state) {
     if (!PROTO_MSG_VALUE_OF_MATCHER.matches(methodInvocationTree, state)) {
+      return Description.NO_MATCH;
+    }
+    // AutoValue Parcelable generated code uses the API in #createForParcel implementation.
+    // We explicitly suppress the matches.
+    if (ASTHelpers.getGeneratedBy(state)
+        .contains("com.ryanharter.auto.value.parcel.AutoValueParcelExtension")) {
       return Description.NO_MATCH;
     }
     return describeMatch(methodInvocationTree);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OptionalMapToOptional.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OptionalMapToOptional.java
@@ -89,6 +89,10 @@ public final class OptionalMapToOptional extends BugChecker implements MethodInv
       return NO_MATCH;
     }
     List<Type> typeArguments = targetType.type().getTypeArguments();
+    // If the receiving Optional is raw, so will the target type of Function.
+    if (typeArguments.isEmpty()) {
+      return NO_MATCH;
+    }
     Type typeMappedTo = typeArguments.get(1);
     if (!OPTIONAL.apply(typeMappedTo, state)) {
       return NO_MATCH;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryAnonymousClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryAnonymousClass.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.base.CaseFormat.LOWER_CAMEL;
+import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.util.ASTHelpers.getReceiver;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.google.errorprone.util.ASTHelpers.getType;
+import static com.google.errorprone.util.ASTHelpers.isGeneratedConstructor;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePathScanner;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.tree.JCTree;
+import java.util.Objects;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
+
+/**
+ * A {@link BugChecker}; see {@code @BugPattern} for details.
+ *
+ * @author cushon@google.com (Liam Miller-Cushon)
+ */
+@BugPattern(
+    name = "UnnecessaryAnonymousClass",
+    summary =
+        "Implementing a functional interface is unnecessary; prefer to implement the functional"
+            + " interface method directly and use a method reference instead.",
+    severity = WARNING,
+    providesFix = REQUIRES_HUMAN_ATTENTION)
+public class UnnecessaryAnonymousClass extends BugChecker implements VariableTreeMatcher {
+
+  @Override
+  public Description matchVariable(VariableTree tree, VisitorState state) {
+    if (tree.getInitializer() == null) {
+      return NO_MATCH;
+    }
+    if (!(tree.getInitializer() instanceof NewClassTree)) {
+      return NO_MATCH;
+    }
+    NewClassTree classTree = (NewClassTree) tree.getInitializer();
+    if (classTree.getClassBody() == null) {
+      return NO_MATCH;
+    }
+    ImmutableList<? extends Tree> members =
+        classTree.getClassBody().getMembers().stream()
+            .filter(x -> !(x instanceof MethodTree && isGeneratedConstructor((MethodTree) x)))
+            .collect(toImmutableList());
+    if (members.size() != 1) {
+      return NO_MATCH;
+    }
+    Tree member = getOnlyElement(members);
+    if (!(member instanceof MethodTree)) {
+      return NO_MATCH;
+    }
+    Symbol sym = getSymbol(tree);
+    if (sym == null
+        || sym.getKind() != ElementKind.FIELD
+        || !sym.isPrivate()
+        || !sym.getModifiers().contains(Modifier.FINAL)) {
+      return NO_MATCH;
+    }
+    MethodTree implementation = (MethodTree) member;
+    Type type = getType(tree.getType());
+    if (type == null || !state.getTypes().isFunctionalInterface(type)) {
+      return NO_MATCH;
+    }
+    SuggestedFix.Builder fix = SuggestedFix.builder();
+    String name =
+        sym.isStatic()
+            ? UPPER_UNDERSCORE.converterTo(LOWER_CAMEL).convert(tree.getName().toString())
+            : tree.getName().toString();
+    new TreePathScanner<Void, Void>() {
+      @Override
+      public Void visitMemberSelect(MemberSelectTree node, Void unused) {
+        if (Objects.equals(getSymbol(node), sym)) {
+          replaceUseWithMethodReference(fix, node, name, state.withPath(getCurrentPath()));
+        }
+        return super.visitMemberSelect(node, null);
+      }
+
+      @Override
+      public Void visitIdentifier(IdentifierTree node, Void unused) {
+        if (Objects.equals(getSymbol(node), sym)) {
+          replaceUseWithMethodReference(fix, node, name, state.withPath(getCurrentPath()));
+        }
+        return super.visitIdentifier(node, null);
+      }
+    }.scan(state.getPath().getCompilationUnit(), null);
+    SuggestedFixes.removeModifiers(tree, state, Modifier.FINAL).ifPresent(fix::merge);
+    int afterModifiers = state.getEndPosition(implementation.getModifiers());
+    if (afterModifiers == -1) {
+      afterModifiers = ((JCTree) implementation).getStartPosition();
+    }
+    fix.replace(state.getEndPosition(tree.getModifiers()) + 1, afterModifiers, "")
+        .replace(state.getEndPosition(implementation), state.getEndPosition(tree), "")
+        // force reformatting of the method body
+        .replace(implementation.getBody(), state.getSourceForNode(implementation.getBody()))
+        .merge(SuggestedFixes.renameMethod(implementation, name, state));
+    return describeMatch(tree, fix.build());
+  }
+
+  private static void replaceUseWithMethodReference(
+      SuggestedFix.Builder fix, ExpressionTree node, String newName, VisitorState state) {
+    Tree parent = state.getPath().getParentPath().getLeaf();
+    if (parent instanceof MemberSelectTree
+        && ((MemberSelectTree) parent).getExpression().equals(node)) {
+      Tree receiver = node.getKind() == Tree.Kind.IDENTIFIER ? null : getReceiver(node);
+      fix.replace(
+          receiver != null ? state.getEndPosition(receiver) : ((JCTree) node).getStartPosition(),
+          state.getEndPosition(parent),
+          newName);
+    } else {
+      Symbol sym = getSymbol(node);
+      fix.replace(
+          node,
+          String.format(
+              "%s::%s", sym.isStatic() ? sym.owner.enclClass().getSimpleName() : "this", newName));
+    }
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryLambda.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryLambda.java
@@ -37,6 +37,7 @@ import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
@@ -120,6 +121,9 @@ public class UnnecessaryLambda extends BugChecker
         || sym.getKind() != ElementKind.FIELD
         || !sym.isPrivate()
         || !sym.getModifiers().contains(Modifier.FINAL)) {
+      return NO_MATCH;
+    }
+    if (ASTHelpers.hasAnnotation(tree, "com.google.inject.testing.fieldbinder.Bind", state)) {
       return NO_MATCH;
     }
     Tree type = tree.getType();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/NullableDereference.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/NullableDereference.java
@@ -127,10 +127,12 @@ public class NullableDereference extends BugChecker
       if (param.equals(sym.getParameters().last()) && sym.isVarArgs()) {
         break; // TODO(b/121273225): support varargs
       }
-      // TODO(b/121273225): handle and check constrained type variables
+      // TODO(b/121273225): check type parameters, e.g., calls to void m(List<@NonNull String> l)
       // TODO(b/121203670): Recognize @ParametersAreNonnullByDefault etc.
       // Ignore unannotated and @Nullable parameters
-      if (NullnessAnnotations.fromAnnotationsOn(param).orElse(null) != Nullness.NONNULL) {
+      if (NullnessAnnotations.fromAnnotationsOn(param)
+              .orElseGet(() -> NullnessAnnotations.getUpperBound(param.type).orElse(null))
+          != Nullness.NONNULL) {
         continue;
       }
       ExpressionTree arg = arguments.get(i);

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -282,6 +282,7 @@ import com.google.errorprone.bugpatterns.TypeParameterUnusedInFormals;
 import com.google.errorprone.bugpatterns.URLEqualsHashCode;
 import com.google.errorprone.bugpatterns.UndefinedEquals;
 import com.google.errorprone.bugpatterns.UngroupedOverloads;
+import com.google.errorprone.bugpatterns.UnnecessaryAnonymousClass;
 import com.google.errorprone.bugpatterns.UnnecessaryBoxedVariable;
 import com.google.errorprone.bugpatterns.UnnecessaryDefaultInEnumSwitch;
 import com.google.errorprone.bugpatterns.UnnecessaryLambda;
@@ -730,6 +731,7 @@ public class BuiltInCheckerSuppliers {
           TypeParameterShadowing.class,
           TypeParameterUnusedInFormals.class,
           UndefinedEquals.class,
+          UnnecessaryAnonymousClass.class,
           UnnecessaryLambda.class,
           UnnecessaryParentheses.class,
           UnsafeFinalization.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/LiteEnumValueOfTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/LiteEnumValueOfTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assume.assumeTrue;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.util.RuntimeVersion;
 import java.util.stream.Stream;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -46,6 +45,21 @@ public class LiteEnumValueOfTest {
   }
 
   @Test
+  public void testPositiveCase2() {
+    compilationHelper
+        .addSourceLines("ProtoLiteEnum.java", PROTOLITE_ENUM)
+        .addSourceLines(
+            "Usage.java",
+            "class Usage {",
+            "  private ProtoLiteEnum testMethod() {",
+            "    // BUG: Diagnostic contains: LiteEnumValueOf",
+            "    return ProtoLiteEnum.valueOf(\"FOO\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void testNegativeCase() {
     compilationHelper.addSourceFile("LiteEnumValueOfNegativeCases.java").doTest();
   }
@@ -59,7 +73,6 @@ public class LiteEnumValueOfTest {
   }
 
   @Test
-  @Ignore("b/130683674")
   public void testWrappedCaseInFullProto() {
     compilationHelper
         .addSourceLines("OuterClass.java", generateProtoLiteEnumInGeneratedMessage())

--- a/core/src/test/java/com/google/errorprone/bugpatterns/OptionalMapToOptionalTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/OptionalMapToOptionalTest.java
@@ -97,4 +97,18 @@ public final class OptionalMapToOptionalTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void rawOptional() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "class Test {",
+            "  public Optional<Integer> test(Optional optional) {",
+            "    return optional.map(i -> 1);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/SelfEqualsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/SelfEqualsTest.java
@@ -64,12 +64,12 @@ public class SelfEqualsTest {
 
   @Test
   public void testPositiveCase_guava() {
-    compilationHelper.addSourceFile("GuavaSelfEqualsPositiveCase.java").doTest();
+    compilationHelper.addSourceFile("SelfEqualsGuavaPositiveCase.java").doTest();
   }
 
   @Test
   public void testNegativeCase_guava() {
-    compilationHelper.addSourceFile("GuavaSelfEqualsNegativeCases.java").doTest();
+    compilationHelper.addSourceFile("SelfEqualsGuavaNegativeCases.java").doTest();
   }
 
   @Test

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryAnonymousClassTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryAnonymousClassTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** {@link UnnecessaryAnonymousClass}Test */
+@RunWith(JUnit4.class)
+public class UnnecessaryAnonymousClassTest {
+
+  private final BugCheckerRefactoringTestHelper testHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryAnonymousClass(), getClass());
+
+  @Test
+  public void variable_instance() {
+    testHelper
+        .addInputLines(
+            "Test.java",
+            "import java.util.function.Function;",
+            "class Test {",
+            "  private final Function<String, String> camelCase = new Function<String, String>() {",
+            "    public String apply(String x) {",
+            "      return \"hello \" + x;",
+            "    }",
+            "  };",
+            "  void g() {",
+            "    Function<String, String> f = camelCase;",
+            "    System.err.println(camelCase.apply(\"world\"));",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.util.function.Function;",
+            "class Test {",
+            "  private String camelCase(String x) {",
+            "    return \"hello \" + x;",
+            "  }",
+            "  void g() {",
+            "    Function<String, String> f = this::camelCase;",
+            "    System.err.println(camelCase(\"world\"));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void variable_static() {
+    testHelper
+        .addInputLines(
+            "Test.java",
+            "import java.util.function.Function;",
+            "class Test {",
+            "  private static final Function<String, String> F = new Function<String, String>() {",
+            "    public String apply(String x) {",
+            "      return \"hello \" + x;",
+            "    }",
+            "  };",
+            "  void g() {",
+            "    Function<String, String> l = Test.F;",
+            "    System.err.println(F.apply(\"world\"));",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.util.function.Function;",
+            "class Test {",
+            "  private static String f(String x) {",
+            "    return \"hello \" + x;",
+            "  }",
+            "  void g() {",
+            "    Function<String, String> l = Test::f;",
+            "    System.err.println(f(\"world\"));",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryLambdaTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryLambdaTest.java
@@ -235,6 +235,36 @@ public class UnnecessaryLambdaTest {
             "  }",
             "}")
         .expectUnchanged()
-        .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
+        .doTest();
+  }
+
+  @Test
+  public void variable_bind() {
+    testHelper
+        .addInputLines(
+            "Bind.java",
+            "package com.google.inject.testing.fieldbinder;",
+            "import static java.lang.annotation.ElementType.FIELD;",
+            "import static java.lang.annotation.RetentionPolicy.RUNTIME;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.Target;",
+            "@Retention(RUNTIME)",
+            "@Target({FIELD})",
+            "public @interface Bind {}")
+        .expectUnchanged()
+        .addInputLines(
+            "Test.java",
+            "import java.util.function.Function;",
+            "import com.google.inject.testing.fieldbinder.Bind;",
+            "class Test {",
+            "  @Bind",
+            "  private final Function<String, String> camelCase = x -> \"hello \" + x;",
+            "  void g() {",
+            "    Function<String, String> f = camelCase;",
+            "    System.err.println(camelCase.apply(\"world\"));",
+            "  }",
+            "}")
+        .expectUnchanged()
+        .doTest();
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedVariableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedVariableTest.java
@@ -1026,7 +1026,8 @@ public class UnusedVariableTest {
             "    int c = b;",
             "    // BUG: Diagnostic contains: This assignment to the local variable",
             "    b = 2;",
-            "    return c;",
+            "    b = 3;",
+            "    return b + c;",
             "  }",
             "}")
         .doTest();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/NullableDereferenceTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/NullableDereferenceTest.java
@@ -327,6 +327,67 @@ public class NullableDereferenceTest {
         .doTest();
   }
 
+  @Test // for https://github.com/google/error-prone/issues/1253
+  public void testCheckNotNull() {
+    createCompilationTestHelper()
+        .addSourceLines(
+            "com/google/errorprone/bugpatterns/nullness/CheckNotNullTest.java",
+            "package com.google.errorprone.bugpatterns.nullness;",
+            "import static com.google.common.base.Preconditions.checkNotNull;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "public class CheckNotNullTest {",
+            "  public void testCheck(@Nullable Integer arg) {",
+            "    // TODO(b/121273225): make checker see <T extends @NonNull Object> bound",
+            "    Integer value = checkNotNull(arg);",
+            "    // Ideally we'd like to avoid the following warning",
+            "    // BUG: Diagnostic contains: possibly null",
+            "    int result = value.intValue();",
+            "    result = arg.intValue();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test // for https://github.com/google/error-prone/issues/1253
+  public void testCustomNotNullBound() {
+    createCompilationTestHelper()
+        .addSourceLines(
+            "com/google/errorprone/bugpatterns/nullness/CheckNotNullTest.java",
+            "package com.google.errorprone.bugpatterns.nullness;",
+            "import org.checkerframework.checker.nullness.qual.NonNull;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "public class CheckNotNullTest {",
+            "  public void testCheck(@Nullable Integer arg) {",
+            "    // BUG: Diagnostic contains: possibly null",
+            "    Integer value = nonNullOnly(arg);",
+            "    // Ideally we'd like to avoid the following warning",
+            "    // BUG: Diagnostic contains: possibly null",
+            "    int result = value.intValue();",
+            "  }",
+            "  private static <T extends @NonNull Object> T nonNullOnly(T arg) { return arg; }",
+            "}")
+        .doTest();
+  }
+
+  /** Tests that {@link com.google.common.base.Verify#verifyNotNull} doesn't generate any errors. */
+  @Test // for https://github.com/google/error-prone/issues/1253
+  public void testVerifyNotNull() {
+    createCompilationTestHelper()
+        .addSourceLines(
+            "com/google/errorprone/bugpatterns/nullness/VerifyNotNullTest.java",
+            "package com.google.errorprone.bugpatterns.nullness;",
+            "import static com.google.common.base.Verify.verifyNotNull;",
+            "import org.checkerframework.checker.nullness.qual.Nullable;",
+            "public class VerifyNotNullTest {",
+            "  public void testVerify(@Nullable Integer arg) {",
+            "    Integer value = verifyNotNull(arg);",
+            "    int result = value.intValue();",
+            "    result = arg.intValue();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   private CompilationTestHelper createCompilationTestHelper() {
     return CompilationTestHelper.newInstance(NullableDereference.class, getClass());
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/SelfEqualsGuavaNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/SelfEqualsGuavaNegativeCases.java
@@ -19,7 +19,7 @@ package com.google.errorprone.bugpatterns.testdata;
 import com.google.common.base.Objects;
 
 /** @author bhagwani@google.com (Sumit Bhagwani) */
-public class GuavaSelfEqualsNegativeCases {
+public class SelfEqualsGuavaNegativeCases {
   private String field;
 
   @Override
@@ -31,7 +31,7 @@ public class GuavaSelfEqualsNegativeCases {
       return false;
     }
 
-    GuavaSelfEqualsNegativeCases other = (GuavaSelfEqualsNegativeCases) o;
+    SelfEqualsGuavaNegativeCases other = (SelfEqualsGuavaNegativeCases) o;
     return Objects.equal(field, other.field);
   }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/SelfEqualsGuavaPositiveCase.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/SelfEqualsGuavaPositiveCase.java
@@ -19,7 +19,7 @@ package com.google.errorprone.bugpatterns.testdata;
 import com.google.common.base.Objects;
 
 /** @author alexeagle@google.com (Alex Eagle) */
-public class GuavaSelfEqualsPositiveCase {
+public class SelfEqualsGuavaPositiveCase {
   private String field = "";
 
   @Override
@@ -30,7 +30,7 @@ public class GuavaSelfEqualsPositiveCase {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    GuavaSelfEqualsPositiveCase other = (GuavaSelfEqualsPositiveCase) o;
+    SelfEqualsGuavaPositiveCase other = (SelfEqualsGuavaPositiveCase) o;
     boolean retVal;
     // BUG: Diagnostic contains: Objects.equal(field, other.field)
     retVal = Objects.equal(field, field);

--- a/core/src/test/java/com/google/errorprone/scanner/ScannerSupplierTest.java
+++ b/core/src/test/java/com/google/errorprone/scanner/ScannerSupplierTest.java
@@ -638,18 +638,19 @@ public class ScannerSupplierTest {
     }
 
     final void hasSeverities(Map<String, SeverityLevel> severities) {
-      check().that(actual().severities()).containsExactlyEntriesIn(severities);
+      check("severities()").that(actual().severities()).containsExactlyEntriesIn(severities);
     }
 
     @SafeVarargs
     final void hasEnabledChecks(Class<? extends BugChecker>... bugCheckers) {
-      check()
+      check("getEnabledChecks()")
           .that(actual().getEnabledChecks())
           .containsExactlyElementsIn(getSuppliers(bugCheckers));
     }
 
     final MapSubject flagsMap() {
-      return check().that(actual().getFlags().getFlagsMap()).named("Flags map");
+      return check("getFlags().getFlagsMap()")
+          .that(actual().getFlags().getFlagsMap());
     }
   }
 

--- a/docs/bugpattern/UnnecessaryAnonymousClass.md
+++ b/docs/bugpattern/UnnecessaryAnonymousClass.md
@@ -1,0 +1,54 @@
+Prefer method references to anonymous classes that implement functional
+interfaces.
+
+That is, prefer this:
+
+```java {.good}
+private static Bar getBar(Foo foo) {
+  return BarService.lookupBar(foo, defaultCredentials());
+}
+
+...
+
+return someStream().map(MyClass::getBar)....;
+```
+
+to this:
+
+```java
+private static final Function<Foo, Bar> GET_BAR_FUNCTION =
+    new Function<Foo, Bar>() {
+      @Override
+      public Bar apply(Foo foo) {
+        return BarService.lookupBar(foo, defaultCredentials());
+      }
+    };
+
+...
+
+return someStream().map(GET_BAR_FUNCTION)....;
+```
+
+Advantages of using a method include:
+
+*   It avoids hardcoding a named dependency on the functional interface type
+    (e.g., is it a `com.google.common.base.Function` or a
+    `java.util.function.Function`?)
+*   It is easier to name the method than the constant.
+*   It is more natural to test the method than the constant.
+*   If the behavior is nontrivial, it's more natural to write javadoc for the
+    method.
+
+Be aware that this change is not purely syntactic: it affects the semantics of
+your program in some small ways. In particular, evaluating the same method
+reference twice is not guaranteed to return an identical object.
+
+This means that, first, inlining the reference instead of using a constant may
+cause additional memory allocations - usually this very slight performance cost
+is worth the improved readability, but use your judgment if the performance
+matters to you.
+
+Secondly, if the correctness of your program depends on reference equality,
+inlining the method reference may break you. Ideally, you should *not* depend on
+reference equality, but if you are doing so, consider not making this change.
+

--- a/docs/bugpattern/UnnecessaryLambda.md
+++ b/docs/bugpattern/UnnecessaryLambda.md
@@ -34,3 +34,17 @@ Advantages of using a method include:
 *   If the behavior is nontrivial, it's more natural to write javadoc for the
     method.
 
+Be aware that this change is not purely syntactic: it affects the semantics of
+your program in some small ways. In particular, evaluating the same method
+reference twice is not guaranteed to return an identical object.
+
+This means that, first, inlining the reference instead of storing a lambda may
+cause additional memory allocations - usually this very slight performance cost
+is worth the improved readability, but use your judgment if the performance
+matters to you.
+
+Secondly, if the correctness of your program depends on reference equality of
+your lambda, inlining it may break you. Ideally, you should *not* depend on
+reference equality for a lambda, but if you are doing so, consider not making
+this change.
+

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>27.0.1-jre</guava.version>
     <gwt.version>2.8.2</gwt.version>
-    <truth.version>0.42</truth.version>
+    <truth.version>0.44</truth.version>
     <javac.version>9+181-r4173-1</javac.version>
     <autovalue.version>1.5.3</autovalue.version>
     <junit.version>4.13-beta-1</junit.version>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Ignore @Bind-annotated fields in UnnecessaryLambda

99a530bc0b0046d2dec8674f136d09223729afe5

-------

<p> Add notes about the semantic impact of applying the suggested fix.

9dd6b9da48397271e3cbf01c376ae7d514c782ef

-------

<p> Migrate Truth Subjects from no-arg check() to the overload that accepts a description.

The overload that accepts a description generally produces better failure messages:
- The first line of the message it produces is something like: "value of: myProto.getResponse()" (where "getResponse()" is taken from the provided description)
- The last line of the message it produces is something like: "myProto was: response: query was throttled" (the full value of myProto)
- And the existing text goes in between.

Additional motivation: We have deprecated the no-arg overload in open-source Truth.

Note that the new overload is available externally as of Truth 0.40.

c65852596e6690b1a83c5147f279891a00b5796a

-------

<p> Simplify @Generated handling

cec21ea4d9871baf2e40774351f0bfc6bea9f19c

-------

<p> Recognize bound type parameters when null-checking method call arguments

discovered due to https://github.com/google/error-prone/issues/1253

cac4cc5e441a8138550310e83e82bbdb0c353ae5

-------

<p> Don't flag AutoValue generated code for LiteEnumValueOf check.

RELNOTES: Don't flag AutoValue generated code for LiteEnumValueOf check.

68247869d7d048fbe411c50ac8b21a27c3ebedbf

-------

<p> OptionalMapToOptional: don't crash on raw types.

Somewhat interesting this didn't come up internally.

Fixes external #1260

7313f66d4bd0d927783a2c40363d458a0466784e

-------

<p> Add a check to detect anonymous classes that can be replaced with method references

fa4b1e2c87c957f5e4b2e2a7eadf12430b4f4222

-------

<p> Fix the finding position for unused reassignments.

36ba43a2d21acc7c44b3d4b0251afc5feee5e230

-------

<p> Test cases for lite proto enum value of matches enclosed in lite and full proto

925e1cd2255661e55bfeb543662b8f46f9a05e7b

-------

<p> Update to Truth 0.44.

f4b4364d051da61f88b53df1810f9785262a1fcd

-------

<p> Don't flag lite enums wrapped in GeneratedMessage

RELNOTES: Don't flag lite enums wrapped in GeneratedMessage

480718d659910e13823dace5ca11f9c2f1828e82

-------

<p> Rename SelfEquals test files for Guava and remove custom TEST_RESOURCES setting in BUILD file

GuavaSelfEquals -> SelfEqualsGuava

3d0fe65e7b34ee84bf8da5a9bcf83b7e656b8b9a

-------

<p> SuggestedFixes#renameMethodInvocation: tokenize so as to handle type args.

5886fb2217a924ad40d6fe7480a92739c023b882