### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/VisitorState.java
+++ b/check_api/src/main/java/com/google/errorprone/VisitorState.java
@@ -18,7 +18,6 @@ package com.google.errorprone;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.errorprone.BugPattern.SeverityLevel;
@@ -518,7 +517,7 @@ public class VisitorState {
    * <p>This is moderately expensive (the source of the node has to be re-lexed), so it should only
    * be used if a fix is already going to be emitted.
    */
-  public ImmutableList<ErrorProneToken> getTokensForNode(Tree tree) {
+  public List<ErrorProneToken> getTokensForNode(Tree tree) {
     return ErrorProneTokens.getTokens(getSourceForNode(tree), context);
   }
 
@@ -529,7 +528,7 @@ public class VisitorState {
    * <p>This is moderately expensive (the source of the node has to be re-lexed), so it should only
    * be used if a fix is already going to be emitted.
    */
-  public ImmutableList<ErrorProneToken> getOffsetTokensForNode(Tree tree) {
+  public List<ErrorProneToken> getOffsetTokensForNode(Tree tree) {
     int start = ((JCTree) tree).getStartPosition();
     return ErrorProneTokens.getTokens(getSourceForNode(tree), start, context);
   }
@@ -541,7 +540,7 @@ public class VisitorState {
    * <p>This is moderately expensive (the source of the node has to be re-lexed), so it should only
    * be used if a fix is already going to be emitted.
    */
-  public ImmutableList<ErrorProneToken> getOffsetTokens(int start, int end) {
+  public List<ErrorProneToken> getOffsetTokens(int start, int end) {
     return ErrorProneTokens.getTokens(
         getSourceCode().subSequence(start, end).toString(), start, context);
   }

--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -1042,7 +1042,7 @@ public class SuggestedFixes {
     } else {
       startTokenization = state.getEndPosition(classTree.getModifiers());
     }
-    ImmutableList<ErrorProneToken> tokens =
+    List<ErrorProneToken> tokens =
         state.getOffsetTokens(startTokenization, state.getEndPosition(tree));
     if (previousMember == null) {
       tokens = getTokensAfterOpeningBrace(tokens);
@@ -1075,8 +1075,7 @@ public class SuggestedFixes {
     return SuggestedFix.replace(startPos, state.getEndPosition(tree), replacement);
   }
 
-  private static ImmutableList<ErrorProneToken> getTokensAfterOpeningBrace(
-      ImmutableList<ErrorProneToken> tokens) {
+  private static List<ErrorProneToken> getTokensAfterOpeningBrace(List<ErrorProneToken> tokens) {
     for (int i = 0; i < tokens.size() - 1; ++i) {
       if (tokens.get(i).kind() == TokenKind.LBRACE) {
         return tokens.subList(i + 1, tokens.size());

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/AbstractChainedMatcher.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/AbstractChainedMatcher.java
@@ -16,10 +16,10 @@
 
 package com.google.errorprone.matchers.method;
 
-import com.google.common.base.Optional;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.annotations.ForOverride;
 import com.sun.source.tree.ExpressionTree;
+import java.util.Optional;
 
 /** Super-type for matchers that compose other matchers. */
 abstract class AbstractChainedMatcher<A, B> extends AbstractSimpleMatcher<B> {
@@ -34,9 +34,6 @@ abstract class AbstractChainedMatcher<A, B> extends AbstractSimpleMatcher<B> {
 
   @Override
   protected final Optional<B> matchResult(ExpressionTree item, VisitorState state) {
-    Optional<A> baseResult = baseMatcher.matchResult(item, state);
-    return baseResult.isPresent()
-        ? matchResult(item, baseResult.get(), state)
-        : Optional.<B>absent();
+    return baseMatcher.matchResult(item, state).flatMap(base -> matchResult(item, base, state));
   }
 }

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/AbstractSimpleMatcher.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/AbstractSimpleMatcher.java
@@ -16,10 +16,10 @@
 
 package com.google.errorprone.matchers.method;
 
-import com.google.common.base.Optional;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.Matcher;
 import com.sun.source.tree.ExpressionTree;
+import java.util.Optional;
 
 /** Super-type for base (non-chained) matchers. */
 abstract class AbstractSimpleMatcher<T> implements Matcher<ExpressionTree> {

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/AnyMethodMatcherImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/AnyMethodMatcherImpl.java
@@ -16,13 +16,13 @@
 
 package com.google.errorprone.matchers.method;
 
-import com.google.common.base.Optional;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.method.MethodMatchers.AnyMethodMatcher;
 import com.google.errorprone.matchers.method.MethodMatchers.MethodClassMatcher;
 import com.google.errorprone.predicates.TypePredicate;
 import com.google.errorprone.predicates.TypePredicates;
 import com.sun.source.tree.ExpressionTree;
+import java.util.Optional;
 
 /** Matches instance or static methods, allows refinement on class type. */
 class AnyMethodMatcherImpl extends MethodMatcher implements AnyMethodMatcher {

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/ConstructorClassMatcherImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/ConstructorClassMatcherImpl.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.matchers.method;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.method.MethodMatchers.ConstructorClassMatcher;
@@ -27,6 +26,7 @@ import com.google.errorprone.suppliers.Suppliers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.tools.javac.code.Type;
 import java.util.Arrays;
+import java.util.Optional;
 
 /** Matches on class type, allows refinement on parameters. */
 class ConstructorClassMatcherImpl extends AbstractChainedMatcher<MatchState, MatchState>
@@ -40,7 +40,7 @@ class ConstructorClassMatcherImpl extends AbstractChainedMatcher<MatchState, Mat
     if (predicate.apply(baseResult.ownerType(), state)) {
       return Optional.of(baseResult);
     }
-    return Optional.absent();
+    return Optional.empty();
   }
 
   public ConstructorClassMatcherImpl(ConstructorMatcherImpl baseMatcher, TypePredicate predicate) {

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/ConstructorMatcherImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/ConstructorMatcherImpl.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.matchers.method;
 
-import com.google.common.base.Optional;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.method.MethodMatchers.ConstructorClassMatcher;
 import com.google.errorprone.matchers.method.MethodMatchers.ConstructorMatcher;
@@ -28,6 +27,7 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Type;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 /** Matches constructors, allows refinement on class type. */
@@ -38,7 +38,7 @@ public class ConstructorMatcherImpl extends AbstractSimpleMatcher<MatchState>
   protected Optional<MatchState> matchResult(ExpressionTree tree, VisitorState state) {
     MethodSymbol sym = getConstructor(tree);
     if (sym == null) {
-      return Optional.absent();
+      return Optional.empty();
     }
     return Optional.of(MatchState.create(sym.owner.type, sym));
   }

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/InstanceMethodMatcherImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/InstanceMethodMatcherImpl.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.matchers.method;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.method.MethodMatchers.InstanceMethodMatcher;
@@ -26,6 +25,7 @@ import com.google.errorprone.predicates.TypePredicates;
 import com.google.errorprone.suppliers.Supplier;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.tools.javac.code.Type;
+import java.util.Optional;
 
 /** Matches instance methods. */
 class InstanceMethodMatcherImpl extends MethodMatcher implements InstanceMethodMatcher {
@@ -34,7 +34,7 @@ class InstanceMethodMatcherImpl extends MethodMatcher implements InstanceMethodM
   protected Optional<MatchState> matchResult(
       ExpressionTree item, MatchState method, VisitorState state) {
     if (method.sym().isStatic()) {
-      return Optional.absent();
+      return Optional.empty();
     }
     return Optional.of(method);
   }

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/MatchState.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/MatchState.java
@@ -17,9 +17,9 @@
 package com.google.errorprone.matchers.method;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Type;
+import java.util.List;
 
 /** The state that is propagated across a match operation. */
 @AutoValue
@@ -31,10 +31,11 @@ abstract class MatchState {
   abstract MethodSymbol sym();
 
   /** The method's formal parameter types. */
-  abstract ImmutableList<Type> paramTypes();
+  final List<Type> paramTypes() {
+    return sym().type.getParameterTypes();
+  }
 
   static MatchState create(Type ownerType, MethodSymbol methodSymbol) {
-    return new AutoValue_MatchState(
-        ownerType, methodSymbol, ImmutableList.copyOf(methodSymbol.type.getParameterTypes()));
+    return new AutoValue_MatchState(ownerType, methodSymbol);
   }
 }

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/MethodClassMatcherImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/MethodClassMatcherImpl.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.matchers.method;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.method.MethodMatchers.MethodClassMatcher;
@@ -25,6 +24,7 @@ import com.google.errorprone.matchers.method.MethodMatchers.MethodSignatureMatch
 import com.google.errorprone.matchers.method.MethodNameMatcherImpl.Regex;
 import com.google.errorprone.predicates.TypePredicate;
 import com.sun.source.tree.ExpressionTree;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 /** Matches on the method's class type, and allows refinement on method name or signature. */
@@ -41,9 +41,7 @@ class MethodClassMatcherImpl extends AbstractChainedMatcher<MatchState, MatchSta
   @Override
   protected Optional<MatchState> matchResult(
       ExpressionTree item, MatchState method, VisitorState state) {
-    return predicate.apply(method.ownerType(), state)
-        ? Optional.of(method)
-        : Optional.<MatchState>absent();
+    return predicate.apply(method.ownerType(), state) ? Optional.of(method) : Optional.empty();
   }
 
   @Override

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/MethodMatcher.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/MethodMatcher.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.matchers.method;
 
-import com.google.common.base.Optional;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
@@ -24,6 +23,7 @@ import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import java.util.Optional;
 
 /** Base matcher for member methods. */
 abstract class MethodMatcher extends AbstractChainedMatcher<MatchState, MatchState> {
@@ -33,11 +33,11 @@ abstract class MethodMatcher extends AbstractChainedMatcher<MatchState, MatchSta
         public Optional<MatchState> matchResult(ExpressionTree tree, VisitorState state) {
           Symbol sym = ASTHelpers.getSymbol(tree);
           if (!(sym instanceof MethodSymbol)) {
-            return Optional.absent();
+            return Optional.empty();
           }
           if (tree instanceof NewClassTree) {
             // Don't match constructors as they are neither static nor instance methods.
-            return Optional.absent();
+            return Optional.empty();
           }
           if (tree instanceof MethodInvocationTree) {
             tree = ((MethodInvocationTree) tree).getMethodSelect();

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/MethodNameMatcherImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/MethodNameMatcherImpl.java
@@ -18,7 +18,6 @@ package com.google.errorprone.matchers.method;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.method.MethodMatchers.MethodNameMatcher;
@@ -27,6 +26,7 @@ import com.google.errorprone.suppliers.Suppliers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.tools.javac.util.Name;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 /** Matchers that select on method name. */
@@ -64,7 +64,7 @@ public abstract class MethodNameMatcherImpl extends AbstractChainedMatcher<Match
     protected Optional<MatchState> matchResult(
         ExpressionTree item, MatchState method, VisitorState state) {
       if (!method.sym().getSimpleName().contentEquals(name)) {
-        return Optional.absent();
+        return Optional.empty();
       }
       return Optional.of(method);
     }
@@ -97,7 +97,7 @@ public abstract class MethodNameMatcherImpl extends AbstractChainedMatcher<Match
     protected Optional<MatchState> matchResult(
         ExpressionTree item, MatchState method, VisitorState state) {
       if (!regex.matcher(method.sym().getSimpleName().toString()).matches()) {
-        return Optional.absent();
+        return Optional.empty();
       }
       return Optional.of(method);
     }
@@ -119,7 +119,7 @@ public abstract class MethodNameMatcherImpl extends AbstractChainedMatcher<Match
       Name symbolName = method.sym().getSimpleName();
       return names.stream().anyMatch(symbolName::contentEquals)
           ? Optional.of(method)
-          : Optional.absent();
+          : Optional.empty();
     }
   }
 }

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/MethodSignatureMatcherImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/MethodSignatureMatcherImpl.java
@@ -16,10 +16,10 @@
 
 package com.google.errorprone.matchers.method;
 
-import com.google.common.base.Optional;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.method.MethodMatchers.MethodSignatureMatcher;
 import com.sun.source.tree.ExpressionTree;
+import java.util.Optional;
 
 /** Matches on method signature. */
 public class MethodSignatureMatcherImpl extends AbstractChainedMatcher<MatchState, MatchState>
@@ -39,6 +39,6 @@ public class MethodSignatureMatcherImpl extends AbstractChainedMatcher<MatchStat
     boolean matches =
         method.sym().getSimpleName().contentEquals(methodName)
             || method.sym().toString().equals(methodName);
-    return matches ? Optional.of(method) : Optional.<MatchState>absent();
+    return matches ? Optional.of(method) : Optional.empty();
   }
 }

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/ParameterMatcherImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/ParameterMatcherImpl.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.matchers.method;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.method.MethodMatchers.ParameterMatcher;
@@ -25,6 +24,7 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.tools.javac.code.Type;
 import java.util.List;
+import java.util.Optional;
 
 /** Matches on a method's formal parameters. */
 public class ParameterMatcherImpl extends AbstractChainedMatcher<MatchState, MatchState>
@@ -43,11 +43,11 @@ public class ParameterMatcherImpl extends AbstractChainedMatcher<MatchState, Mat
       ExpressionTree item, MatchState info, VisitorState state) {
     List<Type> actual = info.paramTypes();
     if (actual.size() != expected.size()) {
-      return Optional.absent();
+      return Optional.empty();
     }
     for (int i = 0; i < actual.size(); ++i) {
       if (!ASTHelpers.isSameType(actual.get(i), expected.get(i).get(state), state)) {
-        return Optional.absent();
+        return Optional.empty();
       }
     }
     return Optional.of(info);

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/ParameterMatcherImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/ParameterMatcherImpl.java
@@ -24,6 +24,7 @@ import com.google.errorprone.suppliers.Supplier;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.tools.javac.code.Type;
+import java.util.List;
 
 /** Matches on a method's formal parameters. */
 public class ParameterMatcherImpl extends AbstractChainedMatcher<MatchState, MatchState>
@@ -40,7 +41,7 @@ public class ParameterMatcherImpl extends AbstractChainedMatcher<MatchState, Mat
   @Override
   protected Optional<MatchState> matchResult(
       ExpressionTree item, MatchState info, VisitorState state) {
-    ImmutableList<Type> actual = ImmutableList.copyOf(info.paramTypes());
+    List<Type> actual = info.paramTypes();
     if (actual.size() != expected.size()) {
       return Optional.absent();
     }

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/StaticMethodMatcherImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/StaticMethodMatcherImpl.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.matchers.method;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.method.MethodMatchers.StaticMethodMatcher;
@@ -25,6 +24,7 @@ import com.google.errorprone.predicates.TypePredicates;
 import com.google.errorprone.suppliers.Supplier;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.tools.javac.code.Type;
+import java.util.Optional;
 
 /** Matches static methods, allows refinement on class type. */
 class StaticMethodMatcherImpl extends MethodMatcher implements StaticMethodMatcher {
@@ -32,7 +32,7 @@ class StaticMethodMatcherImpl extends MethodMatcher implements StaticMethodMatch
   protected Optional<MatchState> matchResult(
       ExpressionTree item, MatchState method, VisitorState state) {
     if (!method.sym().isStatic()) {
-      return Optional.absent();
+      return Optional.empty();
     }
     return Optional.of(method);
   }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -336,6 +336,13 @@
       <version>3.9.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <!-- Apache 2.0 -->
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <version>3.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AbstractMockChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AbstractMockChecker.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.Lists;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.code.Attribute.Compound;
+import com.sun.tools.javac.code.Symbol.CompletionFailure;
+import com.sun.tools.javac.code.Symbol.TypeSymbol;
+import com.sun.tools.javac.code.Type;
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+
+/**
+ * Helper for enforcing Annotations that disallow mocking.
+ *
+ * @author amalloy@google.com (Alan Malloy)
+ */
+public abstract class AbstractMockChecker<T extends Annotation> extends BugChecker
+    implements MethodInvocationTreeMatcher, VariableTreeMatcher {
+
+  public AbstractMockChecker(
+      TypeExtractor<VariableTree> varExtractor,
+      TypeExtractor<MethodInvocationTree> methodExtractor,
+      Class<T> annotationClass,
+      Function<T, String> getValueFunction) {
+    this.varExtractor = varExtractor;
+    this.methodExtractor = methodExtractor;
+    this.annotationClass = annotationClass;
+    this.getValueFunction = getValueFunction;
+    this.annotationName = annotationClass.getSimpleName();
+  }
+
+  /**
+   * A policy for determining what classes should not be mocked.
+   *
+   * <p>This interface's intended use is to forbid mocking of classes you don't control, for example
+   * those in the JDK itself or in a library you use.
+   */
+  public interface MockForbidder {
+
+    /**
+     * If the given type should not be mocked, provide an explanation why.
+     *
+     * @param type the type that is being mocked
+     * @return the reason it should not be mocked
+     */
+    Optional<Reason> forbidReason(Type type, VisitorState state);
+  }
+
+  /** An explanation of what type should not be mocked, and the reason why. */
+  @AutoValue
+  public abstract static class Reason {
+
+    public static Reason of(Type t, String reason) {
+      return new AutoValue_AbstractMockChecker_Reason(t, reason);
+    }
+
+    /** A Type object representing the class that should not be mocked. */
+    public abstract Type unmockableClass();
+
+    /**
+     * The reason this class should not be mocked, which may be as simple as "it is annotated to
+     * forbid mocking" but may also provide a suggested workaround.
+     */
+    public abstract String reason();
+  }
+
+  /**
+   * Produce a MockForbidder to use when looking for disallowed mocks, in addition to the built-in
+   * checks for Annotations of type {@code T}.
+   *
+   * <p>This method will be called at most once for each instance of AbstractMockChecker, but of
+   * course the returned object's {@link MockForbidder#forbidReason(Type, VisitorState)
+   * forbidReason} method may be called many times.
+   *
+   * <p>The default implementation forbids nothing.
+   */
+  protected MockForbidder forbidder() {
+    return (type, state) -> Optional.empty();
+  }
+
+  /**
+   * An extension of {@link Matcher} to return, not just a boolean `matches`, but also extract some
+   * type information about the Tree of interest.
+   *
+   * <p>This is used to identify what classes are being mocked in a Tree.
+   *
+   * @param <T> the type of Tree that this TypeExtractor operates on
+   */
+  public interface TypeExtractor<T extends Tree> {
+
+    /**
+     * Investigate the provided Tree, and return type information about it if it matches.
+     *
+     * @return the Type of the object being mocked, if any; Optional.empty() otherwise
+     */
+    Optional<Type> extract(T tree, VisitorState state);
+
+    /**
+     * Enrich this TypeExtractor with fallback behavior.
+     *
+     * @return a TypeExtractor which first tries {@code this.extract(t, s)}, and if that does not
+     *     match, falls back to {@code other.extract(t, s)}.
+     */
+    default TypeExtractor<T> or(TypeExtractor<T> other) {
+      return (tree, state) ->
+          TypeExtractor.this
+              .extract(tree, state)
+              .map(Optional::of)
+              .orElseGet(() -> other.extract(tree, state));
+    }
+  }
+
+  /**
+   * Produces an extractor which, if the tree matches, extracts the type of that tree, as given by
+   * {@link ASTHelpers#getType(Tree)}.
+   */
+  public static <T extends Tree> TypeExtractor<T> extractType(Matcher<T> m) {
+    return (tree, state) -> {
+      if (m.matches(tree, state)) {
+        return Optional.ofNullable(ASTHelpers.getType(tree));
+      }
+      return Optional.empty();
+    };
+  }
+
+  /**
+   * Produces an extractor which, if the tree matches, extracts the type of the first argument to
+   * the method invocation.
+   */
+  public static TypeExtractor<MethodInvocationTree> extractFirstArg(
+      Matcher<MethodInvocationTree> m) {
+    return (tree, state) -> {
+      if (m.matches(tree, state)) {
+        return Optional.ofNullable(ASTHelpers.getType(tree.getArguments().get(0)));
+      }
+      return Optional.empty();
+    };
+  }
+
+  /**
+   * Produces an extractor which, if the tree matches, extracts the type of the first argument whose
+   * type is {@link Class} (preserving its {@code <T>} type parameter, if it has one}.
+   *
+   * @param m the matcher to use. It is an error for this matcher to succeed on any Tree that does
+   *     not include at least one argument of type {@link Class}; if such a matcher is provided, the
+   *     behavior of the returned Extractor is undefined.
+   */
+  public static TypeExtractor<MethodInvocationTree> extractClassArg(
+      Matcher<MethodInvocationTree> m) {
+    return (tree, state) -> {
+      if (m.matches(tree, state)) {
+        for (ExpressionTree argument : tree.getArguments()) {
+          Type argumentType = ASTHelpers.getType(argument);
+          if (ASTHelpers.isSameType(argumentType, state.getSymtab().classType, state)) {
+            return Optional.of(argumentType);
+          }
+        }
+        // It's undefined, so we could fall through - but an exception is less likely to surprise.
+        throw new IllegalStateException();
+      }
+      return Optional.empty();
+    };
+  }
+
+  /**
+   * Creates a TypeExtractor that extracts the type of a class field if that field is annotated with
+   * any one of the given annotations.
+   */
+  public static TypeExtractor<VariableTree> fieldAnnotatedWithOneOf(
+      Stream<String> annotationClasses) {
+    return extractType(
+        Matchers.allOf(
+            Matchers.isField(),
+            Matchers.anyOf(
+                annotationClasses.map(Matchers::hasAnnotation).collect(Collectors.toList()))));
+  }
+
+  /**
+   * A TypeExtractor for method invocations that create a mock using Mockito.mock, Mockito.spy, or
+   * EasyMock.create[...]Mock, extracting the type being mocked.
+   */
+  public static final TypeExtractor<MethodInvocationTree> MOCKING_METHOD =
+      extractFirstArg(
+              Matchers.toType(
+                  MethodInvocationTree.class,
+                  Matchers.staticMethod().onClass("org.mockito.Mockito").namedAnyOf("mock", "spy")))
+          .or(
+              extractClassArg(
+                  Matchers.toType(
+                      MethodInvocationTree.class,
+                      Matchers.staticMethod()
+                          .onClass("org.easymock.EasyMock")
+                          .withNameMatching(Pattern.compile("^create.*Mock(Builder)?$")))));
+
+  @Override
+  public final Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    return this.methodExtractor
+        .extract(tree, state)
+        .flatMap(type -> argFromClass(type, state))
+        .map(type -> checkMockedType(type, tree, state))
+        .orElse(NO_MATCH);
+  }
+
+  @Override
+  public final Description matchVariable(VariableTree tree, VisitorState state) {
+    return varExtractor
+        .extract(tree, state)
+        .map(type -> checkMockedType(type, tree, state))
+        .orElse(NO_MATCH);
+  }
+
+  private Description checkMockedType(Type mockedClass, Tree tree, VisitorState state) {
+    if (ASTHelpers.isSameType(Type.noType, mockedClass, state)) {
+      return NO_MATCH;
+    }
+
+    // We could extract this for loop to a "default" MockForbidder, but there's not much
+    // advantage in doing so.
+    for (Type currentType : Lists.reverse(state.getTypes().closure(mockedClass))) {
+      TypeSymbol currentSymbol = currentType.asElement();
+      T doNotMock = currentSymbol.getAnnotation(annotationClass);
+      if (doNotMock != null) {
+        return buildDescription(tree)
+            .setMessage(buildMessage(mockedClass, currentSymbol, doNotMock))
+            .build();
+      }
+
+      for (Compound compound : currentSymbol.getAnnotationMirrors()) {
+        TypeSymbol metaAnnotationType = (TypeSymbol) compound.getAnnotationType().asElement();
+        try {
+          metaAnnotationType.complete();
+        } catch (CompletionFailure e) {
+          // if the annotation isn't on the compilation classpath, we can't check it for
+          // the annotationClass meta-annotation
+          continue;
+        }
+        doNotMock = metaAnnotationType.getAnnotation(annotationClass);
+        if (doNotMock != null) {
+          return buildDescription(tree)
+              .setMessage(buildMessage(mockedClass, currentSymbol, metaAnnotationType, doNotMock))
+              .build();
+        }
+      }
+    }
+    return forbidder
+        .get()
+        .forbidReason(mockedClass, state)
+        .map(
+            reason ->
+                buildDescription(tree)
+                    .setMessage(
+                        buildMessage(mockedClass, reason.unmockableClass().tsym, reason.reason()))
+                    .build())
+        .orElse(NO_MATCH);
+  }
+
+  /**
+   * If type is Class<T>, returns the erasure of T. Otherwise, returns type unmodified. Returns
+   * empty() when provided a raw Class as argument.
+   */
+  private static Optional<Type> argFromClass(Type type, VisitorState state) {
+    if (ASTHelpers.isSameType(type, state.getSymtab().classType, state)) {
+      if (type.getTypeArguments().isEmpty()) {
+        return Optional.empty();
+      }
+      return Optional.of(state.getTypes().erasure(getOnlyElement(type.getTypeArguments())));
+    }
+    return Optional.of(type);
+  }
+
+  private String buildMessage(Type mockedClass, TypeSymbol forbiddenType, T doNotMock) {
+    return buildMessage(mockedClass, forbiddenType, null, doNotMock);
+  }
+
+  private String buildMessage(
+      Type mockedClass,
+      TypeSymbol forbiddenType,
+      @Nullable TypeSymbol metaAnnotationType,
+      T doNotMock) {
+    return String.format(
+        "%s; %s is annotated as @%s%s: %s.",
+        buildMessage(mockedClass, forbiddenType),
+        forbiddenType,
+        metaAnnotationType == null ? annotationName : metaAnnotationType,
+        (metaAnnotationType == null
+            ? ""
+            : String.format(" (which is annotated as @%s)", annotationName)),
+        Optional.ofNullable(Strings.emptyToNull(getValueFunction.apply(doNotMock)))
+            .orElseGet(() -> String.format("It is annotated as %s.", annotationName)));
+  }
+
+  private static String buildMessage(Type mockedClass, TypeSymbol forbiddenType) {
+    return String.format(
+        "Do not mock '%s'%s",
+        mockedClass,
+        (mockedClass.asElement().equals(forbiddenType)
+            ? ""
+            : " (which is-a '" + forbiddenType + "')"));
+  }
+
+  private static String buildMessage(Type mockedClass, TypeSymbol forbiddenType, String reason) {
+    return String.format("%s: %s.", buildMessage(mockedClass, forbiddenType), reason);
+  }
+
+  private final TypeExtractor<VariableTree> varExtractor;
+  private final TypeExtractor<MethodInvocationTree> methodExtractor;
+  private final Class<T> annotationClass;
+  private final String annotationName;
+  private final Function<T, String> getValueFunction;
+  private final Supplier<MockForbidder> forbidder = Suppliers.memoize(this::forbidder);
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AbstractToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AbstractToString.java
@@ -78,7 +78,7 @@ public abstract class AbstractToString extends BugChecker
       Tree parent, ExpressionTree expression, VisitorState state);
 
   private static final Matcher<ExpressionTree> TO_STRING =
-      instanceMethod().onDescendantOf("java.lang.Object").withSignature("toString()");
+      instanceMethod().anyClass().withSignature("toString()");
 
   private static final Matcher<ExpressionTree> PRINT_STRING =
       anyOf(

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AnnotationPosition.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AnnotationPosition.java
@@ -148,7 +148,7 @@ public final class AnnotationPosition extends BugChecker
   }
 
   /** Tokenizes as little of the {@code tree} as possible to ensure we grab all the annotations. */
-  private static ImmutableList<ErrorProneToken> annotationTokens(
+  private static List<ErrorProneToken> annotationTokens(
       Tree tree, VisitorState state, int annotationEnd) {
     int endPos;
     if (tree instanceof JCMethodDecl) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AssignmentToMock.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AssignmentToMock.java
@@ -28,6 +28,7 @@ import static com.google.errorprone.matchers.Matchers.hasArgumentWithValue;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.AssignmentTreeMatcher;
@@ -49,6 +50,7 @@ import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreeScanner;
 import com.sun.tools.javac.parser.Tokens.TokenKind;
 import com.sun.tools.javac.tree.JCTree;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /** Discourage manual initialization or assignment to fields annotated with {@code @Mock}. */
@@ -104,9 +106,9 @@ public final class AssignmentToMock extends BugChecker
       return SuggestedFix.delete(anno);
     }
     int startPos = ((JCTree) tree).getStartPosition();
-    ImmutableList<ErrorProneToken> tokens =
+    List<ErrorProneToken> tokens =
         state.getOffsetTokens(startPos, ((JCTree) tree.getInitializer()).getStartPosition());
-    for (ErrorProneToken token : tokens.reverse()) {
+    for (ErrorProneToken token : Lists.reverse(tokens)) {
       if (token.kind() == TokenKind.EQ) {
         return SuggestedFix.replace(token.pos(), state.getEndPosition(tree.getInitializer()), "");
       }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CatchFail.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CatchFail.java
@@ -37,10 +37,10 @@ import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.JUnitMatchers;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.method.MethodMatchers.MethodNameMatcher;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.CatchTree;
 import com.sun.source.tree.ExpressionStatementTree;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
@@ -71,7 +71,7 @@ import java.util.stream.Stream;
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class CatchFail extends BugChecker implements TryTreeMatcher {
 
-  public static final MethodNameMatcher ASSERT_WITH_MESSAGE =
+  public static final Matcher<ExpressionTree> ASSERT_WITH_MESSAGE =
       staticMethod().onClass("com.google.common.truth.Truth").named("assertWithMessage");
 
   private static final Matcher<StatementTree> FAIL_METHOD =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ChainedAssertionLosesContext.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ChainedAssertionLosesContext.java
@@ -16,6 +16,7 @@
 
 package com.google.errorprone.bugpatterns;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
@@ -24,13 +25,18 @@ import static com.google.errorprone.bugpatterns.ProvideDescriptionToCheck.findTh
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
 import static com.google.errorprone.util.ASTHelpers.getDeclaredSymbol;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
 import static com.google.errorprone.util.ASTHelpers.isSubtype;
 import static com.sun.source.tree.Tree.Kind.CLASS;
-import static java.util.stream.Collectors.joining;
+import static java.lang.String.format;
+import static java.util.stream.Stream.concat;
 import static javax.lang.model.element.Modifier.STATIC;
 
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
@@ -40,6 +46,8 @@ import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import javax.annotation.Nullable;
 
 /**
  * Identifies calls to {@code assertThat} and similar methods inside the implementation of a {@code
@@ -78,22 +86,44 @@ public final class ChainedAssertionLosesContext extends BugChecker
         // TODO(cpovirk): Generate a suggested fix without a check description.
         return NO_MATCH;
       }
-      return replace(tree, "check(%s).that(%s)", checkDescription, sourceForArgs(tree, state));
+      return replace(tree.getMethodSelect(), "check(%s).that", checkDescription);
+    } else if (ANY_ASSERT_THAT.matches(tree, state)) {
+      FactoryMethodName factory = tryFindFactory(tree, state);
+      if (factory == null) {
+        // TODO(cpovirk): Generate a warning that instructs the user to find or expose a factory.
+        return NO_MATCH;
+      }
+      if (tree.getArguments().size() != 1) {
+        // TODO(cpovirk): Generate a suggested fix without a check description.
+        return NO_MATCH;
+      }
+      String checkDescription = makeCheckDescription(getOnlyElement(tree.getArguments()), state);
+      if (checkDescription == null) {
+        // TODO(cpovirk): Generate a suggested fix without a check description.
+        return NO_MATCH;
+      }
+      return describeMatch(
+          tree,
+          SuggestedFix.builder()
+              .addStaticImport(factory.clazz() + "." + factory.method())
+              .replace(
+                  tree.getMethodSelect(),
+                  format("check(%s).about(%s()).that", checkDescription, factory.method()))
+              .build());
     } else if (ASSERT_ABOUT.matches(tree, state)) {
       String checkDescription = findThatCallAndMakeCheckDescription(state);
       if (checkDescription == null) {
         // TODO(cpovirk): Generate a suggested fix without a check description.
         return NO_MATCH;
       }
-      return replace(tree, "check(%s).about(%s)", checkDescription, sourceForArgs(tree, state));
+      return replace(tree.getMethodSelect(), "check(%s).about", checkDescription);
     } else if (ASSERT_WITH_MESSAGE.matches(tree, state)) {
       String checkDescription = findThatCallAndMakeCheckDescription(state);
       if (checkDescription == null) {
         // TODO(cpovirk): Generate a suggested fix without a check description.
         return NO_MATCH;
       }
-      return replace(
-          tree, "check(%s).withMessage(%s)", checkDescription, sourceForArgs(tree, state));
+      return replace(tree.getMethodSelect(), "check(%s).withMessage", checkDescription);
     } else if (ASSERT.matches(tree, state)) {
       String checkDescription = findThatCallAndMakeCheckDescription(state);
       if (checkDescription == null) {
@@ -110,15 +140,63 @@ public final class ChainedAssertionLosesContext extends BugChecker
     }
   }
 
+  @FormatMethod
   private Description replace(Tree tree, String format, Object... args) {
     return describeMatch(tree, SuggestedFix.replace(tree, String.format(format, args)));
   }
 
-  private static String sourceForArgs(MethodInvocationTree tree, VisitorState state) {
-    // TODO(cpovirk): This might lose comments.
-    return tree.getArguments().stream()
-        .map(arg -> state.getSourceForNode(arg))
-        .collect(joining(", "));
+  @AutoValue
+  abstract static class FactoryMethodName {
+    static FactoryMethodName create(String clazz, String method) {
+      return new AutoValue_ChainedAssertionLosesContext_FactoryMethodName(clazz, method);
+    }
+
+    @Nullable
+    static FactoryMethodName tryCreate(MethodSymbol symbol) {
+      return symbol.params.isEmpty()
+          ? create(symbol.owner.getQualifiedName().toString(), symbol.getSimpleName().toString())
+          : null;
+    }
+
+    abstract String clazz();
+
+    abstract String method();
+  }
+
+  @Nullable
+  private static FactoryMethodName tryFindFactory(
+      MethodInvocationTree assertThatCall, VisitorState state) {
+    MethodSymbol assertThatSymbol = getSymbol(assertThatCall);
+    if (assertThatSymbol == null) {
+      return null;
+    }
+    /*
+     * First, a special case for ProtoTruth.protos(). Usually the main case below finds it OK, but
+     * sometimes it misses it, I believe because it can't decide between that and
+     * IterableOfProtosSubject.iterableOfMessages.
+     */
+    if (assertThatSymbol.owner.getQualifiedName().contentEquals(PROTO_TRUTH_CLASS)) {
+      return FactoryMethodName.create(PROTO_TRUTH_CLASS, "protos");
+    }
+    ImmutableSet<MethodSymbol> factories =
+        concat(
+                // The class that assertThat is declared in:
+                assertThatSymbol.owner.getEnclosedElements().stream(),
+                // The Subject class (possibly the same; if so, toImmutableSet() will deduplicate):
+                assertThatSymbol.getReturnType().asElement().getEnclosedElements().stream())
+            .filter(s -> s instanceof MethodSymbol)
+            .map(s -> (MethodSymbol) s)
+            .filter(
+                s ->
+                    returns(s, SUBJECT_FACTORY_CLASS, state)
+                        || returns(s, CUSTOM_SUBJECT_BUILDER_FACTORY_CLASS, state))
+            .collect(toImmutableSet());
+    return factories.size() == 1 ? FactoryMethodName.tryCreate(getOnlyElement(factories)) : null;
+    // TODO(cpovirk): If multiple factories exist, try filtering to visible ones only.
+  }
+
+  private static boolean returns(MethodSymbol symbol, String returnType, VisitorState state) {
+    return isSubtype(symbol.getReturnType(), state.getTypeFromString(returnType), state);
   }
 
   private static boolean inInstanceMethodOfSubjectImplementation(VisitorState state) {
@@ -145,9 +223,7 @@ public final class ChainedAssertionLosesContext extends BugChecker
      * IterableSubject.UsingCorrespondence.
      */
     return isSubtype(
-        getDeclaredSymbol(enclosingClass).type,
-        state.getTypeFromString("com.google.common.truth.Subject"),
-        state);
+        getDeclaredSymbol(enclosingClass).type, state.getTypeFromString(SUBJECT_CLASS), state);
   }
 
   private static String findThatCallAndMakeCheckDescription(VisitorState state) {
@@ -158,12 +234,22 @@ public final class ChainedAssertionLosesContext extends BugChecker
     return makeCheckDescription(getOnlyElement(thatCall.getArguments()), state);
   }
 
+  private static final String TRUTH_CLASS = "com.google.common.truth.Truth";
+  private static final String PROTO_TRUTH_CLASS =
+      "com.google.common.truth.extensions.proto.ProtoTruth";
+  private static final String SUBJECT_CLASS = "com.google.common.truth.Subject";
+  private static final String SUBJECT_FACTORY_CLASS = "com.google.common.truth.Subject.Factory";
+  private static final String CUSTOM_SUBJECT_BUILDER_FACTORY_CLASS =
+      "com.google.common.truth.CustomSubjectBuilder.Factory";
+
   private static final Matcher<ExpressionTree> STANDARD_ASSERT_THAT =
-      staticMethod().onClass("com.google.common.truth.Truth").named("assertThat");
+      staticMethod().onClass(TRUTH_CLASS).named("assertThat");
+  private static final Matcher<ExpressionTree> ANY_ASSERT_THAT =
+      staticMethod().anyClass().named("assertThat");
   private static final Matcher<ExpressionTree> ASSERT_ABOUT =
-      staticMethod().onClass("com.google.common.truth.Truth").named("assertAbout");
+      staticMethod().onClass(TRUTH_CLASS).named("assertAbout");
   private static final Matcher<ExpressionTree> ASSERT_WITH_MESSAGE =
-      staticMethod().onClass("com.google.common.truth.Truth").named("assertWithMessage");
+      staticMethod().onClass(TRUTH_CLASS).named("assertWithMessage");
   private static final Matcher<ExpressionTree> ASSERT =
-      staticMethod().onClass("com.google.common.truth.Truth").named("assert_");
+      staticMethod().onClass(TRUTH_CLASS).named("assert_");
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DoNotMockChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DoNotMockChecker.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.annotations.DoNotMock;
+import com.sun.source.tree.VariableTree;
+import java.util.stream.Stream;
+
+/**
+ * Points out if a Mockito or EasyMock mock is mocking an object that would be better off being
+ * tested using an alternative instance.
+ *
+ * @author amalloy@google.com (Alan Malloy)
+ */
+@BugPattern(
+    name = "DoNotMock",
+    severity = SeverityLevel.ERROR,
+    summary = "Identifies undesirable mocks.",
+    documentSuppression = false)
+public class DoNotMockChecker extends AbstractMockChecker<DoNotMock> {
+
+  private static final TypeExtractor<VariableTree> MOCKED_VAR =
+      fieldAnnotatedWithOneOf(
+          Stream.of(
+              "org.mockito.Mock",
+              "org.mockito.Spy"));
+
+  public DoNotMockChecker() {
+    super(MOCKED_VAR, MOCKING_METHOD, DoNotMock.class, DoNotMock::value);
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ImmutableModification.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ImmutableModification.java
@@ -47,47 +47,38 @@ public class ImmutableModification extends BugChecker implements MethodInvocatio
           .putAll(
               "com.google.common.collect.ImmutableCollection",
               "add",
-              "remove",
               "addAll",
+              "clear",
+              "remove",
               "removeAll",
               "removeIf",
-              "retainAll",
-              "clear")
-          .putAll(
-              "com.google.common.collect.ImmutableList",
-              "addAll",
-              "set",
-              "add",
-              "remove",
-              "replaceAll",
-              "sort")
-          .putAll("com.google.common.collect.ImmutableListMultimap", "removeAll", "replaceValues")
+              "retainAll")
+          .putAll("com.google.common.collect.ImmutableList", "set", "sort")
           .putAll(
               "com.google.common.collect.ImmutableMap",
-              "put",
-              "putIfAbsent",
-              "replace",
+              "clear",
+              "compute",
               "computeIfAbsent",
               "computeIfPresent",
-              "compute",
               "merge",
+              "put",
               "putAll",
-              "replaceAll",
+              "putIfAbsent",
               "remove",
-              "clear")
+              "replace",
+              "replaceAll")
           .putAll(
               "com.google.common.collect.ImmutableMultimap",
-              "removeAll",
-              "replaceValues",
               "clear",
               "put",
               "putAll",
-              "remove")
-          .putAll("com.google.common.collect.ImmutableMultiset", "add", "remove", "setCount")
-          .putAll("com.google.common.collect.ImmutableRangeMap", "put", "putAll", "clear", "remove")
+              "remove",
+              "removeAll",
+              "replaceValues")
+          .putAll("com.google.common.collect.ImmutableMultiset", "setCount")
+          .putAll("com.google.common.collect.ImmutableRangeMap", "clear", "put", "putAll", "remove")
           .putAll(
               "com.google.common.collect.ImmutableRangeSet", "add", "addAll", "remove", "removeAll")
-          .putAll("com.google.common.collect.ImmutableSetMultimap", "removeAll", "replaceValues")
           .putAll("com.google.common.collect.ImmutableSortedMap", "pollFirstEntry", "pollLastEntry")
           .putAll("com.google.common.collect.ImmutableSortedSet", "pollFirst", "pollLast")
           .putAll("com.google.common.collect.ImmutableTable", "clear", "put", "putAll", "remove")
@@ -96,12 +87,12 @@ public class ImmutableModification extends BugChecker implements MethodInvocatio
           .putAll(
               "com.google.common.collect.Sets.SetView",
               "add",
-              "remove",
               "addAll",
+              "clear",
+              "remove",
               "removeAll",
               "removeIf",
-              "retainAll",
-              "clear")
+              "retainAll")
           .build();
 
   static final Matcher<ExpressionTree> MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InterfaceWithOnlyStatics.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InterfaceWithOnlyStatics.java
@@ -20,7 +20,6 @@ import static com.google.common.collect.Iterables.getLast;
 import static com.google.errorprone.bugpatterns.inject.dagger.DaggerAnnotations.isAnyModule;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 
-import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
@@ -106,7 +105,7 @@ public final class InterfaceWithOnlyStatics extends BugChecker implements ClassT
   private static SuggestedFix fixClass(ClassTree classTree, VisitorState state) {
     int startPos = ((JCTree) classTree).getStartPosition();
     int endPos = ((JCTree) classTree.getMembers().get(0)).getStartPosition();
-    ImmutableList<ErrorProneToken> tokens = state.getOffsetTokens(startPos, endPos);
+    List<ErrorProneToken> tokens = state.getOffsetTokens(startPos, endPos);
     String modifiers =
         getSymbol(classTree).owner.enclClass() == null ? "final class" : "static final class";
     SuggestedFix.Builder fix = SuggestedFix.builder();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LockNotBeforeTry.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LockNotBeforeTry.java
@@ -30,7 +30,6 @@ import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.method.MethodMatchers.MethodClassMatcher;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ExpressionStatementTree;
 import com.sun.source.tree.ExpressionTree;
@@ -56,10 +55,10 @@ import com.sun.source.util.TreeScanner;
     providesFix = REQUIRES_HUMAN_ATTENTION)
 public final class LockNotBeforeTry extends BugChecker implements MethodInvocationTreeMatcher {
 
-  private static final MethodClassMatcher LOCK_METHOD =
-      instanceMethod().onDescendantOf("java.util.concurrent.locks.Lock");
-  private static final Matcher<ExpressionTree> LOCK = LOCK_METHOD.named("lock");
-  private static final Matcher<ExpressionTree> UNLOCK = LOCK_METHOD.named("unlock");
+  private static final Matcher<ExpressionTree> LOCK =
+      instanceMethod().onDescendantOf("java.util.concurrent.locks.Lock").named("lock");
+  private static final Matcher<ExpressionTree> UNLOCK =
+      instanceMethod().onDescendantOf("java.util.concurrent.locks.Lock").named("unlock");
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MathRoundIntLong.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MathRoundIntLong.java
@@ -31,8 +31,8 @@ import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.method.MethodMatchers.MethodNameMatcher;
 import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 
 /**
@@ -50,7 +50,7 @@ import com.sun.source.tree.MethodInvocationTree;
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public final class MathRoundIntLong extends BugChecker implements MethodInvocationTreeMatcher {
-  private static final MethodNameMatcher MATH_ROUND_CALLS =
+  private static final Matcher<ExpressionTree> MATH_ROUND_CALLS =
       staticMethod().onClass("java.lang.Math").named("round");
 
   private static final Matcher<MethodInvocationTree> ROUND_CALLS_WITH_INT_ARG =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MixedArrayDimensions.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MixedArrayDimensions.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.common.base.CharMatcher;
-import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
@@ -35,6 +34,7 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.parser.Tokens.TokenKind;
+import java.util.List;
 
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
@@ -70,7 +70,7 @@ public class MixedArrayDimensions extends BugChecker
       if (start >= end) {
         continue;
       }
-      ImmutableList<ErrorProneToken> tokens = state.getOffsetTokens(start, end);
+      List<ErrorProneToken> tokens = state.getOffsetTokens(start, end);
       if (tokens.size() > 2 && tokens.get(0).kind() == TokenKind.IDENTIFIER) {
         String dim = source.subSequence(start, end).toString();
         int nonWhitespace = CharMatcher.isNot(' ').indexIn(dim);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MultipleParallelOrSequentialCalls.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MultipleParallelOrSequentialCalls.java
@@ -25,8 +25,9 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
-import com.google.errorprone.matchers.method.MethodMatchers.MethodNameMatcher;
+import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.util.TreePath;
@@ -41,10 +42,10 @@ import com.sun.source.util.TreePath;
 public class MultipleParallelOrSequentialCalls extends BugChecker
     implements MethodInvocationTreeMatcher {
 
-  private static final MethodNameMatcher STREAM =
+  private static final Matcher<ExpressionTree> STREAM =
       instanceMethod().onDescendantOf("java.util.Collection").named("stream");
 
-  private static final MethodNameMatcher PARALLELSTREAM =
+  private static final Matcher<ExpressionTree> PARALLELSTREAM =
       instanceMethod().onDescendantOf("java.util.Collection").named("parallelStream");
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MustBeClosedChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MustBeClosedChecker.java
@@ -38,10 +38,10 @@ import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.method.MethodMatchers.ConstructorMatcher;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionStatementTree;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
@@ -73,7 +73,7 @@ public class MustBeClosedChecker extends AbstractMustBeClosedChecker
 
   private static final Matcher<MethodTree> AUTO_CLOSEABLE_CONSTRUCTOR_MATCHER =
       allOf(methodIsConstructor(), enclosingClass(isSubtypeOf(AutoCloseable.class)));
-  private static final ConstructorMatcher CONSTRUCTOR = constructor();
+  private static final Matcher<ExpressionTree> CONSTRUCTOR = constructor();
 
   /**
    * Check that the {@link MustBeClosed} annotation is only used for constructors of AutoCloseables

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OptionalNotPresent.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OptionalNotPresent.java
@@ -21,8 +21,8 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
-import com.google.errorprone.matchers.method.MethodMatchers.MethodNameMatcher;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.BinaryTree;
@@ -46,12 +46,12 @@ import java.util.Iterator;
     severity = WARNING)
 public class OptionalNotPresent extends BugChecker implements MethodInvocationTreeMatcher {
 
-  private static final MethodNameMatcher GOOGLE_OPTIONAL_PRESENT =
+  private static final Matcher<ExpressionTree> GOOGLE_OPTIONAL_PRESENT =
       Matchers.instanceMethod()
           .onDescendantOf(com.google.common.base.Optional.class.getName())
           .named("isPresent");
 
-  private static final MethodNameMatcher OPTIONAL_PRESENT =
+  private static final Matcher<ExpressionTree> OPTIONAL_PRESENT =
       Matchers.instanceMethod().onDescendantOf("java.util.Optional").named("isPresent");
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OutlineNone.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OutlineNone.java
@@ -30,7 +30,6 @@ import com.google.errorprone.matchers.AnnotationMatcherUtils;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
-import com.google.errorprone.matchers.method.MethodMatchers.MethodNameMatcher;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -51,7 +50,7 @@ public class OutlineNone extends BugChecker
   // TODO(b/119196262): Expand to more methods of setting CSS properties.
   private static final Matcher<AnnotationTree> TEMPLATE_ANNOTATION =
       Matchers.isType("com.google.gwt.safehtml.client.SafeHtmlTemplates.Template");
-  private static final MethodNameMatcher GWT_SET_PROPERTY =
+  private static final Matcher<ExpressionTree> GWT_SET_PROPERTY =
       Matchers.instanceMethod()
           .onDescendantOf("com.google.gwt.dom.client.Style")
           .withNameMatching(Pattern.compile("setProperty(Px)?"));

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ReferenceEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ReferenceEquality.java
@@ -80,8 +80,10 @@ public class ReferenceEquality extends AbstractReferenceEquality {
     }
     Symbol compareTo = getOnlyMember(state, state.getSymtab().comparableType, "compareTo");
     Symbol equals = getOnlyMember(state, state.getSymtab().objectType, "equals");
-    if (!sym.overrides(compareTo, classType.tsym, state.getTypes(), /* checkResult= */ false)
-        && !sym.overrides(equals, classType.tsym, state.getTypes(), /* checkResult= */ false)) {
+    if (!(sym.getSimpleName().contentEquals("compareTo")
+            && sym.overrides(compareTo, classType.tsym, state.getTypes(), /* checkResult= */ false))
+        && !(sym.getSimpleName().contentEquals("equals")
+            && sym.overrides(equals, classType.tsym, state.getTypes(), /* checkResult= */ false))) {
       return false;
     }
     if (!ASTHelpers.isSameType(type, classType, state)) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SizeGreaterThanOrEqualsZero.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SizeGreaterThanOrEqualsZero.java
@@ -38,7 +38,6 @@ import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
-import com.google.errorprone.matchers.method.MethodMatchers.ParameterMatcher;
 import com.google.errorprone.predicates.TypePredicates;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.BinaryTree;
@@ -120,7 +119,7 @@ public class SizeGreaterThanOrEqualsZero extends BugChecker implements BinaryTre
               .onClass(TypePredicates.isDescendantOfAny(CLASSES.column(MethodName.LENGTH).keySet()))
               .named("length"));
   private static final Pattern PROTO_COUNT_METHOD_PATTERN = Pattern.compile("get(.+)Count");
-  private static final ParameterMatcher PROTO_METHOD_NAMED_GET_COUNT =
+  private static final Matcher<ExpressionTree> PROTO_METHOD_NAMED_GET_COUNT =
       instanceMethod()
           .onClass(TypePredicates.isDescendantOf("com.google.protobuf.GeneratedMessage"))
           .withNameMatching(PROTO_COUNT_METHOD_PATTERN)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SystemExitOutsideMain.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SystemExitOutsideMain.java
@@ -36,7 +36,6 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.method.MethodMatchers.MethodNameMatcher;
 import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
@@ -57,7 +56,7 @@ import java.util.Optional;
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class SystemExitOutsideMain extends BugChecker implements MethodInvocationTreeMatcher {
-  private static final MethodNameMatcher CALLS_TO_SYSTEM_EXIT =
+  private static final Matcher<ExpressionTree> CALLS_TO_SYSTEM_EXIT =
       staticMethod().onClass("java.lang.System").named("exit");
 
   private static final Matcher<MethodTree> MAIN_METHOD =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThreadJoinLoop.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThreadJoinLoop.java
@@ -27,12 +27,13 @@ import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
-import com.google.errorprone.matchers.method.MethodMatchers.MethodNameMatcher;
+import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.CatchTree;
 import com.sun.source.tree.EmptyStatementTree;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
@@ -53,7 +54,7 @@ import java.util.concurrent.atomic.AtomicInteger;
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ThreadJoinLoop extends BugChecker implements MethodInvocationTreeMatcher {
 
-  private static final MethodNameMatcher MATCH_THREAD_JOIN =
+  private static final Matcher<ExpressionTree> MATCH_THREAD_JOIN =
       instanceMethod().onDescendantOf("java.lang.Thread").named("join");
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TruthAssertExpected.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TruthAssertExpected.java
@@ -34,7 +34,6 @@ import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
-import com.google.errorprone.matchers.method.MethodMatchers.MethodNameMatcher;
 import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
@@ -65,10 +64,10 @@ public final class TruthAssertExpected extends BugChecker implements MethodInvoc
   private static final String TRUTH = "com.google.common.truth.Truth";
   private static final String PROTOTRUTH = "com.google.common.truth.extensions.proto.ProtoTruth";
 
-  private static final MethodNameMatcher TRUTH_ASSERTTHAT =
+  private static final Matcher<ExpressionTree> TRUTH_ASSERTTHAT =
       staticMethod().onClassAny(TRUTH, PROTOTRUTH).named("assertThat");
 
-  private static final MethodNameMatcher TRUTH_VERB =
+  private static final Matcher<ExpressionTree> TRUTH_VERB =
       instanceMethod()
           .onDescendantOf("com.google.common.truth.StandardSubjectBuilder")
           .named("that");

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryAnonymousClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryAnonymousClass.java
@@ -99,6 +99,9 @@ public class UnnecessaryAnonymousClass extends BugChecker implements VariableTre
     if (type == null || !state.getTypes().isFunctionalInterface(type)) {
       return NO_MATCH;
     }
+    if (state.isAndroidCompatible()) {
+      return NO_MATCH;
+    }
     SuggestedFix.Builder fix = SuggestedFix.builder();
     String name =
         sym.isStatic()

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryBoxedVariable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryBoxedVariable.java
@@ -23,8 +23,8 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.method.MethodMatchers;
-import com.google.errorprone.matchers.method.MethodMatchers.MethodNameMatcher;
 import com.google.errorprone.util.ASTHelpers;
 import com.google.errorprone.util.ASTHelpers.TargetType;
 import com.sun.source.tree.AssignmentTree;
@@ -65,7 +65,7 @@ import javax.lang.model.element.ElementKind;
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
     severity = SeverityLevel.SUGGESTION)
 public class UnnecessaryBoxedVariable extends BugChecker implements VariableTreeMatcher {
-  private static final MethodNameMatcher VALUE_OF_MATCHER =
+  private static final Matcher<ExpressionTree> VALUE_OF_MATCHER =
       MethodMatchers.staticMethod()
           .onClass(UnnecessaryBoxedVariable::isBoxableType)
           .named("valueOf");
@@ -221,11 +221,11 @@ public class UnnecessaryBoxedVariable extends BugChecker implements VariableTree
 
   private static class FindBoxedUsagesScanner extends TreeScanner<Void, Void> {
     // Method invocations like V.hashCode() can be replaced with TypeOfV.hashCode(v).
-    private static final MethodNameMatcher SIMPLE_METHOD_MATCH =
+    private static final Matcher<ExpressionTree> SIMPLE_METHOD_MATCH =
         MethodMatchers.instanceMethod().anyClass().namedAnyOf("hashCode", "toString");
 
     // Method invocations like V.intValue() can be replaced with (int) v.
-    private static final MethodNameMatcher CAST_METHOD_MATCH =
+    private static final Matcher<ExpressionTree> CAST_METHOD_MATCH =
         MethodMatchers.instanceMethod()
             .onClass(UnnecessaryBoxedVariable::isBoxableType)
             .namedAnyOf(

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryBoxedVariable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryBoxedVariable.java
@@ -32,6 +32,7 @@ import com.sun.source.tree.CompoundAssignmentTree;
 import com.sun.source.tree.EnhancedForLoopTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.ReturnTree;
@@ -341,6 +342,19 @@ public class UnnecessaryBoxedVariable extends BugChecker implements VariableTree
       // Don't count a return value as a boxed usage. If it's not otherwise used in a boxed way,
       // it is trivial to box it on return.
       return null;
+    }
+
+    @Override
+    public Void visitMemberReference(MemberReferenceTree node, Void aVoid) {
+      ExpressionTree qualifierExpression = node.getQualifierExpression();
+      if (qualifierExpression.getKind() == Kind.IDENTIFIER) {
+        Symbol symbol = ASTHelpers.getSymbol(qualifierExpression);
+        if (Objects.equals(symbol, varSymbol)) {
+          found = true;
+          return null;
+        }
+      }
+      return super.visitMemberReference(node, aVoid);
     }
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryLambda.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryLambda.java
@@ -94,6 +94,9 @@ public class UnnecessaryLambda extends BugChecker
     if (!canFix(type, sym, state)) {
       return NO_MATCH;
     }
+    if (state.isAndroidCompatible()) {
+      return NO_MATCH;
+    }
     new TreePathScanner<Void, Void>() {
       @Override
       public Void visitMethodInvocation(MethodInvocationTree node, Void unused) {
@@ -128,6 +131,9 @@ public class UnnecessaryLambda extends BugChecker
     }
     Tree type = tree.getType();
     if (!canFix(type, sym, state)) {
+      return NO_MATCH;
+    }
+    if (state.isAndroidCompatible()) {
       return NO_MATCH;
     }
     SuggestedFix.Builder fix = SuggestedFix.builder();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarySetDefault.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarySetDefault.java
@@ -52,7 +52,6 @@ import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.method.MethodMatchers.ParameterMatcher;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionStatementTree;
 import com.sun.source.tree.ExpressionTree;
@@ -245,7 +244,7 @@ public class UnnecessarySetDefault extends BugChecker implements MethodInvocatio
     return description.build();
   }
 
-  private static ParameterMatcher factoryMatcher(Class<?> clazz, String name) {
+  private static Matcher<ExpressionTree> factoryMatcher(Class<?> clazz, String name) {
     return staticMethod().onClass(clazz.getCanonicalName()).named(name).withParameters();
   }
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/TruthIncompatibleType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/TruthIncompatibleType.java
@@ -30,7 +30,6 @@ import com.google.errorprone.bugpatterns.collectionincompatibletype.AbstractColl
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.method.MethodMatchers;
-import com.google.errorprone.matchers.method.MethodMatchers.ParameterMatcher;
 import com.google.errorprone.util.ASTHelpers;
 import com.google.errorprone.util.Signatures;
 import com.sun.source.tree.ExpressionTree;
@@ -53,7 +52,7 @@ public class TruthIncompatibleType extends BugChecker implements MethodInvocatio
       new AbstractCollectionIncompatibleTypeMatcher() {
 
         // TODO(cushon): expand to other assertThat methods to handle e.g. ListSubject
-        private final ParameterMatcher assertThatObject =
+        private final Matcher<ExpressionTree> assertThatObject =
             MethodMatchers.staticMethod()
                 .onClass("com.google.common.truth.Truth")
                 .named("assertThat")

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/ScopeAnnotationOnInterfaceOrAbstractClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/ScopeAnnotationOnInterfaceOrAbstractClass.java
@@ -41,7 +41,7 @@ import com.sun.tools.javac.code.Flags;
 /** @author sgoldfeder@google.com (Steven Goldfeder) */
 @BugPattern(
     name = "InjectScopeAnnotationOnInterfaceOrAbstractClass",
-    summary = "Scope annotation on an interface or abstact class is not allowed",
+    summary = "Scope annotation on an interface or abstract class is not allowed",
     severity = ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class ScopeAnnotationOnInterfaceOrAbstractClass extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/AndroidInjectionBeforeSuper.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/AndroidInjectionBeforeSuper.java
@@ -35,10 +35,9 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.method.MethodMatchers.MethodNameMatcher;
-import com.google.errorprone.matchers.method.MethodMatchers.ParameterMatcher;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ExpressionStatementTree;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.VariableTree;
@@ -84,8 +83,8 @@ public final class AndroidInjectionBeforeSuper extends BugChecker implements Met
 
     private final String lifecycleMethod;
     private final Matcher<MethodTree> methodMatcher;
-    private final MethodNameMatcher methodInvocationMatcher;
-    private final ParameterMatcher injectMethodMatcher;
+    private final Matcher<ExpressionTree> methodInvocationMatcher;
+    private final Matcher<ExpressionTree> injectMethodMatcher;
 
     MatchType(
         String componentType,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByUtils.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByUtils.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.MoreAnnotations;
 import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.parser.JavacParser;
 import com.sun.tools.javac.parser.ParserFactory;
@@ -49,7 +50,11 @@ public class GuardedByUtils {
   }
 
   private static ImmutableSet<String> getAnnotationValueAsStrings(Symbol sym) {
-    return sym.getRawAttributes().stream()
+    List<Attribute.Compound> rawAttributes = sym.getRawAttributes();
+    if (rawAttributes.isEmpty()) {
+      return ImmutableSet.of();
+    }
+    return rawAttributes.stream()
         .filter(a -> a.getAnnotationType().asElement().getSimpleName().contentEquals("GuardedBy"))
         .flatMap(
             a ->

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaNewPeriod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaNewPeriod.java
@@ -34,7 +34,6 @@ import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.method.MethodMatchers.ConstructorClassMatcher;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -52,9 +51,6 @@ import java.util.List;
     providesFix = REQUIRES_HUMAN_ATTENTION)
 public final class JodaNewPeriod extends BugChecker implements MethodInvocationTreeMatcher {
 
-  private static final ConstructorClassMatcher PERIOD_CONSTRUCTOR =
-      constructor().forClass("org.joda.time.Period");
-
   private static final String READABLE_PARTIAL = "org.joda.time.ReadablePartial";
 
   private static final String READABLE_INSTANT = "org.joda.time.ReadableInstant";
@@ -67,9 +63,13 @@ public final class JodaNewPeriod extends BugChecker implements MethodInvocationT
                   "getMonths", "getWeeks", "getDays", "getHours", "getMinutes", "getSeconds"),
           receiverOfInvocation(
               anyOf(
-                  PERIOD_CONSTRUCTOR.withParameters("long", "long"),
-                  PERIOD_CONSTRUCTOR.withParameters(READABLE_PARTIAL, READABLE_PARTIAL),
-                  PERIOD_CONSTRUCTOR.withParameters(READABLE_INSTANT, READABLE_INSTANT))));
+                  constructor().forClass("org.joda.time.Period").withParameters("long", "long"),
+                  constructor()
+                      .forClass("org.joda.time.Period")
+                      .withParameters(READABLE_PARTIAL, READABLE_PARTIAL),
+                  constructor()
+                      .forClass("org.joda.time.Period")
+                      .withParameters(READABLE_INSTANT, READABLE_INSTANT))));
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/refaster/UNewClass.java
+++ b/core/src/main/java/com/google/errorprone/refaster/UNewClass.java
@@ -88,7 +88,8 @@ abstract class UNewClass extends UExpression implements NewClassTree {
         .thenChoose(unifications(getTypeArguments(), newClass.getTypeArguments()))
         .thenChoose(unifications(getIdentifier(), newClass.getIdentifier()))
         .thenChoose(unifications(getClassBody(), newClass.getClassBody()))
-        .thenChoose(unifications(getArguments(), newClass.getArguments()));
+        .thenChoose(
+            unifications(getArguments(), newClass.getArguments(), /* allowVarargs= */ true));
   }
 
   @Override

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -85,6 +85,7 @@ import com.google.errorprone.bugpatterns.DescribeFix;
 import com.google.errorprone.bugpatterns.DiscardedPostfixExpression;
 import com.google.errorprone.bugpatterns.DivZero;
 import com.google.errorprone.bugpatterns.DoNotCallChecker;
+import com.google.errorprone.bugpatterns.DoNotMockChecker;
 import com.google.errorprone.bugpatterns.DoubleBraceInitialization;
 import com.google.errorprone.bugpatterns.DuplicateMapKeys;
 import com.google.errorprone.bugpatterns.EmptyIfStatement;
@@ -486,6 +487,7 @@ public class BuiltInCheckerSuppliers {
           DeadException.class,
           DeadThread.class,
           DoNotCallChecker.class,
+          DoNotMockChecker.class,
           DuplicateMapKeys.class,
           DurationFrom.class,
           DurationGetTemporalUnit.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/DoNotMockCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/DoNotMockCheckerTest.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import com.google.auto.value.processor.AutoValueProcessor;
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.annotations.DoNotMock;
+import java.lang.annotation.Retention;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+
+/**
+ * Tests for {@link DoNotMockChecker}.
+ *
+ * @author amalloy@google.com (Alan Malloy)
+ */
+@RunWith(JUnit4.class)
+public final class DoNotMockCheckerTest {
+
+  private static final String DO_NOT_MOCK_REASON =
+      "the reason why OtherDoNotMockObject is DoNotMock";
+
+  private final CompilationTestHelper testHelper =
+      CompilationTestHelper.newInstance(DoNotMockChecker.class, getClass())
+          .addSourceLines(
+              "lib/DoNotMockObjects.java",
+              "package lib;",
+              "import org.mockito.Mockito;",
+              "import com.google.errorprone.annotations.DoNotMock;",
+              "import java.lang.annotation.Inherited;",
+              "import java.lang.annotation.Retention;",
+              "import java.lang.annotation.RetentionPolicy;",
+              "class DoNotMockObjects {",
+              "",
+              "  class MockableObject {}",
+              "  @DoNotMock(\"" + DO_NOT_MOCK_REASON + "\") class DoNotMockObject {",
+              "    DoNotMockObject(String s) {}",
+              "    DoNotMockObject() {}",
+              "  }",
+              "  @DoNotMock(\"\") class OtherDoNotMockObject {}",
+              "",
+              "  @Inherited",
+              "  @DoNotMock(\"" + DO_NOT_MOCK_REASON + "\")",
+              "  @Retention(RetentionPolicy.RUNTIME)",
+              "  @interface MetaDoNotMock {}",
+              "  @MetaDoNotMock static class MetaDoNotMockObject {}",
+              "",
+              "  @MetaDoNotMock @Retention(RetentionPolicy.RUNTIME)",
+              "  @interface DoubleMetaDoNotMock {}",
+              "  @DoubleMetaDoNotMock static class DoubleMetaAnnotatedDoNotMock {}",
+              "",
+              "  class ExtendsDoNotMockObject extends DoNotMockObject {}",
+              "  class ExtendsMetaDoNotMockObject extends MetaDoNotMockObject {}",
+              "",
+              "  @DoNotMock(\"" + DO_NOT_MOCK_REASON + "\") interface DoNotMockInterface {}",
+              "  @MetaDoNotMock interface MetaDoNotMockInterface {}",
+              "  class ImplementsDoNotMockInterfaceObject implements DoNotMockInterface {}",
+              "  class ImplementsMetaDoNotMockInterfaceObject",
+              "      implements MetaDoNotMockInterface {} ",
+              "}");
+
+  @Test
+  public void matchesMockitoDotMock_doNotMock() {
+    testHelper
+        .addSourceLines(
+            "lib/Lib.java",
+            "package lib;",
+            "import org.mockito.Mockito;",
+            "import lib.DoNotMockObjects.*;",
+            "class Lib {",
+            "",
+            "  public static void f() { ",
+            "    Mockito.spy(MockableObject.class);",
+            "// BUG: Diagnostic contains: "
+                + String.format(
+                    "Do not mock '%s'; %s is annotated as @DoNotMock: %s",
+                    "lib.DoNotMockObjects.DoNotMockObject",
+                    "lib.DoNotMockObjects.DoNotMockObject",
+                    DO_NOT_MOCK_REASON),
+            "    Mockito.mock(DoNotMockObject.class);",
+            "// BUG: Diagnostic contains: "
+                + String.format(
+                    "Do not mock '%s'; %s is annotated as @DoNotMock: %s",
+                    "lib.DoNotMockObjects.OtherDoNotMockObject",
+                    "lib.DoNotMockObjects.OtherDoNotMockObject",
+                    "It is annotated as DoNotMock."),
+            "    Mockito.spy(OtherDoNotMockObject.class);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void matchesEasymockDotMock_doNotMock() {
+
+    String expected =
+        String.format(
+            "Do not mock '%s'; %s is annotated as @DoNotMock: %s",
+            "lib.DoNotMockObjects.DoNotMockObject",
+            "lib.DoNotMockObjects.DoNotMockObject",
+            DO_NOT_MOCK_REASON);
+
+    testHelper
+        .addSourceLines(
+            "lib/Lib.java",
+            "package lib;",
+            "import org.easymock.EasyMock;",
+            "import org.easymock.ConstructorArgs;",
+            "import lib.DoNotMockObjects.*;",
+            "class Lib {",
+            "",
+            "  private static final ConstructorArgs CONSTRUCTOR_ARGS = new ConstructorArgs(",
+            "      (java.lang.reflect.Constructor) null, \"foo\");",
+            "  public static void f() { ",
+            "    EasyMock.createMock(MockableObject.class);",
+            "    // BUG: Diagnostic contains: " + expected,
+            "    EasyMock.createMock(DoNotMockObject.class);",
+            "    // BUG: Diagnostic contains: " + expected,
+            "    EasyMock.createMock(DoNotMockObject.class, CONSTRUCTOR_ARGS);",
+            "    // BUG: Diagnostic contains: " + expected,
+            "    EasyMock.createMock(\"my_name\", DoNotMockObject.class);",
+            "    // BUG: Diagnostic contains: " + expected,
+            "    EasyMock.createMock(\"my_name\", DoNotMockObject.class, CONSTRUCTOR_ARGS);",
+            "    // BUG: Diagnostic contains: " + expected,
+            "    EasyMock.createNiceMock(DoNotMockObject.class);",
+            "    // BUG: Diagnostic contains: " + expected,
+            "    EasyMock.createNiceMock(DoNotMockObject.class, CONSTRUCTOR_ARGS);",
+            "    // BUG: Diagnostic contains: " + expected,
+            "    EasyMock.createNiceMock(\"my_name\", DoNotMockObject.class);",
+            "    // BUG: Diagnostic contains: " + expected,
+            "    EasyMock.createNiceMock(\"my_name\", DoNotMockObject.class, CONSTRUCTOR_ARGS);",
+            "    // BUG: Diagnostic contains: " + expected,
+            "    EasyMock.createMock(DoNotMockObject.class, CONSTRUCTOR_ARGS);",
+            "    // BUG: Diagnostic contains: " + expected,
+            "    EasyMock.createStrictMock(DoNotMockObject.class);",
+            "    // BUG: Diagnostic contains: " + expected,
+            "    EasyMock.createStrictMock(DoNotMockObject.class, CONSTRUCTOR_ARGS);",
+            "    // BUG: Diagnostic contains: " + expected,
+            "    EasyMock.createStrictMock(\"my_name\", DoNotMockObject.class);",
+            "    // BUG: Diagnostic contains: " + expected,
+            "    EasyMock.createStrictMock(\"my_name\", DoNotMockObject.class, CONSTRUCTOR_ARGS);",
+            "    // BUG: Diagnostic contains: " + expected,
+            "    EasyMock.createMockBuilder(DoNotMockObject.class);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void matchesMockitoMockAnnotation_doNotMock() {
+    testHelper
+        .addSourceLines(
+            "lib/Lib.java",
+            "package lib;",
+            "import org.mockito.Mock;",
+            "import org.mockito.Spy;",
+            "import lib.DoNotMockObjects.*;",
+            "class Lib {",
+            "",
+            "  @Mock MockableObject mockableObject;",
+            "  // BUG: Diagnostic contains: "
+                + String.format(
+                    "Do not mock '%s'; %s is annotated as @DoNotMock: %s",
+                    "lib.DoNotMockObjects.DoNotMockObject",
+                    "lib.DoNotMockObjects.DoNotMockObject",
+                    DO_NOT_MOCK_REASON),
+            "  @Mock DoNotMockObject unmockableObject;",
+            "  // BUG: Diagnostic contains: "
+                + String.format(
+                    "Do not mock '%s'; %s is annotated as @DoNotMock: %s",
+                    "lib.DoNotMockObjects.DoNotMockInterface",
+                    "lib.DoNotMockObjects.DoNotMockInterface",
+                    DO_NOT_MOCK_REASON),
+            "  @Mock DoNotMockInterface doNotMockInterface;",
+            "  @Spy MockableObject unspyableObject;",
+            "  // BUG: Diagnostic contains:",
+            "  @Spy DoNotMockObject spyableObject;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void matchesMockAnnotation_doNotMock_extends() {
+    testHelper
+        .addSourceLines(
+            "lib/Lib.java",
+            "package lib;",
+            "import org.mockito.Mock;",
+            "import org.mockito.Spy;",
+            "import lib.DoNotMockObjects.*;",
+            "class Lib {",
+            "",
+            "  // BUG: Diagnostic contains: "
+                + String.format(
+                    "Do not mock '%s' (which is-a '%s'); %s is annotated as @DoNotMock: %s.",
+                    "lib.DoNotMockObjects.ExtendsDoNotMockObject",
+                    "lib.DoNotMockObjects.DoNotMockObject",
+                    "lib.DoNotMockObjects.DoNotMockObject",
+                    DO_NOT_MOCK_REASON),
+            "  @Mock ExtendsDoNotMockObject extendsDoNotMockObject;",
+            "  // BUG: Diagnostic contains: "
+                + String.format(
+                    "Do not mock '%s' (which is-a '%s'); %s",
+                    "lib.DoNotMockObjects.ExtendsMetaDoNotMockObject",
+                    "lib.DoNotMockObjects.MetaDoNotMockObject",
+                    String.format(
+                        "%s is annotated as @%s (which is annotated as @DoNotMock): %s",
+                        "lib.DoNotMockObjects.MetaDoNotMockObject",
+                        "lib.DoNotMockObjects.MetaDoNotMock",
+                        DO_NOT_MOCK_REASON)),
+            "  @Mock ExtendsMetaDoNotMockObject extendsMetaDoNotMockObject;",
+            "  @Mock MockableObject mockableObject;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void matchesMockAnnotation_doNotMock_implements() {
+    testHelper
+        .addSourceLines(
+            "lib/Lib.java",
+            "package lib;",
+            "import org.mockito.Mock;",
+            "import org.mockito.Spy;",
+            "import lib.DoNotMockObjects.*;",
+            "class Lib {",
+            "",
+            "  // BUG: Diagnostic contains: "
+                + String.format(
+                    "Do not mock '%s' (which is-a '%s'); %s is annotated as @DoNotMock: %s.",
+                    "lib.DoNotMockObjects.ImplementsDoNotMockInterfaceObject",
+                    "lib.DoNotMockObjects.DoNotMockInterface",
+                    "lib.DoNotMockObjects.DoNotMockInterface",
+                    DO_NOT_MOCK_REASON),
+            "  @Mock ImplementsDoNotMockInterfaceObject implementsDoNotMockInterfaceObject;",
+            "  // BUG: Diagnostic contains: "
+                + String.format(
+                    "Do not mock '%s' (which is-a '%s'); %s",
+                    "lib.DoNotMockObjects.ImplementsMetaDoNotMockInterfaceObject",
+                    "lib.DoNotMockObjects.MetaDoNotMockInterface",
+                    String.format(
+                        "%s is annotated as @%s (which is annotated as @DoNotMock): %s",
+                        "lib.DoNotMockObjects.MetaDoNotMockInterface",
+                        "lib.DoNotMockObjects.MetaDoNotMock",
+                        DO_NOT_MOCK_REASON)),
+            "  @Mock ImplementsMetaDoNotMockInterfaceObject"
+                + " implementsMetaDoNotMockInterfaceObject;",
+            "  @Mock MockableObject mockableObject;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void matchesMockAnnotation_metaDoNotMock() {
+    testHelper
+        .addSourceLines(
+            "lib/Lib.java",
+            "package lib;",
+            "import org.mockito.Mock;",
+            "import lib.DoNotMockObjects.*;",
+            "class Lib {",
+            "",
+            "  // BUG: Diagnostic contains:",
+            "  @Mock MetaDoNotMockObject metaAnnotatedDoNotMockObject;",
+            "  // BUG: Diagnostic contains:",
+            "  @Mock MetaDoNotMockInterface metaDoNotMockInterface;",
+            "  @Mock MockableObject mockableObject;",
+            "  @Mock DoubleMetaAnnotatedDoNotMock doubleMetaAnnotatedDoNotMock; // mockable",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void matchesMockitoDotMock_autoValue() {
+    testHelper
+        .addSourceLines(
+            "lib/Lib.java",
+            "package lib;",
+            "import org.mockito.Mockito;",
+            "import lib.AutoValueObjects.*;",
+            "public class Lib {",
+            "",
+            "  class MockableObject {}",
+            "",
+            "  public static void f() { ",
+            "    Mockito.mock(MockableObject.class);",
+            "    // BUG: Diagnostic contains:",
+            "    Mockito.mock(DoNotMockMyAutoValue.class);",
+            "    Mockito.mock(MyAutoValue.class);",
+            "    MyAutoValue myAutoValue = MyAutoValue.create(1);",
+            "    DoNotMockMyAutoValue doNotMockMyAutoValue = DoNotMockMyAutoValue.create(1);",
+            "  }",
+            "}")
+        .addSourceLines(
+            "lib/MyAutoValue.java",
+            "package lib;",
+            "import com.google.auto.value.AutoValue;",
+            "import com.google.errorprone.annotations.DoNotMock;",
+            "class AutoValueObjects {",
+            "  @DoNotMock(\"" + DO_NOT_MOCK_REASON + "\")",
+            "  @AutoValue public abstract static class DoNotMockMyAutoValue {",
+            "    public abstract int getFoo();",
+            "    static DoNotMockMyAutoValue create(int foo) {",
+            "      return new AutoValue_AutoValueObjects_DoNotMockMyAutoValue(foo);",
+            "    }",
+            "  }",
+            "  @AutoValue public abstract static class MyAutoValue {",
+            "    public abstract int getBar();",
+            "    static MyAutoValue create(int bar) {",
+            "      return new AutoValue_AutoValueObjects_MyAutoValue(bar);",
+            "    }",
+            "  }",
+            "}")
+        .setArgs(ImmutableList.of("-processor", AutoValueProcessor.class.getName()))
+        .doTest();
+  }
+
+  @Test
+  public void typaram() {
+    CompilationTestHelper.newInstance(DoNotMockChecker.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            "import org.mockito.Mockito;",
+            "import org.mockito.Mock;",
+            "class Test<E> {",
+            "  @Mock E e;",
+            "  <T> T f(T x) {",
+            "    T m = Mockito.spy(x);",
+            "    return m;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void rawClass() {
+    CompilationTestHelper.newInstance(DoNotMockChecker.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            "import org.mockito.Mockito;",
+            "class Test {",
+            "  <T> T evil(Class<T> clazz) {",
+            "    return (T) Mockito.mock((Class) clazz);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void mockArray() {
+    CompilationTestHelper.newInstance(DoNotMockChecker.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            "import java.lang.annotation.Annotation;",
+            "import org.mockito.Mock;",
+            "class Test {",
+            "  @Mock Annotation[] annotations;",
+            "}")
+        .doTest();
+  }
+
+  /** Example meta-annotation to put on the test's classpath. */
+  @Retention(RUNTIME)
+  @DoNotMock("unmockable")
+  public @interface AnnotationWithDoNotMock {}
+
+  /** An example usage of this meta-annotation. */
+  @AnnotationWithDoNotMock
+  public static class AnnotatedClass {}
+
+  // test the check's behaviour if a mocked type is annotated, but the annotation's classfile
+  // is missing from the compilation classpath
+  @Test
+  public void noMetaAnnotationIncompleteClasspath() {
+    CompilationTestHelper.newInstance(DoNotMockChecker.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            "import " + AnnotatedClass.class.getCanonicalName() + ";",
+            "import org.mockito.Mock;",
+            "class Test {",
+            "  @Mock AnnotatedClass x;",
+            "}")
+        .withClasspath(
+            AnnotatedClass.class, DoNotMockCheckerTest.class, DoNotMock.class, Mock.class)
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ReferenceEqualityTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ReferenceEqualityTest.java
@@ -394,6 +394,35 @@ public class ReferenceEqualityTest {
             "  public int compareTo(Test o) {",
             "    return this == o ? 0 : -1;",
             "  }",
+            "  public boolean equals(Object obj) {",
+            "    return obj instanceof Test;",
+            "  }",
+            "  public int hashCode() {",
+            "    return 1;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void likeCompareToButDifferentName() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test implements Comparable<Test> {",
+            "  public int compareTo(Test o) {",
+            "    return this == o ? 0 : -1;",
+            "  }",
+            "  public int notCompareTo(Test o) {",
+            "    // BUG: Diagnostic contains:",
+            "    return this == o ? 0 : -1;",
+            "  }",
+            "  public boolean equals(Object obj) {",
+            "    return obj instanceof Test;",
+            "  }",
+            "  public int hashCode() {",
+            "    return 1;",
+            "  }",
             "}")
         .doTest();
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ChainedAssertionLosesContextNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ChainedAssertionLosesContextNegativeCases.java
@@ -39,11 +39,6 @@ public class ChainedAssertionLosesContextNegativeCases {
     static FooSubject assertThat(Foo foo) {
       return assertAbout(foos()).that(foo);
     }
-
-    FooSubject otherFoo() {
-      // Should someday suggest: check("otherFoo()").about(foos()).that(actual.otherFoo())
-      return assertThat(actual.otherFoo());
-    }
   }
 
   void someTestMethod() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ChainedAssertionLosesContextNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ChainedAssertionLosesContextNegativeCases.java
@@ -25,8 +25,11 @@ import com.google.common.truth.Subject;
 /** @author cpovirk@google.com (Chris Povirk) */
 public class ChainedAssertionLosesContextNegativeCases {
   static final class FooSubject extends Subject<FooSubject, Foo> {
+    private final Foo actual;
+
     private FooSubject(FailureMetadata metadata, Foo actual) {
       super(metadata, actual);
+      this.actual = actual;
     }
 
     static Factory<FooSubject, Foo> foos() {
@@ -38,8 +41,8 @@ public class ChainedAssertionLosesContextNegativeCases {
     }
 
     FooSubject otherFoo() {
-      // Should someday suggest: check("otherFoo()").about(foos()).that(actual().otherFoo())
-      return assertThat(actual().otherFoo());
+      // Should someday suggest: check("otherFoo()").about(foos()).that(actual.otherFoo())
+      return assertThat(actual.otherFoo());
     }
   }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ChainedAssertionLosesContextPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ChainedAssertionLosesContextPositiveCases.java
@@ -27,6 +27,8 @@ import com.google.common.truth.Truth;
 /** @author cpovirk@google.com (Chris Povirk) */
 public class ChainedAssertionLosesContextPositiveCases {
   static final class FooSubject extends Subject<FooSubject, Foo> {
+    private final Foo actual;
+
     static Factory<FooSubject, Foo> foos() {
       return FooSubject::new;
     }
@@ -37,40 +39,41 @@ public class ChainedAssertionLosesContextPositiveCases {
 
     private FooSubject(FailureMetadata metadata, Foo actual) {
       super(metadata, actual);
+      this.actual = actual;
     }
 
     void hasString(String expected) {
-      // BUG: Diagnostic contains: check("string()").that(actual().string()).isEqualTo(expected)
-      Truth.assertThat(actual().string()).isEqualTo(expected);
+      // BUG: Diagnostic contains: check("string()").that(actual.string()).isEqualTo(expected)
+      Truth.assertThat(actual.string()).isEqualTo(expected);
     }
 
     void hasOtherFooInteger(int expected) {
       // BUG: Diagnostic contains:
-      // check("otherFoo().integer()").that(actual().otherFoo().integer()).isEqualTo(expected)
-      Truth.assertThat(actual().otherFoo().integer()).isEqualTo(expected);
+      // check("otherFoo().integer()").that(actual.otherFoo().integer()).isEqualTo(expected)
+      Truth.assertThat(actual.otherFoo().integer()).isEqualTo(expected);
     }
 
     FooSubject otherFooAbout() {
-      // BUG: Diagnostic contains: check("otherFoo()").about(foos()).that(actual().otherFoo())
-      return assertAbout(foos()).that(actual().otherFoo());
+      // BUG: Diagnostic contains: check("otherFoo()").about(foos()).that(actual.otherFoo())
+      return assertAbout(foos()).that(actual.otherFoo());
     }
 
     void withMessage(String expected) {
       // BUG: Diagnostic contains:
-      // check("string()").withMessage("blah").that(actual().string()).isEqualTo(expected)
-      assertWithMessage("blah").that(actual().string()).isEqualTo(expected);
+      // check("string()").withMessage("blah").that(actual.string()).isEqualTo(expected)
+      assertWithMessage("blah").that(actual.string()).isEqualTo(expected);
     }
 
     void withMessageWithArgs(String expected) {
       // BUG: Diagnostic contains:
-      // check("string()").withMessage("%s", "blah").that(actual().string()).isEqualTo(expected)
-      assertWithMessage("%s", "blah").that(actual().string()).isEqualTo(expected);
+      // check("string()").withMessage("%s", "blah").that(actual.string()).isEqualTo(expected)
+      assertWithMessage("%s", "blah").that(actual.string()).isEqualTo(expected);
     }
 
     void plainAssert(String expected) {
       // BUG: Diagnostic contains:
-      // check("string()").that(actual().string()).isEqualTo(expected)
-      assert_().that(actual().string()).isEqualTo(expected);
+      // check("string()").that(actual.string()).isEqualTo(expected)
+      assert_().that(actual.string()).isEqualTo(expected);
     }
   }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ChainedAssertionLosesContextPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ChainedAssertionLosesContextPositiveCases.java
@@ -58,6 +58,11 @@ public class ChainedAssertionLosesContextPositiveCases {
       return assertAbout(foos()).that(actual.otherFoo());
     }
 
+    FooSubject otherFooThat() {
+      // BUG: Diagnostic contains: check("otherFoo()").about(foos()).that(actual.otherFoo())
+      return assertThat(actual.otherFoo());
+    }
+
     void withMessage(String expected) {
       // BUG: Diagnostic contains:
       // check("string()").withMessage("blah").that(actual.string()).isEqualTo(expected)

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ImplementAssertionWithChainingNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ImplementAssertionWithChainingNegativeCases.java
@@ -22,24 +22,27 @@ import com.google.common.truth.Subject;
 /** @author cpovirk@google.com (Chris Povirk) */
 public class ImplementAssertionWithChainingNegativeCases {
   static final class FooSubject extends Subject<FooSubject, Foo> {
+    private final Foo actual;
+
     private FooSubject(FailureMetadata metadata, Foo actual) {
       super(metadata, actual);
+      this.actual = actual;
     }
 
     void doesNotHaveString(String other) {
-      if (actual().string().equals(other)) {
+      if (actual.string().equals(other)) {
         fail("matched unexpected string");
       }
     }
 
     void doesNotHaveInteger(int other) {
-      if (actual().integer() == other) {
+      if (actual.integer() == other) {
         fail("had unexpected integer");
       }
     }
 
     void hasBoxedIntegerSameInstance(Integer expected) {
-      if (actual().boxedInteger() != expected) {
+      if (actual.boxedInteger() != expected) {
         fail("didn't match expected string instance");
       }
     }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ImplementAssertionWithChainingPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ImplementAssertionWithChainingPositiveCases.java
@@ -22,49 +22,52 @@ import com.google.common.truth.Subject;
 /** @author cpovirk@google.com (Chris Povirk) */
 public class ImplementAssertionWithChainingPositiveCases {
   static final class FooSubject extends Subject<FooSubject, Foo> {
+    private final Foo actual;
+
     private FooSubject(FailureMetadata metadata, Foo actual) {
       super(metadata, actual);
+      this.actual = actual;
     }
 
     void hasString(String expected) {
-      // BUG: Diagnostic contains: check("string()").that(actual().string()).isEqualTo(expected)
-      if (!actual().string().equals(expected)) {
+      // BUG: Diagnostic contains: check("string()").that(actual.string()).isEqualTo(expected)
+      if (!actual.string().equals(expected)) {
         fail("didn't match expected string");
       }
     }
 
     void hasStringGuavaObjectsEqual(String expected) {
-      // BUG: Diagnostic contains: check("string()").that(actual().string()).isEqualTo(expected)
-      if (!com.google.common.base.Objects.equal(actual().string(), expected)) {
+      // BUG: Diagnostic contains: check("string()").that(actual.string()).isEqualTo(expected)
+      if (!com.google.common.base.Objects.equal(actual.string(), expected)) {
         fail("didn't match expected string");
       }
     }
 
     void hasStringJavaObjectsEquals(String expected) {
-      // BUG: Diagnostic contains: check("string()").that(actual().string()).isEqualTo(expected)
-      if (!java.util.Objects.equals(actual().string(), expected)) {
+      // BUG: Diagnostic contains: check("string()").that(actual.string()).isEqualTo(expected)
+      if (!java.util.Objects.equals(actual.string(), expected)) {
         fail("didn't match expected string");
       }
     }
 
     void hasInteger(int expected) {
-      // BUG: Diagnostic contains: check("integer()").that(actual().integer()).isEqualTo(expected)
-      if (actual().integer() != expected) {
+      // BUG: Diagnostic contains: check("integer()").that(actual.integer()).isEqualTo(expected)
+      if (actual.integer() != expected) {
         fail("has integer %s", expected);
       }
     }
 
     void hasKind(Kind expected) {
-      // BUG: Diagnostic contains: check("kind()").that(actual().kind()).isEqualTo(expected)
-      if (actual().kind() != expected) {
+      // BUG: Diagnostic contains: check("kind()").that(actual.kind()).isEqualTo(expected)
+      if (actual.kind() != expected) {
         fail("has kind %s", expected);
       }
     }
 
     void hasOtherFooInteger(int expected) {
       // BUG: Diagnostic contains:
-      // check("otherFoo().integer()").that(actual().otherFoo().integer()).isEqualTo(expected)
-      if (actual().otherFoo().integer() != expected) {
+      // check("otherFoo().integer()").that(actual.otherFoo().integer()).isEqualTo(expected)
+      if (actual.otherFoo().integer() != expected) {
         fail("has other foo with integer %s", expected);
       }
     }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ProvideDescriptionToCheckNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ProvideDescriptionToCheckNegativeCases.java
@@ -22,12 +22,15 @@ import com.google.common.truth.Subject;
 /** @author cpovirk@google.com (Chris Povirk) */
 public class ProvideDescriptionToCheckNegativeCases {
   static final class FooSubject extends Subject<FooSubject, Foo> {
+    private final Foo actual;
+
     private FooSubject(FailureMetadata metadata, Foo actual) {
       super(metadata, actual);
+      this.actual = actual;
     }
 
     void alreadyPassesDescription(String expected) {
-      check("s()").that(actual().string()).isEqualTo(expected);
+      check("s()").that(actual.string()).isEqualTo(expected);
     }
   }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ProvideDescriptionToCheckPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ProvideDescriptionToCheckPositiveCases.java
@@ -25,36 +25,39 @@ import com.google.common.truth.Subject;
 /** @author cpovirk@google.com (Chris Povirk) */
 public class ProvideDescriptionToCheckPositiveCases {
   static final class FooSubject extends Subject<FooSubject, Foo> {
+    private final Foo actual;
+
     private FooSubject(FailureMetadata metadata, Foo actual) {
       super(metadata, actual);
+      this.actual = actual;
     }
 
     void hasString(String expected) {
-      // BUG: Diagnostic contains: check("string()").that(actual().string()).isEqualTo(expected)
-      check().that(actual().string()).isEqualTo(expected);
+      // BUG: Diagnostic contains: check("string()").that(actual.string()).isEqualTo(expected)
+      check().that(actual.string()).isEqualTo(expected);
     }
 
     void hasStringWithMessage(String expected) {
       // BUG: Diagnostic contains:
-      // check("string()").withMessage("abc").that(actual().string()).isEqualTo(expected)
-      check().withMessage("abc").that(actual().string()).isEqualTo(expected);
+      // check("string()").withMessage("abc").that(actual.string()).isEqualTo(expected)
+      check().withMessage("abc").that(actual.string()).isEqualTo(expected);
     }
 
     void hasStringAbout(String expected) {
       // BUG: Diagnostic contains:
-      // check("string()").about(myStrings()).that(actual().string()).isEqualTo(expected)
-      check().about(myStrings()).that(actual().string()).isEqualTo(expected);
+      // check("string()").about(myStrings()).that(actual.string()).isEqualTo(expected)
+      check().about(myStrings()).that(actual.string()).isEqualTo(expected);
     }
 
     void hasStringWithMessageAbout(String expected) {
       // BUG: Diagnostic contains: check("string()")
-      check().withMessage("abc").about(myStrings()).that(actual().string()).isEqualTo(expected);
+      check().withMessage("abc").about(myStrings()).that(actual.string()).isEqualTo(expected);
     }
 
     void hasOtherFooInteger(int expected) {
       // BUG: Diagnostic contains:
-      // check("otherFoo().integer()").that(actual().otherFoo().integer()).isEqualTo(expected)
-      check().that(actual().otherFoo().integer()).isEqualTo(expected);
+      // check("otherFoo().integer()").that(actual.otherFoo().integer()).isEqualTo(expected)
+      check().that(actual.otherFoo().integer()).isEqualTo(expected);
     }
   }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ProvideDescriptionToCheckPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ProvideDescriptionToCheckPositiveCases.java
@@ -18,6 +18,7 @@ package com.google.errorprone.bugpatterns.testdata;
 
 import static com.google.errorprone.bugpatterns.testdata.ProvideDescriptionToCheckPositiveCases.MyStringSubject.myStrings;
 
+import com.google.common.truth.CustomSubjectBuilder;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.StringSubject;
 import com.google.common.truth.Subject;
@@ -35,6 +36,11 @@ public class ProvideDescriptionToCheckPositiveCases {
     void hasString(String expected) {
       // BUG: Diagnostic contains: check("string()").that(actual.string()).isEqualTo(expected)
       check().that(actual.string()).isEqualTo(expected);
+    }
+
+    void hasStringThisCheck(String expected) {
+      // BUG: Diagnostic contains: this.check("string()").that(actual.string()).isEqualTo(
+      this.check().that(actual.string()).isEqualTo(expected);
     }
 
     void hasStringWithMessage(String expected) {
@@ -59,6 +65,12 @@ public class ProvideDescriptionToCheckPositiveCases {
       // check("otherFoo().integer()").that(actual.otherFoo().integer()).isEqualTo(expected)
       check().that(actual.otherFoo().integer()).isEqualTo(expected);
     }
+
+    FooSubject hasOtherFooUsingFactory() {
+      // BUG: Diagnostic contains:
+      // check("otherFoo()").about(foos()).that(actual.otherFoo())
+      return check().about(foos()).that(actual.otherFoo());
+    }
   }
 
   static final class MyStringSubject extends StringSubject {
@@ -69,6 +81,20 @@ public class ProvideDescriptionToCheckPositiveCases {
     static Factory<StringSubject, String> myStrings() {
       return MyStringSubject::new;
     }
+  }
+
+  static final class FooCustomSubjectBuilder extends CustomSubjectBuilder {
+    FooCustomSubjectBuilder(FailureMetadata metadata) {
+      super(metadata);
+    }
+
+    FooSubject that(Foo actual) {
+      return new FooSubject(metadata(), actual);
+    }
+  }
+
+  static CustomSubjectBuilder.Factory<FooCustomSubjectBuilder> foos() {
+    return FooCustomSubjectBuilder::new;
   }
 
   private static final class Foo {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ShouldHaveEvenArgsMultimapPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ShouldHaveEvenArgsMultimapPositiveCases.java
@@ -53,26 +53,13 @@ public class ShouldHaveEvenArgsMultimapPositiveCases {
 
   public void testWithOddArgsWithCorrespondence() {
     assertThat(multimap)
-        .comparingValuesUsing(new TestCorrespondence())
+        .comparingValuesUsing(Correspondence.from((a, b) -> true, "dummy"))
         // BUG: Diagnostic contains: even number of arguments
         .containsExactly("hello", "there", "rest");
 
     assertThat(multimap)
-        .comparingValuesUsing(new TestCorrespondence())
+        .comparingValuesUsing(Correspondence.from((a, b) -> true, "dummy"))
         // BUG: Diagnostic contains: even number of arguments
         .containsExactly("hello", "there", "hello", "there", "rest");
-  }
-
-  private static class TestCorrespondence extends Correspondence<String, String> {
-
-    @Override
-    public boolean compare(String str1, String str2) {
-      return true;
-    }
-
-    @Override
-    public String toString() {
-      return "test_correspondence";
-    }
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ShouldHaveEvenArgsPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ShouldHaveEvenArgsPositiveCases.java
@@ -53,26 +53,13 @@ public class ShouldHaveEvenArgsPositiveCases {
 
   public void testWithOddArgsWithCorrespondence() {
     assertThat(map)
-        .comparingValuesUsing(new TestCorrespondence())
+        .comparingValuesUsing(Correspondence.from((a, b) -> true, "dummy"))
         // BUG: Diagnostic contains: even number of arguments
         .containsExactly("hello", "there", "rest");
 
     assertThat(map)
-        .comparingValuesUsing(new TestCorrespondence())
+        .comparingValuesUsing(Correspondence.from((a, b) -> true, "dummy"))
         // BUG: Diagnostic contains: even number of arguments
         .containsExactly("hello", "there", "hello", "there", "rest");
-  }
-
-  private static class TestCorrespondence extends Correspondence<String, String> {
-
-    @Override
-    public boolean compare(String str1, String str2) {
-      return true;
-    }
-
-    @Override
-    public String toString() {
-      return "test_correspondence";
-    }
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UnnecessaryBoxedVariableCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UnnecessaryBoxedVariableCases.java
@@ -17,6 +17,7 @@
 package com.google.errorprone.bugpatterns.testdata;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 /** @author awturner@google.com (Andy Turner) */
 class UnnecessaryBoxedVariableCases {
@@ -145,6 +146,11 @@ class UnnecessaryBoxedVariableCases {
   void positive_castMethod_statementExpression() {
     Integer myVariable = 0;
     myVariable.longValue();
+  }
+
+  void negative_methodReference() {
+    Integer myVariable = 0;
+    Stream<Integer> stream = Stream.of(1).filter(myVariable::equals);
   }
 
   private void methodPrimitiveArg(int i) {}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UnnecessaryBoxedVariableCases_expected.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UnnecessaryBoxedVariableCases_expected.java
@@ -17,6 +17,7 @@
 package com.google.errorprone.bugpatterns.testdata;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 /** @author awturner@google.com (Andy Turner) */
 class UnnecessaryBoxedVariableCases {
@@ -144,6 +145,11 @@ class UnnecessaryBoxedVariableCases {
 
   void positive_castMethod_statementExpression() {
     int myVariable = 0;
+  }
+
+  void negative_methodReference() {
+    Integer myVariable = 0;
+    Stream<Integer> stream = Stream.of(1).filter(myVariable::equals);
   }
 
   private void methodPrimitiveArg(int i) {}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/testdata/TimeUnitMismatchPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/testdata/TimeUnitMismatchPositiveCases.java
@@ -58,6 +58,8 @@ public class TimeUnitMismatchPositiveCases {
 
   void doSomething(double startSec, double endSec) {}
 
+  void setMyMillis(int timeout) {}
+
   void args() {
     double ms = 0;
     double ns = 0;
@@ -65,6 +67,9 @@ public class TimeUnitMismatchPositiveCases {
     doSomething(ms, ns);
     // BUG: Diagnostic contains: expected seconds but was nanoseconds
     doSomething(ms, ns);
+
+    // BUG: Diagnostic contains: expected milliseconds but was nanoseconds
+    setMyMillis((int) ns);
   }
 
   void timeUnit() {

--- a/docs/bugpattern/ChainedAssertionLosesContext.md
+++ b/docs/bugpattern/ChainedAssertionLosesContext.md
@@ -1,0 +1,39 @@
+Assertions made _inside the implementation of another [Truth] assertion_ should
+use [`check`], not `assertThat`.
+
+Before:
+
+```
+class MyProtoSubject {
+  public void hasFoo(Foo expected) {
+    assertThat(actual().foo()).isEqualTo(expected);
+  }
+}
+```
+
+After:
+
+```
+class MyProtoSubject {
+  public void hasFoo(Foo expected) {
+    check("foo()").that(actual().foo()).isEqualTo(expected);
+  }
+}
+```
+
+Benefits of `check` include:
+
+-   When the assertion fails, the failure message includes more context: The
+    message specifies that the assertion was performed on `myProto.foo()`, and
+    it includes the full value of `myProto` for reference.
+-   If the user of the assertion called `assertWithMessage`, that message, which
+    is lost in the `assertThat` version, is shown by the `check` version.
+-   `check` makes it possible to test the assertion with [`ExpectFailure`] and
+    to use [`Expect`] or [`assume`]. `assertThat`, by contrast, overrides any
+    user-specified failure behavior.
+
+[Truth]: https://github.com/google/truth
+[`check`]: https://google.github.io/truth/api/latest/com/google/common/truth/Subject.html#check-java.lang.String-java.lang.Object...-
+[`ExpectFailure`]: https://google.github.io/truth/api/latest/com/google/common/truth/ExpectFailure.html
+[`Expect`]: https://google.github.io/truth/api/latest/com/google/common/truth/Expect.html
+[`assume`]: https://google.github.io/truth/api/latest/com/google/common/truth/TruthJUnit.html#assume--


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Use HashMap with computeIfAbsent instead of a LoadingCache for VisitorState.getTypeFromString(). LoadingCache has concurrency baked in, but we were setting concurrencyLevel = 1 because javac is not meant to be used in a concurrency environment.

RELNOTES: Performance improvements

a0884fb6eb14e24778458ac78daa41a25a3433fc

-------

<p> A few small cleanups:
  - Inline "GuardedBy" as it's the only value of this parameter
  - Use methods from MoreAnnotations now that they're available

a40748050e91efb5f4053aa31c38126ece82378a

-------

<p> Prepend a supertype check in CollectionIncompatibleType so we can abort quickly if none of the applicable types match.

For each method invocation, we're currently checking for 20 methods in the worst-case, which means 20 type-hierarchy checks. This is costly given that it runs on every method invocation in the compilation. The 20 methods are on types that share one of 3 collective supertypes: adding a first order check for one of them reduces the type-hierarchy checks considerably for the common case. The non-common case should not be affected greatly.

An alternative would be to index the common AbstractCollectionIncompatibleTypeMatchers by supertype first. That may be a little easier to maintain, but my guess is that it would be a little slower for the common case since we'd be reducing 20 -> 7 instead of 20 -> 3. We could try a layered map, but I'm not sure if that's worth it.

This reduces the cost of CollectionIncompatibleType by 45% on some builds.

RELNOTES: Performance improvements

18baf0453ff8ddd2bbaee62618b0e3155bd6db80

-------

<p> Remove some superfluous cases from ImmutableModification

Also alphabetize the lists so they're easier to maintain

7237a092f49ba05958bb1216bb9a6622393ad9c5

-------

<p> Make MatchState.paramTypes() a derived property to save a costly allocation in a type that is created very frequently.

The ImmutableList.copyOf() is 70% of the current runtime of this method. Reducing it to use Collections.unmodifiableList() cut that time in half, but added its own cost (albeit smaller). Making it a derived property reduces the cost entirely and shifts it to the caller side.

Because the list is never modified by javac and we're in a single-threaded environment, and because this is an internal type with only one caller, I didn't bother retaining the ImmutableList type from the now-derived property method. But I can add that back if we'd like.

This is used throughout ErrorProne, most notably perhaps in CollectionIncompatibleType, which is the 2nd most expensive checker internally.

a3357355906894bf91a8fcbab287fb67444aff1b

-------

<p> Short-circuit and avoid a stream if the collection is empty.

Normally this would seem not worthwhile, but this is called enough times that it's probably worth the micro-optimization.

We can also possibly see if there is a better iterative approach here.

050ef9818d8a86420a2fdfc14dda9f1f5a641bf7

-------

<p> Open source DoNotMockChecker, the enforcer for @DoNotMock

3c36239404055c6fd10e62f99ee6ef063c832145

-------

<p> Migrate some uses of Guava Optional to j.u.Optional

Specifically, AbstractChainedMatcher and AbstractSimpleMatcher.

a020e4e54a0a2789e7c237702492c62f58310ff0

-------

<p> Speed up TemporalAccessorGetChronoField a little

Inlines the work done by MethodMatcher and does things in an order to keep short-circuiting (the common case) cheap, only doing the expensive checks when they're likely to succeed.

This roughly halves the time spent in TemporalAccessorGetChronoField.

6df5ae67546943f27dc013a4e7a0793ef5caaf11

-------

<p> Simplify a method matcher: all types descend from java.lang.Object

85b30080d67d89e281674fb73386b842ecb1bdb1

-------

<p> Support varargs on constructor invocations in Refaster.

78fb95b4b639e2842280093b8520c5761db05bef

-------

<p> UnnecessaryBoxedVariable: consider a method reference as a boxed usage

1a8db89b93f6b43fda89c7869553aba0b2f03011

-------

<p> Disable Unnecessary{Lambda,AnonymousClass} on Android code

due to concerns around performance overhead and breaking code
relying on reference equality.

58b28d2f87300a79c196ef068aa3794d7f903224

-------

<p> User Matcher<ExpressionTree> instead of the MethodMatchers fluent interfaces

5448a3d4941ff1f700740f145d4502bbfcf2966e

-------

<p> Small enhancements to TimeUnitMismatch: check variable names through typecasts,
and try to find void setSomethingMillis(int timeout)

RELNOTES: TimeUnitMismatch detects more instances of time unit mismatches

da399ba53a845503eaaf02d76654f305e436a9c2

-------

<p> Don't expose c.g.common types in Error Prone APIs

f4fd68a2cb9e54ec068edc5543f4b8b7c4f735e0

-------

<p> Update checks to look for a field named "actual" in addition to looking for the about-to-be-removed actual() and getSubject() methods.

Update tests so that they won't break when we remove those methods.

dbfd412e0324e6359705c2417ed54440603963d6

-------

<p> Fix typo.

7bbd602d1661b02e543dda4daa31c33d83cc0c13

-------

<p> Improvements to Truth-related checks:

ChainedAssertionLosesContext:
1. When code uses a custom assertThat method (e.g., ProtoTruth.assertThat, as opposed to Truth.assertThat), look for an accompanying factory so that we can suggest a migration to check(...).about(factory()).that(...).
2. Replace MethodSelectTree rather than the full MethodInvocationTree. This is slightly simpler, and it would help avoid removing code comments. (It appears never to come up inside Google, though.)

ProvideDescriptionToCheck:
1. Correctly handle CustomSubjectBuilder: Users never have an instance that is statically of that exact type, only of a subtype.
2. Handle qualified calls to check() (like this.check() and otherObject.check()). (This appears not to come up inside Google, aside from one call that we don't match anyway for other reasons.)
3. Be paranoid and always use onDescendantOf rather than onExactClass. (I'd made this change for NO_ARG_CHECK as part of #2 and for SUBJECT_BUILDER_THAT's CustomSubjectBuilder as part of #1. It shouldn't matter for the other matchers, but I'm playing it safe.)

ImplementAssertionWithChaining
1. Leave a TODO to produce "this.check(...)," "otherObject.check(...)," etc. when needed, and take a baby step in that direction by using onDescendantOf.

RELNOTES: none

0e732909f8183fcb1ab4c9ac1928ab8459fd575e

-------

<p> Some cleanups in Matchers.java

Most prominently, turned many anonymous classes into lambdas; but I
also did some general refactoring and simplifications.

19ffdf7d1fb022250e2f01d8ed3c3241cab44b64

-------

<p> Make ReferenceEquality work on methods that "look like" equals() or compareTo().

Because Symbol.overrides doesn't check method names, we were failing to report errors in some cases, typically when the signature was `foo(MyType)`, which looks enough like `compareTo(MyType)`.

Also, when testing my change, I noticed that my new test didn't initially reproduce the problem. That turned out to be because my class didn't implement equals(). I updated negative_compareTo() to implement equals(), too, to confirm that the check is disabled there on account of compareTo(), not on account of the missing equals() implementation.

RELNOTES: Fixed `ReferenceEquality` to catch some matches it was missing.

897efc8e2415cfe346e298c6d8cf49caa488c6e8

-------

<p> Migrate Correspondence subclasses to instead call Correspondence.from.

This makes the code shorter, and the subclassing approach is deprecated.

Open-source note: Correspondence.from was added to Truth 0.43. (So was Correspondence.transforming, which I'm using occasionally instead.) Correspondence.formattingDiffsUsing was added in Truth 0.44.

c5c251e927ee9a1102aa88f9ded7bfd00fca0f0d