### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/VisitorState.java
+++ b/check_api/src/main/java/com/google/errorprone/VisitorState.java
@@ -21,6 +21,7 @@ import com.google.common.base.Splitter;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.errorprone.BugPattern.SeverityLevel;
@@ -522,7 +523,7 @@ public class VisitorState {
    * <p>This is moderately expensive (the source of the node has to be re-lexed), so it should only
    * be used if a fix is already going to be emitted.
    */
-  public List<ErrorProneToken> getTokensForNode(Tree tree) {
+  public ImmutableList<ErrorProneToken> getTokensForNode(Tree tree) {
     return ErrorProneTokens.getTokens(getSourceForNode(tree), context);
   }
 
@@ -533,9 +534,21 @@ public class VisitorState {
    * <p>This is moderately expensive (the source of the node has to be re-lexed), so it should only
    * be used if a fix is already going to be emitted.
    */
-  public List<ErrorProneToken> getOffsetTokensForNode(Tree tree) {
+  public ImmutableList<ErrorProneToken> getOffsetTokensForNode(Tree tree) {
     int start = ((JCTree) tree).getStartPosition();
     return ErrorProneTokens.getTokens(getSourceForNode(tree), start, context);
+  }
+
+  /**
+   * Returns the list of {@link Token}s for source code between the given positions, offset by the
+   * start position.
+   *
+   * <p>This is moderately expensive (the source of the node has to be re-lexed), so it should only
+   * be used if a fix is already going to be emitted.
+   */
+  public ImmutableList<ErrorProneToken> getOffsetTokens(int start, int end) {
+    return ErrorProneTokens.getTokens(
+        getSourceCode().subSequence(start, end).toString(), start, context);
   }
 
   /** Returns the end position of the node, or -1 if it is not available. */

--- a/check_api/src/main/java/com/google/errorprone/VisitorState.java
+++ b/check_api/src/main/java/com/google/errorprone/VisitorState.java
@@ -526,6 +526,18 @@ public class VisitorState {
     return ErrorProneTokens.getTokens(getSourceForNode(tree), context);
   }
 
+  /**
+   * Returns the list of {@link Token}s for the given {@link JCTree}, offset by the start position
+   * of the tree within the overall source.
+   *
+   * <p>This is moderately expensive (the source of the node has to be re-lexed), so it should only
+   * be used if a fix is already going to be emitted.
+   */
+  public List<ErrorProneToken> getOffsetTokensForNode(Tree tree) {
+    int start = ((JCTree) tree).getStartPosition();
+    return ErrorProneTokens.getTokens(getSourceForNode(tree), start, context);
+  }
+
   /** Returns the end position of the node, or -1 if it is not available. */
   public int getEndPosition(Tree node) {
     JCCompilationUnit compilationUnit = (JCCompilationUnit) getPath().getCompilationUnit();

--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -308,7 +308,7 @@ public class ASTHelpers {
         return false;
       }
       // TODO(b/112139121): work around for javac's too-early constant string folding
-      return ErrorProneTokens.getTokens(state.getSourceForNode(expression), state.context).stream()
+      return state.getOffsetTokensForNode(expression).stream()
           .anyMatch(t -> t.kind() == TokenKind.PLUS);
     }
     if (expression instanceof UnaryTree) {
@@ -1655,8 +1655,7 @@ public class ASTHelpers {
 
   /** Returns whether the given {@code tree} contains any comments in its source. */
   public static boolean containsComments(Tree tree, VisitorState state) {
-    return ErrorProneTokens.getTokens(state.getSourceForNode(tree), state.context).stream()
-        .anyMatch(t -> !t.comments().isEmpty());
+    return state.getOffsetTokensForNode(tree).stream().anyMatch(t -> !t.comments().isEmpty());
   }
 
   /**

--- a/check_api/src/main/java/com/google/errorprone/util/Commented.java
+++ b/check_api/src/main/java/com/google/errorprone/util/Commented.java
@@ -81,34 +81,4 @@ public abstract class Commented<T extends Tree> {
     abstract Commented<T> build();
   }
 
-  private static final class OffsetComment implements Comment {
-
-    private final Comment wrapped;
-    private final int offset;
-
-    private OffsetComment(Comment wrapped, int offset) {
-      this.wrapped = wrapped;
-      this.offset = offset;
-    }
-
-    @Override
-    public String getText() {
-      return wrapped.getText();
-    }
-
-    @Override
-    public int getSourcePos(int i) {
-      return wrapped.getSourcePos(i) + offset;
-    }
-
-    @Override
-    public CommentStyle getStyle() {
-      return wrapped.getStyle();
-    }
-
-    @Override
-    public boolean isDeprecated() {
-      return false;
-    }
-  }
 }

--- a/check_api/src/main/java/com/google/errorprone/util/ErrorProneTokens.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ErrorProneTokens.java
@@ -31,11 +31,16 @@ import com.sun.tools.javac.util.Position.LineMap;
 
 /** A utility for tokenizing and preserving comments. */
 public class ErrorProneTokens {
-
+  private final int offset;
   private final CommentSavingTokenizer commentSavingTokenizer;
   private final ScannerFactory scannerFactory;
 
   public ErrorProneTokens(String source, Context context) {
+    this(source, 0, context);
+  }
+
+  public ErrorProneTokens(String source, int offset, Context context) {
+    this.offset = offset;
     scannerFactory = ScannerFactory.instance(context);
     char[] buffer = source == null ? new char[] {} : source.toCharArray();
     commentSavingTokenizer = new CommentSavingTokenizer(scannerFactory, buffer, buffer.length);
@@ -50,14 +55,23 @@ public class ErrorProneTokens {
     ImmutableList.Builder<ErrorProneToken> tokens = ImmutableList.builder();
     do {
       scanner.nextToken();
-      tokens.add(new ErrorProneToken(scanner.token()));
+      tokens.add(new ErrorProneToken(scanner.token(), offset));
     } while (scanner.token().kind != TokenKind.EOF);
     return tokens.build();
   }
 
   /** Returns the tokens for the given source text, including comments. */
   public static ImmutableList<ErrorProneToken> getTokens(String source, Context context) {
-    return new ErrorProneTokens(source, context).getTokens();
+    return getTokens(source, 0, context);
+  }
+
+  /**
+   * Returns the tokens for the given source text, including comments, indicating the offset of the
+   * source within the overall file.
+   */
+  public static ImmutableList<ErrorProneToken> getTokens(
+      String source, int offset, Context context) {
+    return new ErrorProneTokens(source, offset, context).getTokens();
   }
 
   /** A {@link JavaTokenizer} that saves comments. */

--- a/check_api/src/main/java/com/google/errorprone/util/OffsetComment.java
+++ b/check_api/src/main/java/com/google/errorprone/util/OffsetComment.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.util;
+
+import com.sun.tools.javac.parser.Tokens.Comment;
+
+/** Wraps a {@link Comment} to allow an offset source position to be reported. */
+final class OffsetComment implements Comment {
+
+  private final Comment wrapped;
+  private final int offset;
+
+  OffsetComment(Comment wrapped, int offset) {
+    this.wrapped = wrapped;
+    this.offset = offset;
+  }
+
+  @Override
+  public String getText() {
+    return wrapped.getText();
+  }
+
+  @Override
+  public int getSourcePos(int i) {
+    return wrapped.getSourcePos(i) + offset;
+  }
+
+  @Override
+  public CommentStyle getStyle() {
+    return wrapped.getStyle();
+  }
+
+  @Override
+  public boolean isDeprecated() {
+    return false;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AnnotateFormatMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AnnotateFormatMethod.java
@@ -27,7 +27,6 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
-import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.util.ASTHelpers;
@@ -50,20 +49,17 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "AnnotateFormatMethod",
     summary =
-        "This method passes a pair of parameters through to String.format, but the enclosing "
-            + "method wasn't annotated @FormatMethod. Doing so gives compile-time rather than "
-            + "run-time protection against malformed format strings.\n\n"
-            + "WARNING: There's a very high chance that existing code will not be passing in "
-            + "well-formed format strings. Make sure you run tests including all users of "
-            + "this code before submitting.",
+        "This method passes a pair of parameters through to String.format, but the enclosing"
+            + " method wasn't annotated @FormatMethod. Doing so gives compile-time rather than"
+            + " run-time protection against malformed format strings.",
     severity = WARNING,
     tags = FRAGILE_CODE,
     providesFix = REQUIRES_HUMAN_ATTENTION)
 public final class AnnotateFormatMethod extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final String REORDER =
-      " The parameters of this method would need to be reordered to make the format string and "
-          + "arguments the final parameters before the @FormatMethod annotation can be used.";
+      " (The parameters of this method would need to be reordered to make the format string and "
+          + "arguments the final parameters before the @FormatMethod annotation can be used.)";
 
   private static final Matcher<ExpressionTree> STRING_FORMAT =
       staticMethod().onClass("java.lang.String").named("format");
@@ -101,17 +97,9 @@ public final class AnnotateFormatMethod extends BugChecker implements MethodInvo
     // We can only generate a fix if the format string is the penultimate parameter.
     boolean fixable =
         formatParameter.get().equals(enclosingParameters.get(enclosingParameters.size() - 2));
-    if (fixable) {
-      return describeMatch(
-          enclosingMethod,
-          SuggestedFix.builder()
-              .prefixWith(enclosingMethod, "@FormatMethod ")
-              .prefixWith(formatParameter.get(), "@FormatString ")
-              .addImport("com.google.errorprone.annotations.FormatMethod")
-              .addImport("com.google.errorprone.annotations.FormatString")
-              .build());
-    }
-    return buildDescription(enclosingMethod).setMessage(message() + REORDER).build();
+    return buildDescription(enclosingMethod)
+        .setMessage(fixable ? message() : (message() + REORDER))
+        .build();
   }
 
   private static Optional<? extends VariableTree> findParameterWithSymbol(

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AssignmentToMock.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AssignmentToMock.java
@@ -38,7 +38,6 @@ import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.MultiMatcher;
 import com.google.errorprone.util.ASTHelpers;
 import com.google.errorprone.util.ErrorProneToken;
-import com.google.errorprone.util.ErrorProneTokens;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.ClassTree;
@@ -106,16 +105,10 @@ public final class AssignmentToMock extends BugChecker
     }
     int startPos = ((JCTree) tree).getStartPosition();
     ImmutableList<ErrorProneToken> tokens =
-        ErrorProneTokens.getTokens(
-            state
-                .getSourceCode()
-                .subSequence(startPos, ((JCTree) tree.getInitializer()).getStartPosition())
-                .toString(),
-            state.context);
+        state.getOffsetTokens(startPos, ((JCTree) tree.getInitializer()).getStartPosition());
     for (ErrorProneToken token : tokens.reverse()) {
       if (token.kind() == TokenKind.EQ) {
-        return SuggestedFix.replace(
-            startPos + token.pos(), state.getEndPosition(tree.getInitializer()), "");
+        return SuggestedFix.replace(token.pos(), state.getEndPosition(tree.getInitializer()), "");
       }
     }
     return SuggestedFix.builder().build();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ExtendingJUnitAssert.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ExtendingJUnitAssert.java
@@ -35,7 +35,6 @@ import com.sun.source.tree.Tree;
 import com.sun.source.util.TreeScanner;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.parser.Tokens.TokenKind;
-import com.sun.tools.javac.tree.JCTree;
 import java.util.List;
 
 /** @author kayco@google.com (Kayla Walker) */
@@ -77,25 +76,22 @@ public class ExtendingJUnitAssert extends BugChecker implements ClassTreeMatcher
         null);
 
     Tree extendsClause = tree.getExtendsClause();
-    int startOfClass = ((JCTree) tree).getStartPosition();
     int endOfExtendsClause = state.getEndPosition(extendsClause);
-    int extendsPosInClass = endOfExtendsClause - startOfClass;
 
-    List<ErrorProneToken> tokens = state.getTokensForNode(tree);
+    List<ErrorProneToken> tokens = state.getOffsetTokensForNode(tree);
 
-    int max = 0;
+    int startPos = 0;
     for (ErrorProneToken token : tokens) {
-      if (token.pos() > extendsPosInClass) {
+      if (token.pos() > endOfExtendsClause) {
         break;
       }
       if (token.kind() == TokenKind.EXTENDS) {
         int curr = token.pos();
-        if (curr > max) {
-          max = curr;
+        if (curr > startPos) {
+          startPos = curr;
         }
       }
     }
-    int startPos = ((JCTree) tree).getStartPosition() + max;
     return fix.replace(startPos, endOfExtendsClause, "").build();
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IdentityBinaryExpression.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IdentityBinaryExpression.java
@@ -109,10 +109,12 @@ public class IdentityBinaryExpression extends BugChecker implements BinaryTreeMa
       return NO_MATCH;
     }
     switch (tree.getKind()) {
-      case EQUAL_TO:
+      case NOT_EQUAL_TO:
+        // X != X is only true when X is NaN, so suggest isNaN(X)
         replacement = isNanReplacement(tree, state).orElse(replacement);
         break;
-      case NOT_EQUAL_TO:
+      case EQUAL_TO:
+        // X == X is true unless X is NaN, so suggest !isNaN(X)
         replacement = isNanReplacement(tree, state).map(r -> "!" + r).orElse(replacement);
         break;
       default: // fall out

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InterfaceWithOnlyStatics.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InterfaceWithOnlyStatics.java
@@ -30,7 +30,6 @@ import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.util.ErrorProneToken;
-import com.google.errorprone.util.ErrorProneTokens;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
@@ -107,15 +106,13 @@ public final class InterfaceWithOnlyStatics extends BugChecker implements ClassT
   private static SuggestedFix fixClass(ClassTree classTree, VisitorState state) {
     int startPos = ((JCTree) classTree).getStartPosition();
     int endPos = ((JCTree) classTree.getMembers().get(0)).getStartPosition();
-    ImmutableList<ErrorProneToken> tokens =
-        ErrorProneTokens.getTokens(
-            state.getSourceCode().subSequence(startPos, endPos).toString(), state.context);
+    ImmutableList<ErrorProneToken> tokens = state.getOffsetTokens(startPos, endPos);
     String modifiers =
         getSymbol(classTree).owner.enclClass() == null ? "final class" : "static final class";
     SuggestedFix.Builder fix = SuggestedFix.builder();
     for (ErrorProneToken token : tokens) {
       if (token.kind() == TokenKind.INTERFACE) {
-        fix.replace(startPos + token.pos(), startPos + token.endPos(), modifiers);
+        fix.replace(token.pos(), token.endPos(), modifiers);
       }
     }
     return fix.build();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingDefault.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingDefault.java
@@ -29,7 +29,6 @@ import com.google.errorprone.bugpatterns.BugChecker.SwitchTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.util.ASTHelpers;
-import com.google.errorprone.util.ErrorProneTokens;
 import com.google.errorprone.util.Reachability;
 import com.sun.source.tree.CaseTree;
 import com.sun.source.tree.SwitchTree;
@@ -85,10 +84,8 @@ public class MissingDefault extends BugChecker implements SwitchTreeMatcher {
     if (idx != tree.getCases().size() - 1) {
       return NO_MATCH;
     }
-    int end = state.getEndPosition(tree);
-    if (ErrorProneTokens.getTokens(
-            state.getSourceCode().subSequence(state.getEndPosition(defaultCase), end).toString(),
-            state.context)
+    if (state
+        .getOffsetTokens(state.getEndPosition(defaultCase), state.getEndPosition(tree))
         .stream()
         .anyMatch(t -> !t.comments().isEmpty())) {
       return NO_MATCH;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MixedArrayDimensions.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MixedArrayDimensions.java
@@ -30,7 +30,6 @@ import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.util.ErrorProneToken;
-import com.google.errorprone.util.ErrorProneTokens;
 import com.sun.source.tree.ArrayTypeTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
@@ -71,12 +70,9 @@ public class MixedArrayDimensions extends BugChecker
       if (start >= end) {
         continue;
       }
-      String dim = source.subSequence(start, end).toString();
-      if (dim.isEmpty()) {
-        continue;
-      }
-      ImmutableList<ErrorProneToken> tokens = ErrorProneTokens.getTokens(dim.trim(), state.context);
+      ImmutableList<ErrorProneToken> tokens = state.getOffsetTokens(start, end);
       if (tokens.size() > 2 && tokens.get(0).kind() == TokenKind.IDENTIFIER) {
+        String dim = source.subSequence(start, end).toString();
         int nonWhitespace = CharMatcher.isNot(' ').indexIn(dim);
         int idx = dim.indexOf("[]", nonWhitespace);
         if (idx > nonWhitespace) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RedundantOverride.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RedundantOverride.java
@@ -31,7 +31,6 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
-import com.google.errorprone.util.ErrorProneTokens;
 import com.sun.source.doctree.DocCommentTree;
 import com.sun.source.tree.ExpressionStatementTree;
 import com.sun.source.tree.ExpressionTree;
@@ -121,7 +120,7 @@ public final class RedundantOverride extends BugChecker implements MethodTreeMat
       }
     }
     // Exempt if there are comments within the body. (Do this last, as it's expensive.)
-    if (ErrorProneTokens.getTokens(state.getSourceForNode(tree.getBody()), state.context).stream()
+    if (state.getOffsetTokensForNode(tree.getBody()).stream()
         .anyMatch(t -> !t.comments().isEmpty())) {
       return NO_MATCH;
     }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/AnnotateFormatMethodTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/AnnotateFormatMethodTest.java
@@ -16,8 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import com.google.errorprone.BugCheckerRefactoringTestHelper;
-import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,29 +43,6 @@ public final class AnnotateFormatMethodTest {
             "  }",
             "}")
         .doTest();
-  }
-
-  @Test
-  public void refactoring() {
-    BugCheckerRefactoringTestHelper.newInstance(new AnnotateFormatMethod(), getClass())
-        .addInputLines(
-            "AnnotateFormatMethodPositiveCases.java",
-            "class AnnotateFormatMethodPositiveCases {",
-            "  String formatMe(String formatString, Object... args) {",
-            "    return String.format(formatString, args);",
-            "  }",
-            "}")
-        .addOutputLines(
-            "AnnotateFormatMethodPositiveCases_expected.java",
-            "import com.google.errorprone.annotations.FormatMethod;",
-            "import com.google.errorprone.annotations.FormatString;",
-            "class AnnotateFormatMethodPositiveCases {",
-            "  @FormatMethod",
-            "  String formatMe(@FormatString String formatString, Object... args) {",
-            "    return String.format(formatString, args);",
-            "  }",
-            "}")
-        .doTest(TestMode.AST_MATCH);
   }
 
   @Test

--- a/core/src/test/java/com/google/errorprone/bugpatterns/IdentityBinaryExpressionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/IdentityBinaryExpressionTest.java
@@ -16,6 +16,7 @@
 
 package com.google.errorprone.bugpatterns;
 
+
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -163,21 +164,21 @@ public class IdentityBinaryExpressionTest {
             "class Test {",
             "  boolean f(float a, Float b, double c, Double d) {",
             "    boolean r = false;",
-            "    // BUG: Diagnostic contains: equivalent to `Float.isNaN(a)`",
-            "    r |= a == a;",
             "    // BUG: Diagnostic contains: equivalent to `!Float.isNaN(a)`",
+            "    r |= a == a;",
+            "    // BUG: Diagnostic contains: equivalent to `Float.isNaN(a)`",
             "    r |= a != a;",
-            "    // BUG: Diagnostic contains: equivalent to `Float.isNaN(b)`",
-            "    r |= b == b;",
             "    // BUG: Diagnostic contains: equivalent to `!Float.isNaN(b)`",
+            "    r |= b == b;",
+            "    // BUG: Diagnostic contains: equivalent to `Float.isNaN(b)`",
             "    r |= b != b;",
-            "    // BUG: Diagnostic contains: equivalent to `Double.isNaN(c)`",
-            "    r |= c == c;",
             "    // BUG: Diagnostic contains: equivalent to `!Double.isNaN(c)`",
+            "    r |= c == c;",
+            "    // BUG: Diagnostic contains: equivalent to `Double.isNaN(c)`",
             "    r |= c != c;",
-            "    // BUG: Diagnostic contains: equivalent to `Double.isNaN(d)`",
-            "    r |= d == d;",
             "    // BUG: Diagnostic contains: equivalent to `!Double.isNaN(d)`",
+            "    r |= d == d;",
+            "    // BUG: Diagnostic contains: equivalent to `Double.isNaN(d)`",
             "    r |= d != d;",
             "    return r;",
             "  }",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/ReturnMissingNullableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/ReturnMissingNullableTest.java
@@ -355,6 +355,28 @@ public class ReturnMissingNullableTest {
   }
 
   @Test
+  public void testNegativeCases_checkNotNullNullableInput() {
+    createCompilationTestHelper()
+        .addSourceLines(
+            "com/google/errorprone/bugpatterns/nullness/NullReturnTest.java",
+            "package com.google.errorprone.bugpatterns.nullness;",
+            "import javax.annotation.Nullable;",
+            "public class NullReturnTest {",
+            "  @Nullable String message;",
+            "  public String getMessage() {",
+            "    return checkNotNull(message);",
+            "  }",
+            // One style of "check not null" method, whose type argument is unannotated, and accepts
+            // a @Nullable input.
+            "  private static <T> T checkNotNull(@Nullable T obj) {",
+            "    if (obj==null) throw new NullPointerException();",
+            "    return obj;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void testNegativeCases_nonNullArrayWithNullableElements() {
     createCompilationTestHelper()
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/DurationToLongTimeUnitTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/DurationToLongTimeUnitTest.java
@@ -282,4 +282,23 @@ public class DurationToLongTimeUnitTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void intTimeUnitParameters() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.util.concurrent.TimeUnit;",
+            "public class TestClass {",
+            "  void javaTime(Duration d) {",
+            // TODO(b/132492921) "    // BUG: Diagnostic contains: DurationToLongTimeUnit",
+            "    myMethod((int) d.toHours(), TimeUnit.SECONDS);",
+            "  }",
+            "  void myMethod(int value, TimeUnit unit) {",
+            "    // no op",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/scanner/ScannerSupplierTest.java
+++ b/core/src/test/java/com/google/errorprone/scanner/ScannerSupplierTest.java
@@ -633,24 +633,26 @@ public class ScannerSupplierTest {
 
   private static class ScannerSupplierSubject
       extends Subject<ScannerSupplierSubject, ScannerSupplier> {
+    private final ScannerSupplier actual;
+
     ScannerSupplierSubject(FailureMetadata failureMetadata, ScannerSupplier scannerSupplier) {
       super(failureMetadata, scannerSupplier);
+      this.actual = scannerSupplier;
     }
 
     final void hasSeverities(Map<String, SeverityLevel> severities) {
-      check("severities()").that(actual().severities()).containsExactlyEntriesIn(severities);
+      check("severities()").that(actual.severities()).containsExactlyEntriesIn(severities);
     }
 
     @SafeVarargs
     final void hasEnabledChecks(Class<? extends BugChecker>... bugCheckers) {
       check("getEnabledChecks()")
-          .that(actual().getEnabledChecks())
+          .that(actual.getEnabledChecks())
           .containsExactlyElementsIn(getSuppliers(bugCheckers));
     }
 
     final MapSubject flagsMap() {
-      return check("getFlags().getFlagsMap()")
-          .that(actual().getFlags().getFlagsMap());
+      return check("getFlags().getFlagsMap()").that(actual.getFlags().getFlagsMap());
     }
   }
 

--- a/core/src/test/java/com/google/errorprone/util/ASTHelpersTest.java
+++ b/core/src/test/java/com/google/errorprone/util/ASTHelpersTest.java
@@ -73,6 +73,7 @@ import com.sun.tools.javac.code.Type.TypeVar;
 import com.sun.tools.javac.main.Main.Result;
 import com.sun.tools.javac.model.JavacElements;
 import com.sun.tools.javac.parser.Tokens.Comment;
+import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCLiteral;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -612,10 +613,11 @@ public class ASTHelpersTest extends CompilerBasedAbstractTest {
           public Void visitNewClass(NewClassTree tree, VisitorState state) {
             setAssertionsComplete();
             List<String> comments = new ArrayList<>();
-            for (ErrorProneToken t : state.getTokensForNode(tree)) {
+            int startPos = ((JCTree) tree).getStartPosition();
+            for (ErrorProneToken t : state.getOffsetTokensForNode(tree)) {
               if (!t.comments().isEmpty()) {
                 for (Comment c : t.comments()) {
-                  Verify.verify(c.getSourcePos(0) >= 0);
+                  Verify.verify(c.getSourcePos(0) >= startPos);
                   comments.add(c.getText());
                 }
               }

--- a/docs/bugpattern/AnnotateFormatMethod.md
+++ b/docs/bugpattern/AnnotateFormatMethod.md
@@ -1,0 +1,32 @@
+This method passes a pair of parameters through to `String#format`, but the
+enclosing method wasn't annotated `@FormatMethod`. Doing so gives compile-time
+rather than run-time protection against malformed format strings. Consider
+annotating the format string with
+`@com.google.errorprone.annotations.FormatString` and the method with
+`@FormatMethod` to allow compile-time checking for well-formed format strings.
+
+```java {.bad}
+static void log(String format, String... args) {
+  Log.w(format, args);
+}
+
+void frobnicate(int a, int b) {
+  if (a < b) {
+    // Whoops: didn't provide enough format args.
+    log("%s < %s", a);
+  }
+}
+```
+
+```java {.good}
+@FormatMethod
+static void log(@FormatString String format, String... args) {
+  Log.w(format, args);
+}
+```
+
+WARNING: There's a very high chance that manual intervention will be required
+after applying this fix, either due to existing uses of the method not passing
+in valid format strings, or methods which delegate to this one requiring the
+`@FormatMethod` annotation as well. Please ensure that everything depending on
+this code still compiles after applying.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix Nan-related suggestions in IdentityBinaryExpression.

Fixes #1274

b34aec776eb39f51e133ef41201ae1a17024f1ab

-------

<p> Instead of calling Subject.actual(), store the actual value in a field, and read that.

actual() is being removed.

b7048c190d026b57daf24964075ab9777cece077

-------

<p> Recognize a sample default annotation in nullness inference

57cd16015761332065bf99322eb726d4c2a2c3bb

-------

<p> Make the description of AnnotateFormatMethod more ominous, and don't emit a fix (that almost certainly won't compile).

d882f24717b7acecf6ab07b2e38d0eb8dc8f35dd

-------

<p> Add a test for (int, TimeUnit) mismatch.

5e8e1aadd34059b4cc80c92d84c235668c156714

-------

<p> Add test for one style of 'checkNotNull'.

9a2c76169f9455502827cfa674602efb042550ea

-------

<p> ErrorProneToken: allow an offset to be supplied when tokenizing, in order that you do not have to keep remembering to add the offset when using the start/end positions.

Add some helper methods to ErrorProneTokens to allow offset tokens to be constructed.

edc0e7085fb46a7b7747fd86432e01af0dd6e29f

-------

<p> Add another helper method to VisitorState, to handle the common pattern of tokenizing a region of the source code.

Start using getOffsetTokens{,ForNode} in error prone.

2693d822227bc82f161415cfc1b4172a86d70e81