### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/test/java/com/google/errorprone/dataflow/nullnesspropagation/NonNullAssumptionsTest.java
+++ b/check_api/src/test/java/com/google/errorprone/dataflow/nullnesspropagation/NonNullAssumptionsTest.java
@@ -51,7 +51,7 @@ public class NonNullAssumptionsTest {
         if (Modifier.isFinal(field.getModifiers()) && Modifier.isStatic(field.getModifiers())) {
           ++found;
           field.setAccessible(true);
-          assertThat(field.get(null)).named(field.toString()).isNotNull();
+          assertWithMessage(field.toString()).that(field.get(null)).isNotNull();
         }
       }
       assertWithMessage(classname).that(found).isGreaterThan(0);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/WellKnownMutability.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/WellKnownMutability.java
@@ -134,6 +134,7 @@ public final class WellKnownMutability implements ThreadSafety.KnownTypes {
         .add("com.google.protobuf.Descriptors$EnumValueDescriptor")
         .add("com.google.protobuf.Descriptors$FieldDescriptor")
         .add("com.google.protobuf.Descriptors$FileDescriptor")
+        .add("com.google.protobuf.Descriptors$OneofDescriptor")
         .add("com.google.protobuf.Descriptors$ServiceDescriptor")
         .add("com.google.protobuf.Extension")
         .add("com.google.protobuf.ExtensionRegistry$ExtensionInfo")

--- a/core/src/test/java/com/google/errorprone/ErrorProneCompilerIntegrationTest.java
+++ b/core/src/test/java/com/google/errorprone/ErrorProneCompilerIntegrationTest.java
@@ -526,7 +526,7 @@ public class ErrorProneCompilerIntegrationTest {
                         "    return;",
                         "  }",
                         "}")));
-    assertThat(exitCode).named(outputStream.toString()).isEqualTo(Result.ERROR);
+    assertWithMessage(outputStream.toString()).that(exitCode).isEqualTo(Result.ERROR);
     assertThat(diagnosticHelper.getDiagnostics()).hasSize(1);
     Diagnostic<? extends JavaFileObject> diag =
         Iterables.getOnlyElement(diagnosticHelper.getDiagnostics());
@@ -556,7 +556,7 @@ public class ErrorProneCompilerIntegrationTest {
             new String[] {"-XDcompilePolicy=byfile"},
             Arrays.asList(compiler.fileManager().forSourceLines("Test.java", "class Test {}")));
     outputStream.flush();
-    assertThat(exitCode).named(outputStream.toString()).isEqualTo(Result.OK);
+    assertWithMessage(outputStream.toString()).that(exitCode).isEqualTo(Result.OK);
   }
 
   @Test
@@ -566,7 +566,7 @@ public class ErrorProneCompilerIntegrationTest {
             new String[] {"-XDcompilePolicy=simple"},
             Arrays.asList(compiler.fileManager().forSourceLines("Test.java", "class Test {}")));
     outputStream.flush();
-    assertThat(exitCode).named(outputStream.toString()).isEqualTo(Result.OK);
+    assertWithMessage(outputStream.toString()).that(exitCode).isEqualTo(Result.OK);
   }
 
   @BugPattern(

--- a/core/src/test/java/com/google/errorprone/ErrorProneJavacPluginTest.java
+++ b/core/src/test/java/com/google/errorprone/ErrorProneJavacPluginTest.java
@@ -19,6 +19,7 @@ package com.google.errorprone;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Locale.ENGLISH;
 import static org.junit.Assert.assertThrows;
@@ -146,8 +147,8 @@ public class ErrorProneJavacPluginTest {
                     "-XDcompilePolicy=byfile"),
                 ImmutableList.of(),
                 fileManager.getJavaFileObjects(fileA, fileB));
-    assertThat(task.call())
-        .named(Joiner.on('\n').join(diagnosticCollector.getDiagnostics()))
+    assertWithMessage(Joiner.on('\n').join(diagnosticCollector.getDiagnostics()))
+        .that(task.call())
         .isTrue();
     assertThat(Files.readAllLines(fileA, UTF_8))
         .containsExactly(
@@ -205,8 +206,8 @@ public class ErrorProneJavacPluginTest {
                     "-XDcompilePolicy=byfile"),
                 ImmutableList.of(),
                 fileManager.getJavaFileObjects(fileA, fileB));
-    assertThat(task.call())
-        .named(Joiner.on('\n').join(diagnosticCollector.getDiagnostics()))
+    assertWithMessage(Joiner.on('\n').join(diagnosticCollector.getDiagnostics()))
+        .that(task.call())
         .isTrue();
     assertThat(
             Files.readAllLines(patchFile, UTF_8).stream()

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterNamingTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterNamingTest.java
@@ -15,7 +15,7 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.errorprone.bugpatterns.TypeParameterNaming.TypeParameterNamingClassification.CLASS_NAME_WITH_T;
 import static com.google.errorprone.bugpatterns.TypeParameterNaming.TypeParameterNamingClassification.LETTER_WITH_MAYBE_NUMERAL;
 import static com.google.errorprone.bugpatterns.TypeParameterNaming.TypeParameterNamingClassification.NON_CLASS_NAME_WITH_T_SUFFIX;
@@ -313,6 +313,6 @@ public class TypeParameterNamingTest {
   }
 
   private static Subject<?, TypeParameterNamingClassification> assertKindOfName(String s) {
-    return assertThat(TypeParameterNamingClassification.classify(s)).named(s);
+    return assertWithMessage(s).that(TypeParameterNamingClassification.classify(s));
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/apidiff/CompilationBuilderHelpers.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/apidiff/CompilationBuilderHelpers.java
@@ -136,8 +136,8 @@ public class CompilationBuilderHelpers {
     CompilationResult compileOrDie() throws IOException {
       CompilationResult result = compile();
       assertWithMessage("Compilation failed unexpectedly")
+          .withMessage(Joiner.on('\n').join(result.diagnostics()))
           .that(result.ok())
-          .named(Joiner.on('\n').join(result.diagnostics()))
           .isTrue();
       return result;
     }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Mark OneofDescriptor as immutable in WellKnownMutability.

RELNOTES: N/A

e44441822cf76a4713e482e5e1763e5fec81de0c

-------

<p> Migrate from assertThat(foo).named("foo") to assertWithMessage("foo").that(foo).

(The exact change is slightly different in some cases, like when using custom subjects or check(), but it's always a migration from named(...) to [assert]WithMessage(...).)

named(...) is being removed.

This CL may slightly modify the failure messages produced, but all the old information will still be present.

66350e06789373a3213a8f39337a9afecf3c2162