### PR TITLE
Rejuvenate log levels

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/apply/DiffApplier.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/DiffApplier.java
@@ -94,7 +94,7 @@ public class DiffApplier extends AbstractService {
         notifyFailed(e);
       }
       logger.log(
-          Level.INFO, String.format("Completed %d files in %s", completedFiles.get(), stopwatch));
+          Level.FINEST, String.format("Completed %d files in %s", completedFiles.get(), stopwatch));
       if (!diffsFailedPaths.isEmpty()) {
         logger.log(
             Level.SEVERE,

--- a/check_api/src/main/java/com/google/errorprone/apply/DiscardingFileDestination.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/DiscardingFileDestination.java
@@ -25,7 +25,7 @@ public class DiscardingFileDestination implements FileDestination {
 
   @Override
   public void writeFile(SourceFile file) {
-    log.info(String.format("Altered file %s thrown away", file.getPath()));
+    log.finest(String.format("Altered file %s thrown away", file.getPath()));
   }
 
   @Override

--- a/core/src/main/java/com/google/errorprone/refaster/RefasterRuleBuilderScanner.java
+++ b/core/src/main/java/com/google/errorprone/refaster/RefasterRuleBuilderScanner.java
@@ -18,7 +18,6 @@ package com.google.errorprone.refaster;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static java.util.logging.Level.FINE;
 
 import com.google.common.collect.ImmutableClassToInstanceMap;
 import com.google.common.collect.ImmutableList;
@@ -41,6 +40,9 @@ import com.sun.source.util.SimpleTreeVisitor;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.util.Context;
+
+import static java.util.logging.Level.FINEST;
+
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -109,7 +111,7 @@ public final class RefasterRuleBuilderScanner extends SimpleTreeVisitor<Void, Vo
   public Void visitMethod(MethodTree tree, Void v) {
     try {
       VisitorState state = new VisitorState(context);
-      logger.log(FINE, "Discovered method with name {0}", tree.getName());
+      logger.log(FINEST, "Discovered method with name {0}", tree.getName());
       if (ASTHelpers.hasAnnotation(tree, Placeholder.class, state)) {
         checkArgument(
             tree.getModifiers().getFlags().contains(Modifier.ABSTRACT),


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. We hypothesize that portions of a system that are worked on more and more recently should have higher log levels (e.g., INFO as compared to FINEST) and vice-versa. This places event logs related to tasks that are currently more important to the forefront while pushing event logs pertaining to tasks worked on in the past to the background. The goal is to reduce information overload, bring more relevant events to developers' attention, and alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and program elements, such as edits. In this project, we calculate the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Settings

We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

1. Treat  CONFIG level as a category and not a traditional level, i.e., our tool ignores CONFIG log level.
1. Never lower the logging level of logging statements within catch blocks.
1. Never lower the logging level of logging statements within if statements.
1. Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
1. The greatest number of commits evaluated: 1000.

The head at time of analysis was: 43ca100034a01050fb764170bd32b085ac9a3c22