### PR TITLE
Moe Sync

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.44</version>
+      <version>0.45</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/check_api/src/test/java/com/google/errorprone/fixes/AppliedFixTest.java
+++ b/check_api/src/test/java/com/google/errorprone/fixes/AppliedFixTest.java
@@ -20,7 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertThrows;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
@@ -64,7 +64,8 @@ public class BadImport extends BugChecker implements ImportTreeMatcher {
 
   private static final ImmutableSet<String> BAD_NESTED_CLASSES =
       ImmutableSet.of(
-          "Builder");
+          "Builder",
+          "Class");
   private static final ImmutableSet<String> BAD_STATIC_IDENTIFIERS =
       ImmutableSet.of(
           "copyOf",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
@@ -67,7 +67,14 @@ public class BadImport extends BugChecker implements ImportTreeMatcher {
           "Builder");
   private static final ImmutableSet<String> BAD_STATIC_IDENTIFIERS =
       ImmutableSet.of(
-          "copyOf", "of", "from", "INSTANCE", "builder", "newBuilder", "getDefaultInstance");
+          "copyOf",
+          "of",
+          "from",
+          "INSTANCE",
+          "builder",
+          "newBuilder",
+          "getDefaultInstance",
+          "valueOf");
 
   private static final MultiMatcher<Tree, AnnotationTree> HAS_TYPE_USE_ANNOTATION =
       annotations(AT_LEAST_ONE, (t, state) -> isTypeAnnotation(t));

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ComparisonContractViolated.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ComparisonContractViolated.java
@@ -224,8 +224,8 @@ public class ComparisonContractViolated extends BugChecker implements MethodTree
           }
           BinaryTree binaryExpr = (BinaryTree) conditionExpr;
           Type ty = ASTHelpers.getType(binaryExpr.getLeftOperand());
-          Types types = Types.instance(state.context);
-          Symtab symtab = Symtab.instance(state.context);
+          Types types = state.getTypes();
+          Symtab symtab = state.getSymtab();
 
           ExpressionTree first =
               trueFirst ? binaryExpr.getLeftOperand() : binaryExpr.getRightOperand();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FunctionalInterfaceMethodChanged.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FunctionalInterfaceMethodChanged.java
@@ -64,7 +64,7 @@ public class FunctionalInterfaceMethodChanged extends BugChecker implements Meth
     ClassTree enclosingClazz = ASTHelpers.findEnclosingNode(state.getPath(), ClassTree.class);
     if (tree.getModifiers().getFlags().contains(Modifier.DEFAULT)
         && IS_FUNCTIONAL_INTERFACE.matches(enclosingClazz, state)) {
-      Types types = Types.instance(state.context);
+      Types types = state.getTypes();
       Set<Symbol> functionalSuperInterfaceSams =
           enclosingClazz.getImplementsClause().stream()
               .filter(t -> IS_FUNCTIONAL_INTERFACE.matches(t, state))

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InconsistentHashCode.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InconsistentHashCode.java
@@ -215,7 +215,8 @@ public final class InconsistentHashCode extends BugChecker implements ClassTreeM
     }
 
     private void handleSymbol(Symbol symbol) {
-      if (symbol.getKind() == ElementKind.FIELD
+      if (symbol != null
+          && symbol.getKind() == ElementKind.FIELD
           && !symbol.isStatic()
           && symbol.owner.equals(classSymbol)) {
         String name = symbol.name.toString();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JavaLangClash.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JavaLangClash.java
@@ -37,7 +37,6 @@ import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
 import com.sun.tools.javac.util.Name;
-import com.sun.tools.javac.util.Names;
 
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @BugPattern(
@@ -61,8 +60,7 @@ public class JavaLangClash extends BugChecker
 
   private Description check(Tree tree, Name simpleName, VisitorState state) {
     Symtab symtab = state.getSymtab();
-    PackageSymbol javaLang =
-        symtab.enterPackage(symtab.java_base, Names.instance(state.context).java_lang);
+    PackageSymbol javaLang = symtab.enterPackage(symtab.java_base, state.getNames().java_lang);
     Symbol other =
         getFirst(
             javaLang.members().getSymbolsByName(simpleName, s -> s.getModifiers().contains(PUBLIC)),

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ObjectToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ObjectToString.java
@@ -58,7 +58,7 @@ public class ObjectToString extends AbstractToString {
       return false;
     }
     Types types = state.getTypes();
-    Names names = Names.instance(state.context);
+    Names names = state.getNames();
     // find Object.toString
     MethodSymbol toString =
         (MethodSymbol) state.getSymtab().objectType.tsym.members().findFirst(names.toString);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SelfAssignment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SelfAssignment.java
@@ -65,8 +65,15 @@ public class SelfAssignment extends BugChecker
     implements AssignmentTreeMatcher, VariableTreeMatcher {
   private static final Matcher<MethodInvocationTree> NON_NULL_MATCHER =
       anyOf(
+          staticMethod().onClass("java.util.Objects").named("requireNonNull"),
           staticMethod().onClass("com.google.common.base.Preconditions").named("checkNotNull"),
-          staticMethod().onClass("java.util.Objects").named("requireNonNull"));
+          staticMethod()
+              .onClass("com.google.common.time.Durations")
+              .namedAnyOf("checkNotNegative", "checkPositive"),
+          staticMethod()
+              .onClass("com.google.protobuf.util.Durations")
+              .namedAnyOf("checkNotNegative", "checkPositive", "checkValid"),
+          staticMethod().onClass("com.google.protobuf.util.Timestamps").named("checkValid"));
 
   @Override
   public Description matchAssignment(AssignmentTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeNameShadowing.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeNameShadowing.java
@@ -46,7 +46,6 @@ import com.sun.tools.javac.comp.AttrContext;
 import com.sun.tools.javac.comp.Enter;
 import com.sun.tools.javac.comp.Env;
 import com.sun.tools.javac.tree.JCTree.Tag;
-import com.sun.tools.javac.util.Names;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -123,8 +122,7 @@ public class TypeNameShadowing extends BugChecker implements MethodTreeMatcher, 
             .getEnv(ASTHelpers.getSymbol(state.findEnclosing(ClassTree.class)));
 
     Symtab symtab = state.getSymtab();
-    PackageSymbol javaLang =
-        symtab.enterPackage(symtab.java_base, Names.instance(state.context).java_lang);
+    PackageSymbol javaLang = symtab.enterPackage(symtab.java_base, state.getNames().java_lang);
 
     Iterable<Symbol> enclosingTypes = typesInEnclosingScope(env, javaLang);
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
@@ -47,8 +47,7 @@ public class TypeParameterQualifier extends BugChecker implements MemberSelectTr
       return Description.NO_MATCH;
     }
     TreeMaker make =
-        TreeMaker.instance(state.context)
-            .forToplevel((JCCompilationUnit) state.getPath().getCompilationUnit());
+        state.getTreeMaker().forToplevel((JCCompilationUnit) state.getPath().getCompilationUnit());
     JCExpression qual = make.QualIdent(ASTHelpers.getSymbol(tree));
     return describeMatch(tree, SuggestedFix.replace(tree, qual.toString()));
   }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryAnonymousClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryAnonymousClass.java
@@ -44,6 +44,7 @@ import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePathScanner;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.tree.JCTree;
 import java.util.Objects;
@@ -97,6 +98,18 @@ public class UnnecessaryAnonymousClass extends BugChecker implements VariableTre
     MethodTree implementation = (MethodTree) member;
     Type type = getType(tree.getType());
     if (type == null || !state.getTypes().isFunctionalInterface(type)) {
+      return NO_MATCH;
+    }
+    MethodSymbol methodSymbol = getSymbol(implementation);
+    if (methodSymbol == null) {
+      return NO_MATCH;
+    }
+    Symbol descriptorSymbol = state.getTypes().findDescriptorSymbol(type.tsym);
+    if (!methodSymbol.getSimpleName().contentEquals(descriptorSymbol.getSimpleName())) {
+      return NO_MATCH;
+    }
+    if (!methodSymbol.overrides(
+        descriptorSymbol, methodSymbol.owner.enclClass(), state.getTypes(), false)) {
       return NO_MATCH;
     }
     if (state.isAndroidCompatible()) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedException.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedException.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.BugPattern.StandardTags.STYLE;
@@ -66,8 +65,6 @@ import javax.lang.model.element.Modifier;
             + " exception rather than setting it as a cause. This can make debugging harder.",
     severity = WARNING,
     tags = STYLE,
-    linkType = CUSTOM,
-    link = "https://google.github.io/styleguide/javaguide.html#s6.2-caught-exceptions",
     providesFix = REQUIRES_HUMAN_ATTENTION,
     documentSuppression = false)
 public final class UnusedException extends BugChecker implements CatchTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/package-info.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/package-info.java
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-/** Bug patterns related to <a href="http://google.github.io/dagger/">Dagger</a>. */
+/** Bug patterns related to <a href="http://dagger.dev/">Dagger</a>. */
 package com.google.errorprone.bugpatterns.inject.dagger;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByBinder.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByBinder.java
@@ -57,7 +57,7 @@ public class GuardedByBinder {
                   ALREADY_BOUND_RESOLVER,
                   ASTHelpers.getSymbol(visitorState.findEnclosing(ClassTree.class)),
                   visitorState.getTypes(),
-                  Names.instance(visitorState.context))));
+                  visitorState.getNames())));
     } catch (IllegalGuardedBy expected) {
       return Optional.empty();
     }
@@ -72,8 +72,8 @@ public class GuardedByBinder {
               BinderContext.of(
                   resolver,
                   resolver.enclosingClass(),
-                  Types.instance(resolver.context()),
-                  Names.instance(resolver.context()))));
+                  resolver.visitorState().getTypes(),
+                  resolver.visitorState().getNames())));
     } catch (IllegalGuardedBy expected) {
       return Optional.empty();
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedBySymbolResolver.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedBySymbolResolver.java
@@ -35,8 +35,6 @@ import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.tree.TreeMaker;
 import com.sun.tools.javac.util.Context;
-import com.sun.tools.javac.util.Name;
-import com.sun.tools.javac.util.Names;
 import javax.lang.model.element.ElementKind;
 
 /**
@@ -50,6 +48,7 @@ public class GuardedBySymbolResolver implements GuardedByBinder.Resolver {
   private final Tree decl;
   private final JCTree.JCCompilationUnit compilationUnit;
   private final Context context;
+  private final VisitorState visitorState;
   private final Types types;
 
   public static GuardedBySymbolResolver from(Tree tree, VisitorState visitorState) {
@@ -57,25 +56,39 @@ public class GuardedBySymbolResolver implements GuardedByBinder.Resolver {
         ASTHelpers.getSymbol(tree).owner.enclClass(),
         visitorState.getPath().getCompilationUnit(),
         visitorState.context,
-        tree);
+        tree,
+        visitorState);
   }
 
   public static GuardedBySymbolResolver from(
-      ClassSymbol owner, CompilationUnitTree compilationUnit, Context context, Tree leaf) {
-    return new GuardedBySymbolResolver(owner, compilationUnit, context, leaf);
+      ClassSymbol owner,
+      CompilationUnitTree compilationUnit,
+      Context context,
+      Tree leaf,
+      VisitorState visitorState) {
+    return new GuardedBySymbolResolver(owner, compilationUnit, context, leaf, visitorState);
   }
 
   private GuardedBySymbolResolver(
-      ClassSymbol enclosingClass, CompilationUnitTree compilationUnit, Context context, Tree leaf) {
+      ClassSymbol enclosingClass,
+      CompilationUnitTree compilationUnit,
+      Context context,
+      Tree leaf,
+      VisitorState visitorState) {
     this.compilationUnit = (JCCompilationUnit) compilationUnit;
     this.enclosingClass = requireNonNull(enclosingClass);
     this.context = context;
-    this.types = Types.instance(context);
+    this.types = visitorState.getTypes();
     this.decl = leaf;
+    this.visitorState = visitorState;
   }
 
   public Context context() {
     return context;
+  }
+
+  public VisitorState visitorState() {
+    return visitorState;
   }
 
   public ClassSymbol enclosingClass() {
@@ -151,7 +164,7 @@ public class GuardedBySymbolResolver implements GuardedByBinder.Resolver {
     }
     for (Type t : types.closure(classSymbol.type)) {
       Scope scope = t.tsym.members();
-      for (Symbol sym : scope.getSymbolsByName(getName(name))) {
+      for (Symbol sym : scope.getSymbolsByName(visitorState.getName(name))) {
         if (sym.getKind().equals(kind)) {
           return type.cast(sym);
         }
@@ -241,12 +254,8 @@ public class GuardedBySymbolResolver implements GuardedByBinder.Resolver {
 
   private Symbol attribIdent(String name) {
     Attr attr = Attr.instance(context);
-    TreeMaker tm = TreeMaker.instance(context);
-    return attr.attribIdent(tm.Ident(getName(name)), compilationUnit);
-  }
-
-  private Name getName(String name) {
-    return Names.instance(context).fromString(name);
+    TreeMaker tm = visitorState.getTreeMaker();
+    return attr.attribIdent(tm.Ident(visitorState.getName(name)), compilationUnit);
   }
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationGetTemporalUnit.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationGetTemporalUnit.java
@@ -79,7 +79,9 @@ public final class DurationGetTemporalUnit extends BugChecker
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (MATCHER.matches(tree, state)) {
-      Optional<ChronoUnit> invalidUnit = getInvalidChronoUnit(tree, INVALID_TEMPORAL_UNITS);
+      Optional<ChronoUnit> invalidUnit =
+          getInvalidChronoUnit(
+              Iterables.getOnlyElement(tree.getArguments()), INVALID_TEMPORAL_UNITS);
       if (invalidUnit.isPresent()) {
         if (SUGGESTIONS.containsKey(invalidUnit.get())) {
           SuggestedFix.Builder builder = SuggestedFix.builder();
@@ -95,10 +97,10 @@ public final class DurationGetTemporalUnit extends BugChecker
     return Description.NO_MATCH;
   }
 
-  // used by PeriodGetTemporalUnit
+  // used by PeriodGetTemporalUnit and DurationOfLongTemporalUnit
   static Optional<ChronoUnit> getInvalidChronoUnit(
-      MethodInvocationTree tree, EnumSet<ChronoUnit> invalidUnits) {
-    Optional<String> constant = getEnumName(Iterables.getOnlyElement(tree.getArguments()));
+      ExpressionTree tree, Iterable<ChronoUnit> invalidUnits) {
+    Optional<String> constant = getEnumName(tree);
     if (constant.isPresent()) {
       for (ChronoUnit invalidTemporalUnit : invalidUnits) {
         if (constant.get().equals(invalidTemporalUnit.name())) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationOfLongTemporalUnit.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationOfLongTemporalUnit.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.common.collect.Sets.toImmutableEnumSet;
+import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.bugpatterns.time.DurationGetTemporalUnit.getInvalidChronoUnit;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+
+/**
+ * Bans calls to {@code Duration.of(long, TemporalUnit)} where the {@link
+ * java.time.temporal.TemporalUnit} has an estimated duration (which is guaranteed to throw an
+ * {@code DateTimeException}).
+ */
+@BugPattern(
+    name = "DurationOfLongTemporalUnit",
+    summary = "Duration.of(long, TemporalUnit) only works for TemporalUnits with exact durations.",
+    explanation =
+        "Duration.of(long, TemporalUnit) only works for TemporalUnits with exact durations. "
+            + "E.g., Duration.of(1, ChronoUnit.YEAR) is guaranteed to throw a DateTimeException.",
+    severity = ERROR,
+    providesFix = NO_FIX)
+public final class DurationOfLongTemporalUnit extends BugChecker
+    implements MethodInvocationTreeMatcher {
+
+  private static final Matcher<ExpressionTree> DURATION_OF_LONG_TEMPORAL_UNIT =
+      allOf(
+          staticMethod()
+              .onClass("java.time.Duration")
+              .named("of")
+              .withParameters("long", "java.time.temporal.TemporalUnit"),
+          Matchers.not(Matchers.packageStartsWith("java.")));
+
+  private static final ImmutableSet<ChronoUnit> INVALID_TEMPORAL_UNITS =
+      Arrays.stream(ChronoUnit.values())
+          .filter(c -> c.isDurationEstimated())
+          .collect(toImmutableEnumSet());
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (DURATION_OF_LONG_TEMPORAL_UNIT.matches(tree, state)) {
+      if (getInvalidChronoUnit(tree.getArguments().get(1), INVALID_TEMPORAL_UNITS).isPresent()) {
+        // TODO(kak): do we want to include the name of the invalid ChronoUnit in the message?
+        return describeMatch(tree);
+      }
+    }
+    return Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/InstantTemporalUnit.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/InstantTemporalUnit.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.common.collect.Sets.toImmutableEnumSet;
+import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.bugpatterns.time.DurationGetTemporalUnit.getInvalidChronoUnit;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+
+/**
+ * Bans calls to {@code Instant} APIs where the {@link java.time.temporal.TemporalUnit} is not one
+ * of: {@code NANOS}, {@code MICROS}, {@code MILLIS}, {@code SECONDS}, {@code MINUTES}, {@code
+ * HOURS}, {@code HALF_DAYS}, or {@code DAYS}.
+ */
+@BugPattern(
+    name = "InstantTemporalUnit",
+    summary =
+        "Instant APIs only work for NANOS, MICROS, MILLIS, SECONDS, MINUTES, HOURS, HALF_DAYS and"
+            + " DAYS.",
+    severity = ERROR,
+    providesFix = NO_FIX)
+public final class InstantTemporalUnit extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private static final String INSTANT = "java.time.Instant";
+  private static final String TEMPORAL_UNIT = "java.time.temporal.TemporalUnit";
+
+  private static final Matcher<ExpressionTree> INSTANT_OF_LONG_TEMPORAL_UNIT =
+      allOf(
+          anyOf(
+              instanceMethod()
+                  .onExactClass(INSTANT)
+                  .named("minus")
+                  .withParameters("long", TEMPORAL_UNIT),
+              instanceMethod()
+                  .onExactClass(INSTANT)
+                  .named("plus")
+                  .withParameters("long", TEMPORAL_UNIT),
+              instanceMethod()
+                  .onExactClass(INSTANT)
+                  .named("until")
+                  .withParameters("java.time.temporal.Temporal", TEMPORAL_UNIT)),
+          Matchers.not(Matchers.packageStartsWith("java.")));
+
+  // This definition comes from Instant.isSupported(TemporalUnit)
+  static final ImmutableSet<ChronoUnit> INVALID_TEMPORAL_UNITS =
+      Arrays.stream(ChronoUnit.values())
+          .filter(c -> !c.isTimeBased())
+          .filter(c -> !c.equals(ChronoUnit.DAYS)) // DAYS is explicitly allowed
+          .collect(toImmutableEnumSet());
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (INSTANT_OF_LONG_TEMPORAL_UNIT.matches(tree, state)) {
+      if (getInvalidChronoUnit(tree.getArguments().get(1), INVALID_TEMPORAL_UNITS).isPresent()) {
+        return describeMatch(tree);
+      }
+    }
+    return Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/LocalDateTemporalAmount.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/LocalDateTemporalAmount.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.argument;
+import static com.google.errorprone.matchers.Matchers.isSameType;
+import static com.google.errorprone.matchers.Matchers.not;
+import static com.google.errorprone.matchers.Matchers.packageStartsWith;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.MethodInvocationTree;
+
+/**
+ * Bans calls to {@code LocalDate.plus(TemporalAmount)} and {@code LocalDate.minus(TemporalAmount)}
+ * where the {@link java.time.temporal.TemporalAmount} is a non-zero {@link java.time.Duration}.
+ */
+@BugPattern(
+    name = "LocalDateTemporalAmount",
+    summary = "LocalDate.plus() and minus() does not work with non-zero Durations",
+    severity = ERROR,
+    providesFix = NO_FIX)
+public final class LocalDateTemporalAmount extends BugChecker
+    implements MethodInvocationTreeMatcher {
+
+  private static final Matcher<MethodInvocationTree> MATCHER =
+      allOf(
+          instanceMethod()
+              .onExactClass("java.time.LocalDate")
+              .namedAnyOf("plus", "minus")
+              .withParameters("java.time.temporal.TemporalAmount"),
+          // TODO(kak): If the parameter is equal to Duration.ZERO, then technically this call will
+          // work, but that's a very small corner case to worry about.
+          argument(0, isSameType("java.time.Duration")),
+          not(packageStartsWith("java.")));
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    return MATCHER.matches(tree, state) ? describeMatch(tree) : Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/LocalDateTemporalAmount.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/LocalDateTemporalAmount.java
@@ -38,7 +38,10 @@ import com.sun.source.tree.MethodInvocationTree;
  */
 @BugPattern(
     name = "LocalDateTemporalAmount",
-    summary = "LocalDate.plus() and minus() does not work with non-zero Durations",
+    summary =
+        "LocalDate.plus() and minus() does not work with Durations. LocalDate represents civil"
+            + " time (years/months/days), so java.time.Period is the appropriate thing to add or"
+            + " subtract instead.",
     severity = ERROR,
     providesFix = NO_FIX)
 public final class LocalDateTemporalAmount extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PeriodGetTemporalUnit.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PeriodGetTemporalUnit.java
@@ -19,6 +19,7 @@ import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.bugpatterns.time.DurationGetTemporalUnit.getInvalidChronoUnit;
 
+import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -57,7 +58,9 @@ public final class PeriodGetTemporalUnit extends BugChecker implements MethodInv
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     return MATCHER.matches(tree, state)
-            && getInvalidChronoUnit(tree, INVALID_TEMPORAL_UNITS).isPresent()
+            && getInvalidChronoUnit(
+                    Iterables.getOnlyElement(tree.getArguments()), INVALID_TEMPORAL_UNITS)
+                .isPresent()
         ? describeMatch(tree)
         : Description.NO_MATCH;
   }

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -391,8 +391,9 @@ import com.google.errorprone.bugpatterns.threadsafety.ThreadPriorityCheck;
 import com.google.errorprone.bugpatterns.threadsafety.UnlockMethodChecker;
 import com.google.errorprone.bugpatterns.time.DurationFrom;
 import com.google.errorprone.bugpatterns.time.DurationGetTemporalUnit;
-import com.google.errorprone.bugpatterns.time.DurationOfLongTemporalUnit;
+import com.google.errorprone.bugpatterns.time.DurationTemporalUnit;
 import com.google.errorprone.bugpatterns.time.DurationToLongTimeUnit;
+import com.google.errorprone.bugpatterns.time.InstantTemporalUnit;
 import com.google.errorprone.bugpatterns.time.JavaDurationGetSecondsGetNano;
 import com.google.errorprone.bugpatterns.time.JavaDurationWithNanos;
 import com.google.errorprone.bugpatterns.time.JavaDurationWithSeconds;
@@ -492,7 +493,7 @@ public class BuiltInCheckerSuppliers {
           DuplicateMapKeys.class,
           DurationFrom.class,
           DurationGetTemporalUnit.class,
-          DurationOfLongTemporalUnit.class,
+          DurationTemporalUnit.class,
           DurationToLongTimeUnit.class,
           EqualsHashCode.class,
           EqualsNaN.class,
@@ -518,6 +519,7 @@ public class BuiltInCheckerSuppliers {
           InfiniteRecursion.class,
           InjectOnFinalField.class,
           InjectOnMemberAndConstructor.class,
+          InstantTemporalUnit.class,
           InvalidPatternSyntax.class,
           InvalidTimeZoneID.class,
           InvalidZoneId.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -391,6 +391,7 @@ import com.google.errorprone.bugpatterns.threadsafety.ThreadPriorityCheck;
 import com.google.errorprone.bugpatterns.threadsafety.UnlockMethodChecker;
 import com.google.errorprone.bugpatterns.time.DurationFrom;
 import com.google.errorprone.bugpatterns.time.DurationGetTemporalUnit;
+import com.google.errorprone.bugpatterns.time.DurationOfLongTemporalUnit;
 import com.google.errorprone.bugpatterns.time.DurationToLongTimeUnit;
 import com.google.errorprone.bugpatterns.time.JavaDurationGetSecondsGetNano;
 import com.google.errorprone.bugpatterns.time.JavaDurationWithNanos;
@@ -491,6 +492,7 @@ public class BuiltInCheckerSuppliers {
           DuplicateMapKeys.class,
           DurationFrom.class,
           DurationGetTemporalUnit.class,
+          DurationOfLongTemporalUnit.class,
           DurationToLongTimeUnit.class,
           EqualsHashCode.class,
           EqualsNaN.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -407,6 +407,7 @@ import com.google.errorprone.bugpatterns.time.JodaPlusMinusLong;
 import com.google.errorprone.bugpatterns.time.JodaTimeConverterManager;
 import com.google.errorprone.bugpatterns.time.JodaToSelf;
 import com.google.errorprone.bugpatterns.time.JodaWithDurationAddedLong;
+import com.google.errorprone.bugpatterns.time.LocalDateTemporalAmount;
 import com.google.errorprone.bugpatterns.time.PeriodFrom;
 import com.google.errorprone.bugpatterns.time.PeriodGetTemporalUnit;
 import com.google.errorprone.bugpatterns.time.PeriodTimeMath;
@@ -534,6 +535,7 @@ public class BuiltInCheckerSuppliers {
           JUnit4TestNotRun.class,
           JUnitAssertSameCheck.class,
           LiteByteStringUtf8.class,
+          LocalDateTemporalAmount.class,
           LoopConditionChecker.class,
           MathRoundIntLong.class,
           MislabeledAndroidString.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -19,6 +19,7 @@ package com.google.errorprone.scanner;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Streams;
 import com.google.errorprone.BugCheckerInfo;
 import com.google.errorprone.bugpatterns.AmbiguousMethodReference;
 import com.google.errorprone.bugpatterns.AnnotateFormatMethod;
@@ -430,11 +431,9 @@ public class BuiltInCheckerSuppliers {
 
   public static ImmutableSet<BugCheckerInfo> getSuppliers(
       Iterable<Class<? extends BugChecker>> checkers) {
-    ImmutableSet.Builder<BugCheckerInfo> result = ImmutableSet.builder();
-    for (Class<? extends BugChecker> checker : checkers) {
-      result.add(BugCheckerInfo.create(checker));
-    }
-    return result.build();
+    return Streams.stream(checkers)
+        .map(BugCheckerInfo::create)
+        .collect(ImmutableSet.toImmutableSet());
   }
 
   /** Returns a {@link ScannerSupplier} with all {@link BugChecker}s in Error Prone. */

--- a/core/src/test/java/com/google/errorprone/VisitorStateTest.java
+++ b/core/src/test/java/com/google/errorprone/VisitorStateTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link VisitorState}. */
+@RunWith(JUnit4.class)
+public class VisitorStateTest {
+
+  @Test
+  public void symbolFromString_defaultPackage() {
+    assertThat(VisitorState.inferBinaryName("InDefaultPackage")).isEqualTo("InDefaultPackage");
+  }
+
+  @Test
+  public void symbolFromString_nestedTypeInDefaultPackage() {
+    assertThat(VisitorState.inferBinaryName("InDefaultPackage.Nested"))
+        .isEqualTo("InDefaultPackage$Nested");
+  }
+
+  @Test
+  public void symbolFromString_regularClass() {
+    assertThat(VisitorState.inferBinaryName("test.RegularClass")).isEqualTo("test.RegularClass");
+    assertThat(VisitorState.inferBinaryName("com.google.RegularClass"))
+        .isEqualTo("com.google.RegularClass");
+  }
+
+  @Test
+  public void symbolFromString_nestedTypeInRegularPackage() {
+    assertThat(VisitorState.inferBinaryName("test.RegularClass.Nested"))
+        .isEqualTo("test.RegularClass$Nested");
+    assertThat(VisitorState.inferBinaryName("com.google.RegularClass.Nested"))
+        .isEqualTo("com.google.RegularClass$Nested");
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/InconsistentHashCodeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/InconsistentHashCodeTest.java
@@ -128,4 +128,31 @@ public final class InconsistentHashCodeTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void breakLabeledBlock() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  private int a;",
+            "  private int b;",
+            "  private int hashCode;",
+            "  public void accessesLocalWithLabeledBreak() {",
+            "    label: {",
+            "      switch (a) {",
+            "        case 0: break label;",
+            "      }",
+            "    }",
+            "  }",
+            "  @Override public boolean equals(Object o) {",
+            "    Test that = (Test) o;",
+            "    return this.a == that.a && this.b == that.b;",
+            "  }",
+            "  @Override public int hashCode() {",
+            "    return hashCode;",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterNamingTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterNamingTest.java
@@ -312,7 +312,7 @@ public class TypeParameterNamingTest {
     assertKindOfName("ACanalPanamaT").isEqualTo(NON_CLASS_NAME_WITH_T_SUFFIX);
   }
 
-  private static Subject<?, TypeParameterNamingClassification> assertKindOfName(String s) {
+  private static Subject assertKindOfName(String s) {
     return assertWithMessage(s).that(TypeParameterNamingClassification.classify(s));
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryAnonymousClassTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryAnonymousClassTest.java
@@ -91,4 +91,29 @@ public class UnnecessaryAnonymousClassTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void abstractClass() {
+    testHelper
+        .addInputLines(
+            "Test.java",
+            "import java.util.function.Function;",
+            "class Test {",
+            "  static abstract class Impl implements Function<String, String> {",
+            "    public String apply(String input) {",
+            "      return input;",
+            "    }",
+            "    public abstract void f(String input);",
+            "  }",
+            "  private final Function<String, String> camelCase = new Impl() {",
+            "    public void f(String input) {}",
+            "  };",
+            "  void g() {",
+            "    Function<String, String> f = camelCase;",
+            "    System.err.println(camelCase.apply(\"world\"));",
+            "  }",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ChainedAssertionLosesContextNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ChainedAssertionLosesContextNegativeCases.java
@@ -24,7 +24,7 @@ import com.google.common.truth.Subject;
 
 /** @author cpovirk@google.com (Chris Povirk) */
 public class ChainedAssertionLosesContextNegativeCases {
-  static final class FooSubject extends Subject<FooSubject, Foo> {
+  static final class FooSubject extends Subject {
     private final Foo actual;
 
     private FooSubject(FailureMetadata metadata, Foo actual) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ChainedAssertionLosesContextPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ChainedAssertionLosesContextPositiveCases.java
@@ -26,7 +26,7 @@ import com.google.common.truth.Truth;
 
 /** @author cpovirk@google.com (Chris Povirk) */
 public class ChainedAssertionLosesContextPositiveCases {
-  static final class FooSubject extends Subject<FooSubject, Foo> {
+  static final class FooSubject extends Subject {
     private final Foo actual;
 
     static Factory<FooSubject, Foo> foos() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ImplementAssertionWithChainingNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ImplementAssertionWithChainingNegativeCases.java
@@ -21,7 +21,7 @@ import com.google.common.truth.Subject;
 
 /** @author cpovirk@google.com (Chris Povirk) */
 public class ImplementAssertionWithChainingNegativeCases {
-  static final class FooSubject extends Subject<FooSubject, Foo> {
+  static final class FooSubject extends Subject {
     private final Foo actual;
 
     private FooSubject(FailureMetadata metadata, Foo actual) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ImplementAssertionWithChainingPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ImplementAssertionWithChainingPositiveCases.java
@@ -21,7 +21,7 @@ import com.google.common.truth.Subject;
 
 /** @author cpovirk@google.com (Chris Povirk) */
 public class ImplementAssertionWithChainingPositiveCases {
-  static final class FooSubject extends Subject<FooSubject, Foo> {
+  static final class FooSubject extends Subject {
     private final Foo actual;
 
     private FooSubject(FailureMetadata metadata, Foo actual) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ProvideDescriptionToCheckNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ProvideDescriptionToCheckNegativeCases.java
@@ -21,7 +21,7 @@ import com.google.common.truth.Subject;
 
 /** @author cpovirk@google.com (Chris Povirk) */
 public class ProvideDescriptionToCheckNegativeCases {
-  static final class FooSubject extends Subject<FooSubject, Foo> {
+  static final class FooSubject extends Subject {
     private final Foo actual;
 
     private FooSubject(FailureMetadata metadata, Foo actual) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ProvideDescriptionToCheckPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ProvideDescriptionToCheckPositiveCases.java
@@ -25,7 +25,7 @@ import com.google.common.truth.Subject;
 
 /** @author cpovirk@google.com (Chris Povirk) */
 public class ProvideDescriptionToCheckPositiveCases {
-  static final class FooSubject extends Subject<FooSubject, Foo> {
+  static final class FooSubject extends Subject {
     private final Foo actual;
 
     private FooSubject(FailureMetadata metadata, Foo actual) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByBinderTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByBinderTest.java
@@ -21,6 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.fail;
 
 import com.google.errorprone.ErrorProneInMemoryFileManager;
+import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.tools.javac.api.JavacTaskImpl;
@@ -515,7 +516,11 @@ public class GuardedByBinderTest {
               GuardedByBinder.bindString(
                   exprString,
                   GuardedBySymbolResolver.from(
-                      ASTHelpers.getSymbol(classDecl), compilationUnit, task.getContext(), null));
+                      ASTHelpers.getSymbol(classDecl),
+                      compilationUnit,
+                      task.getContext(),
+                      null,
+                      VisitorState.createForUtilityPurposes(task.getContext())));
           if (!guardExpression.isPresent()) {
             throw new IllegalGuardedBy(exprString);
           }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/DurationOfLongTemporalUnitTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/DurationOfLongTemporalUnitTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link DurationOfLongTemporalUnit}. */
+@RunWith(JUnit4.class)
+public class DurationOfLongTemporalUnitTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(DurationOfLongTemporalUnit.class, getClass());
+
+  @Test
+  public void durationOf() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.time.temporal.ChronoUnit;",
+            "public class TestClass {",
+            "  private static final Duration D1 = Duration.of(1, ChronoUnit.SECONDS);",
+            "  private static final Duration D2 = Duration.of(1, ChronoUnit.NANOS);",
+            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  private static final Duration D3 = Duration.of(1, ChronoUnit.YEARS);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void durationOfStaticImport() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import static java.time.temporal.ChronoUnit.NANOS;",
+            "import static java.time.temporal.ChronoUnit.SECONDS;",
+            "import static java.time.temporal.ChronoUnit.YEARS;",
+            "import java.time.Duration;",
+            "public class TestClass {",
+            "  private static final Duration D1 = Duration.of(1, SECONDS);",
+            "  private static final Duration D2 = Duration.of(1, NANOS);",
+            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  private static final Duration D3 = Duration.of(1, YEARS);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void durationOfWithRandomTemporalUnit() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import static java.time.temporal.ChronoUnit.SECONDS;",
+            "import static java.time.temporal.ChronoUnit.YEARS;",
+            "import java.time.Duration;",
+            "import java.time.temporal.TemporalUnit;",
+            "import java.util.Random;",
+            "public class TestClass {",
+            "  private static final TemporalUnit random = ",
+            "      new Random().nextBoolean() ? YEARS : SECONDS;",
+            // Since we don't know at compile time what 'random' is, we can't flag this
+            "  private static final Duration D1 = Duration.of(1, random);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void durationOfWithAliasedTemporalUnit() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import static java.time.temporal.ChronoUnit.YEARS;",
+            "import java.time.Duration;",
+            "import java.time.temporal.Temporal;",
+            "import java.time.temporal.TemporalUnit;",
+            "public class TestClass {",
+            "  private static final TemporalUnit SECONDS = YEARS;",
+            // This really should be flagged, but isn't :(
+            "  private static final Duration D1 = Duration.of(1, SECONDS);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void durationOfWithCustomTemporalUnit() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.time.temporal.Temporal;",
+            "import java.time.temporal.TemporalUnit;",
+            "public class TestClass {",
+            "  private static class BadTemporalUnit implements TemporalUnit {",
+            "    @Override",
+            "    public long between(Temporal t1, Temporal t2) {",
+            "      throw new AssertionError();",
+            "    }",
+            "    @Override",
+            "    public <R extends Temporal> R addTo(R temporal, long amount) {",
+            "      throw new AssertionError();",
+            "    }",
+            "    @Override",
+            "    public boolean isTimeBased() {",
+            "      throw new AssertionError();",
+            "    }",
+            "    @Override",
+            "    public boolean isDateBased() {",
+            "      throw new AssertionError();",
+            "    }",
+            "    @Override",
+            "    public boolean isDurationEstimated() {",
+            "      throw new AssertionError();",
+            "    }",
+            "    @Override",
+            "    public Duration getDuration() {",
+            "      throw new AssertionError();",
+            "    }",
+            "  }",
+            "  private static final TemporalUnit MINUTES = new BadTemporalUnit();",
+            "  private static final TemporalUnit SECONDS = new BadTemporalUnit();",
+            // This really should be flagged, but isn't :(
+            "  private static final Duration D1 = Duration.of(1, SECONDS);",
+            "  private static final Duration D2 = Duration.of(1, MINUTES);",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/DurationOfLongTemporalUnitTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/DurationOfLongTemporalUnitTest.java
@@ -27,17 +27,49 @@ public class DurationOfLongTemporalUnitTest {
       CompilationTestHelper.newInstance(DurationOfLongTemporalUnit.class, getClass());
 
   @Test
-  public void durationOf() {
+  public void durationOf_good() {
     helper
         .addSourceLines(
             "TestClass.java",
             "import java.time.Duration;",
             "import java.time.temporal.ChronoUnit;",
             "public class TestClass {",
-            "  private static final Duration D1 = Duration.of(1, ChronoUnit.SECONDS);",
-            "  private static final Duration D2 = Duration.of(1, ChronoUnit.NANOS);",
+            "  private static final Duration D0 = Duration.of(1, ChronoUnit.DAYS);",
+            "  private static final Duration D1 = Duration.of(1, ChronoUnit.HALF_DAYS);",
+            "  private static final Duration D2 = Duration.of(1, ChronoUnit.HOURS);",
+            "  private static final Duration D3 = Duration.of(1, ChronoUnit.MICROS);",
+            "  private static final Duration D4 = Duration.of(1, ChronoUnit.MILLIS);",
+            "  private static final Duration D5 = Duration.of(1, ChronoUnit.MINUTES);",
+            "  private static final Duration D6 = Duration.of(1, ChronoUnit.NANOS);",
+            "  private static final Duration D7 = Duration.of(1, ChronoUnit.SECONDS);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void durationOf_bad() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.time.temporal.ChronoUnit;",
+            "public class TestClass {",
             "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
-            "  private static final Duration D3 = Duration.of(1, ChronoUnit.YEARS);",
+            "  private static final Duration D0 = Duration.of(1, ChronoUnit.CENTURIES);",
+            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  private static final Duration D1 = Duration.of(1, ChronoUnit.DECADES);",
+            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  private static final Duration D2 = Duration.of(1, ChronoUnit.ERAS);",
+            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  private static final Duration D3 = Duration.of(1, ChronoUnit.FOREVER);",
+            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  private static final Duration D4 = Duration.of(1, ChronoUnit.MILLENNIA);",
+            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  private static final Duration D5 = Duration.of(1, ChronoUnit.MONTHS);",
+            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  private static final Duration D6 = Duration.of(1, ChronoUnit.WEEKS);",
+            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  private static final Duration D7 = Duration.of(1, ChronoUnit.YEARS);",
             "}")
         .doTest();
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/DurationTemporalUnitTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/DurationTemporalUnitTest.java
@@ -20,11 +20,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link DurationOfLongTemporalUnit}. */
+/** Tests for {@link DurationTemporalUnit}. */
 @RunWith(JUnit4.class)
-public class DurationOfLongTemporalUnitTest {
+public class DurationTemporalUnitTest {
   private final CompilationTestHelper helper =
-      CompilationTestHelper.newInstance(DurationOfLongTemporalUnit.class, getClass());
+      CompilationTestHelper.newInstance(DurationTemporalUnit.class, getClass());
 
   @Test
   public void durationOf_good() {
@@ -54,22 +54,118 @@ public class DurationOfLongTemporalUnitTest {
             "import java.time.Duration;",
             "import java.time.temporal.ChronoUnit;",
             "public class TestClass {",
-            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
             "  private static final Duration D0 = Duration.of(1, ChronoUnit.CENTURIES);",
-            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
             "  private static final Duration D1 = Duration.of(1, ChronoUnit.DECADES);",
-            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
             "  private static final Duration D2 = Duration.of(1, ChronoUnit.ERAS);",
-            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
             "  private static final Duration D3 = Duration.of(1, ChronoUnit.FOREVER);",
-            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
             "  private static final Duration D4 = Duration.of(1, ChronoUnit.MILLENNIA);",
-            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
             "  private static final Duration D5 = Duration.of(1, ChronoUnit.MONTHS);",
-            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
             "  private static final Duration D6 = Duration.of(1, ChronoUnit.WEEKS);",
-            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
             "  private static final Duration D7 = Duration.of(1, ChronoUnit.YEARS);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void durationPlus_good() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.time.temporal.ChronoUnit;",
+            "public class TestClass {",
+            "  private static final Duration D0 = Duration.ZERO.plus(1, ChronoUnit.DAYS);",
+            "  private static final Duration D1 = Duration.ZERO.plus(1, ChronoUnit.HALF_DAYS);",
+            "  private static final Duration D2 = Duration.ZERO.plus(1, ChronoUnit.HOURS);",
+            "  private static final Duration D3 = Duration.ZERO.plus(1, ChronoUnit.MICROS);",
+            "  private static final Duration D4 = Duration.ZERO.plus(1, ChronoUnit.MILLIS);",
+            "  private static final Duration D5 = Duration.ZERO.plus(1, ChronoUnit.MINUTES);",
+            "  private static final Duration D6 = Duration.ZERO.plus(1, ChronoUnit.NANOS);",
+            "  private static final Duration D7 = Duration.ZERO.plus(1, ChronoUnit.SECONDS);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void durationPlus_bad() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.time.temporal.ChronoUnit;",
+            "public class TestClass {",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D0 = Duration.ZERO.plus(1, ChronoUnit.CENTURIES);",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D1 = Duration.ZERO.plus(1, ChronoUnit.DECADES);",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D2 = Duration.ZERO.plus(1, ChronoUnit.ERAS);",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D3 = Duration.ZERO.plus(1, ChronoUnit.FOREVER);",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D4 = Duration.ZERO.plus(1, ChronoUnit.MILLENNIA);",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D5 = Duration.ZERO.plus(1, ChronoUnit.MONTHS);",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D6 = Duration.ZERO.plus(1, ChronoUnit.WEEKS);",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D7 = Duration.ZERO.plus(1, ChronoUnit.YEARS);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void durationMinus_good() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.time.temporal.ChronoUnit;",
+            "public class TestClass {",
+            "  private static final Duration D0 = Duration.ZERO.minus(1, ChronoUnit.DAYS);",
+            "  private static final Duration D1 = Duration.ZERO.minus(1, ChronoUnit.HALF_DAYS);",
+            "  private static final Duration D2 = Duration.ZERO.minus(1, ChronoUnit.HOURS);",
+            "  private static final Duration D3 = Duration.ZERO.minus(1, ChronoUnit.MICROS);",
+            "  private static final Duration D4 = Duration.ZERO.minus(1, ChronoUnit.MILLIS);",
+            "  private static final Duration D5 = Duration.ZERO.minus(1, ChronoUnit.MINUTES);",
+            "  private static final Duration D6 = Duration.ZERO.minus(1, ChronoUnit.NANOS);",
+            "  private static final Duration D7 = Duration.ZERO.minus(1, ChronoUnit.SECONDS);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void durationMinus_bad() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.time.temporal.ChronoUnit;",
+            "public class TestClass {",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D0 = Duration.ZERO.minus(1, ChronoUnit.CENTURIES);",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D1 = Duration.ZERO.minus(1, ChronoUnit.DECADES);",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D2 = Duration.ZERO.minus(1, ChronoUnit.ERAS);",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D3 = Duration.ZERO.minus(1, ChronoUnit.FOREVER);",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D4 = Duration.ZERO.minus(1, ChronoUnit.MILLENNIA);",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D5 = Duration.ZERO.minus(1, ChronoUnit.MONTHS);",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D6 = Duration.ZERO.minus(1, ChronoUnit.WEEKS);",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
+            "  private static final Duration D7 = Duration.ZERO.minus(1, ChronoUnit.YEARS);",
             "}")
         .doTest();
   }
@@ -86,7 +182,7 @@ public class DurationOfLongTemporalUnitTest {
             "public class TestClass {",
             "  private static final Duration D1 = Duration.of(1, SECONDS);",
             "  private static final Duration D2 = Duration.of(1, NANOS);",
-            "  // BUG: Diagnostic contains: DurationOfLongTemporalUnit",
+            "  // BUG: Diagnostic contains: DurationTemporalUnit",
             "  private static final Duration D3 = Duration.of(1, YEARS);",
             "}")
         .doTest();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/InstantTemporalUnitTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/InstantTemporalUnitTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.errorprone.CompilationTestHelper;
+import java.time.temporal.ChronoUnit;
+import java.util.EnumSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link InstantTemporalUnit}. */
+@RunWith(JUnit4.class)
+public final class InstantTemporalUnitTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(InstantTemporalUnit.class, getClass());
+
+  @Test
+  public void invalidTemporalUnitsMatchesEnumeratedList() throws Exception {
+    // This list comes from the Instant javadocs, but the checker builds the list based on the
+    // definition in Instant.isSupported(): unit.isTimeBased() || unit == DAYS;
+    assertThat(InstantTemporalUnit.INVALID_TEMPORAL_UNITS)
+        .containsExactlyElementsIn(
+            EnumSet.complementOf(
+                EnumSet.of(
+                    ChronoUnit.NANOS,
+                    ChronoUnit.MICROS,
+                    ChronoUnit.MILLIS,
+                    ChronoUnit.SECONDS,
+                    ChronoUnit.MINUTES,
+                    ChronoUnit.HOURS,
+                    ChronoUnit.HALF_DAYS,
+                    ChronoUnit.DAYS)));
+  }
+
+  @Test
+  public void instantPlus_good() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Instant;",
+            "import java.time.temporal.ChronoUnit;",
+            "public class TestClass {",
+            "  private static final Instant I0 = Instant.EPOCH.plus(1, ChronoUnit.DAYS);",
+            "  private static final Instant I1 = Instant.EPOCH.plus(1, ChronoUnit.HALF_DAYS);",
+            "  private static final Instant I2 = Instant.EPOCH.plus(1, ChronoUnit.HOURS);",
+            "  private static final Instant I3 = Instant.EPOCH.plus(1, ChronoUnit.MICROS);",
+            "  private static final Instant I4 = Instant.EPOCH.plus(1, ChronoUnit.MILLIS);",
+            "  private static final Instant I5 = Instant.EPOCH.plus(1, ChronoUnit.MINUTES);",
+            "  private static final Instant I6 = Instant.EPOCH.plus(1, ChronoUnit.NANOS);",
+            "  private static final Instant I7 = Instant.EPOCH.plus(1, ChronoUnit.SECONDS);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void instantPlus_bad() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Instant;",
+            "import java.time.temporal.ChronoUnit;",
+            "public class TestClass {",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I0 = Instant.EPOCH.plus(1, ChronoUnit.CENTURIES);",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I1 = Instant.EPOCH.plus(1, ChronoUnit.DECADES);",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I2 = Instant.EPOCH.plus(1, ChronoUnit.ERAS);",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I3 = Instant.EPOCH.plus(1, ChronoUnit.FOREVER);",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I4 = Instant.EPOCH.plus(1, ChronoUnit.MILLENNIA);",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I5 = Instant.EPOCH.plus(1, ChronoUnit.MONTHS);",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I6 = Instant.EPOCH.plus(1, ChronoUnit.WEEKS);",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I7 = Instant.EPOCH.plus(1, ChronoUnit.YEARS);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void instantMinus_good() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Instant;",
+            "import java.time.temporal.ChronoUnit;",
+            "public class TestClass {",
+            "  private static final Instant I0 = Instant.EPOCH.minus(1, ChronoUnit.DAYS);",
+            "  private static final Instant I1 = Instant.EPOCH.minus(1, ChronoUnit.HALF_DAYS);",
+            "  private static final Instant I2 = Instant.EPOCH.minus(1, ChronoUnit.HOURS);",
+            "  private static final Instant I3 = Instant.EPOCH.minus(1, ChronoUnit.MICROS);",
+            "  private static final Instant I4 = Instant.EPOCH.minus(1, ChronoUnit.MILLIS);",
+            "  private static final Instant I5 = Instant.EPOCH.minus(1, ChronoUnit.MINUTES);",
+            "  private static final Instant I6 = Instant.EPOCH.minus(1, ChronoUnit.NANOS);",
+            "  private static final Instant I7 = Instant.EPOCH.minus(1, ChronoUnit.SECONDS);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void instantMinus_bad() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Instant;",
+            "import java.time.temporal.ChronoUnit;",
+            "public class TestClass {",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I0 = Instant.EPOCH.minus(1, ChronoUnit.CENTURIES);",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I1 = Instant.EPOCH.minus(1, ChronoUnit.DECADES);",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I2 = Instant.EPOCH.minus(1, ChronoUnit.ERAS);",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I3 = Instant.EPOCH.minus(1, ChronoUnit.FOREVER);",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I4 = Instant.EPOCH.minus(1, ChronoUnit.MILLENNIA);",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I5 = Instant.EPOCH.minus(1, ChronoUnit.MONTHS);",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I6 = Instant.EPOCH.minus(1, ChronoUnit.WEEKS);",
+            "  // BUG: Diagnostic contains: InstantTemporalUnit",
+            "  private static final Instant I7 = Instant.EPOCH.minus(1, ChronoUnit.YEARS);",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/LocalDateTemporalAmountTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/LocalDateTemporalAmountTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link LocalDateTemporalAmount}. */
+@RunWith(JUnit4.class)
+public final class LocalDateTemporalAmountTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(LocalDateTemporalAmount.class, getClass());
+
+  @Test
+  public void localDatePlus_good() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.LocalDate;",
+            "import java.time.Period;",
+            "import java.time.temporal.ChronoUnit;",
+            "public class TestClass {",
+            "  private static final LocalDate LD = LocalDate.of(1985, 5, 31);",
+            "  private static final Period PERIOD = Period.ofDays(1);",
+            "  private static final LocalDate LD1 = LD.plus(PERIOD);",
+            "  private static final LocalDate LD2 = LD.plus(1, ChronoUnit.DAYS);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void localDatePlus_bad() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.time.LocalDate;",
+            "public class TestClass {",
+            "  private static final LocalDate LD = LocalDate.of(1985, 5, 31);",
+            "  private static final Duration DURATION = Duration.ofDays(1);",
+            "  // BUG: Diagnostic contains: LocalDateTemporalAmount",
+            "  private static final LocalDate LD0 = LD.plus(DURATION);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void localDatePlus_zero() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.time.LocalDate;",
+            "public class TestClass {",
+            "  private static final LocalDate LD = LocalDate.of(1985, 5, 31);",
+            "  // BUG: Diagnostic contains: LocalDateTemporalAmount",
+            // This call technically doesn't throw, but we don't currently special case it
+            "  private static final LocalDate LD0 = LD.plus(Duration.ZERO);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void localDateMinus_good() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.LocalDate;",
+            "import java.time.Period;",
+            "import java.time.temporal.ChronoUnit;",
+            "public class TestClass {",
+            "  private static final LocalDate LD = LocalDate.of(1985, 5, 31);",
+            "  private static final Period PERIOD = Period.ofDays(1);",
+            "  private static final LocalDate LD1 = LD.minus(PERIOD);",
+            "  private static final LocalDate LD2 = LD.minus(1, ChronoUnit.DAYS);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void localDateMinus_bad() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.time.LocalDate;",
+            "public class TestClass {",
+            "  private static final LocalDate LD = LocalDate.of(1985, 5, 31);",
+            "  private static final Duration DURATION = Duration.ofDays(1);",
+            "  // BUG: Diagnostic contains: LocalDateTemporalAmount",
+            "  private static final LocalDate LD0 = LD.minus(DURATION);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void localDateMinus_zero() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.time.LocalDate;",
+            "public class TestClass {",
+            "  private static final LocalDate LD = LocalDate.of(1985, 5, 31);",
+            "  // BUG: Diagnostic contains: LocalDateTemporalAmount",
+            // This call technically doesn't throw, but we don't currently special case it
+            "  private static final LocalDate LD0 = LD.minus(Duration.ZERO);",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/UArrayAccessTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/UArrayAccessTest.java
@@ -16,7 +16,7 @@
 
 package com.google.errorprone.refaster;
 
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/core/src/test/java/com/google/errorprone/refaster/UMethodInvocationTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/UMethodInvocationTest.java
@@ -16,7 +16,7 @@
 
 package com.google.errorprone.refaster;
 
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/core/src/test/java/com/google/errorprone/refaster/UUnaryTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/UUnaryTest.java
@@ -17,7 +17,7 @@
 package com.google.errorprone.refaster;
 
 import static org.junit.Assert.assertThrows;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/core/src/test/java/com/google/errorprone/scanner/ScannerSupplierTest.java
+++ b/core/src/test/java/com/google/errorprone/scanner/ScannerSupplierTest.java
@@ -631,8 +631,7 @@ public class ScannerSupplierTest {
     assertThat(exception).hasMessageThat().contains("may not be disabled");
   }
 
-  private static class ScannerSupplierSubject
-      extends Subject<ScannerSupplierSubject, ScannerSupplier> {
+  private static class ScannerSupplierSubject extends Subject {
     private final ScannerSupplier actual;
 
     ScannerSupplierSubject(FailureMetadata failureMetadata, ScannerSupplier scannerSupplier) {

--- a/docs/bugpattern/ChainedAssertionLosesContext.md
+++ b/docs/bugpattern/ChainedAssertionLosesContext.md
@@ -6,7 +6,7 @@ Before:
 ```
 class MyProtoSubject {
   public void hasFoo(Foo expected) {
-    assertThat(actual().foo()).isEqualTo(expected);
+    assertThat(actual.foo()).isEqualTo(expected);
   }
 }
 ```
@@ -16,7 +16,7 @@ After:
 ```
 class MyProtoSubject {
   public void hasFoo(Foo expected) {
-    check("foo()").that(actual().foo()).isEqualTo(expected);
+    check("foo()").that(actual.foo()).isEqualTo(expected);
   }
 }
 ```

--- a/docs/bugpattern/EmptySetMultibindingContributions.md
+++ b/docs/bugpattern/EmptySetMultibindingContributions.md
@@ -13,4 +13,4 @@ However, there's a slightly easier way to express this:
 @Multibinds abstract Set<MyType> provideEmptySetOfMyType();
 ```
 
-[dmb]: https://google.github.io/dagger/multibindings.html
+[dmb]: https://dagger.dev/multibindings.html

--- a/docs/bugpattern/ProtoFieldNullComparison.md
+++ b/docs/bugpattern/ProtoFieldNullComparison.md
@@ -5,9 +5,9 @@ comparisons like these often indicate a nearby error.
 
 If you need to distinguish between an unset optional value and a default value,
 you have two options. In most cases, you can simply use the `hasField()` method.
-proto3 however does not generate `hasField()` methods for scalar fields of type
-`string` or `bytes`. In those cases you will need to wrap your field in
-`google.protobuf.StringValue` or `google.protobuf.BytesValue`, respectively.
+proto3 however does not generate `hasField()` methods for primitive types
+(including `string` and `bytes`). In those cases you will need to wrap your
+field in `google.protobuf.StringValue` or similar.
 
 NOTE: This check applies to normal (server) protos and Lite protos. The
 deprecated nano runtime does produce objects which use `null` values to indicate
@@ -40,3 +40,15 @@ void test(MyProto proto) {
   }
 }
 ```
+
+If the presence of a field is required information in proto3, the field can be
+wrapped. For example,
+
+```java {.good}
+message MyMessage {
+  google.protobuf.StringValue my_string = 1;
+}
+```
+
+Presence can then be tested using `myMessage.hasMyString()`, and the value
+retrieved using `myMessage.getMyString().getValue()`.

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <guava.version>27.0.1-jre</guava.version>
     <gwt.version>2.8.2</gwt.version>
-    <truth.version>0.44</truth.version>
+    <truth.version>0.45</truth.version>
     <javac.version>9+181-r4173-1</javac.version>
     <autovalue.version>1.5.3</autovalue.version>
     <junit.version>4.13-beta-1</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <javac.version>9+181-r4173-1</javac.version>
     <autovalue.version>1.5.3</autovalue.version>
     <junit.version>4.13-beta-1</junit.version>
-    <dataflow.version>2.5.3</dataflow.version>
+    <dataflow.version>2.8.1</dataflow.version>
     <mockito.version>2.25.0</mockito.version>
     <compile.testing.version>0.16</compile.testing.version>
   </properties>

--- a/test_helpers/src/main/java/com/google/errorprone/BugCheckerRefactoringTestHelper.java
+++ b/test_helpers/src/main/java/com/google/errorprone/BugCheckerRefactoringTestHelper.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.io.CharStreams;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CheckReturnValue;
 import com.google.errorprone.apply.DescriptionBasedDiff;
 import com.google.errorprone.apply.ImportOrganizer;
@@ -62,6 +63,7 @@ import javax.tools.JavaFileObject;
  *
  * @author kurs@google.com (Jan Kurs)
  */
+@CheckReturnValue
 public class BugCheckerRefactoringTestHelper {
 
   /** Test mode for matching refactored source against expected source. */
@@ -143,44 +145,37 @@ public class BugCheckerRefactoringTestHelper {
     this.fileManager = new ErrorProneInMemoryFileManager(clazz);
   }
 
-  @CheckReturnValue
   public static BugCheckerRefactoringTestHelper newInstance(
       BugChecker refactoringBugChecker, Class<?> clazz) {
     return new BugCheckerRefactoringTestHelper(refactoringBugChecker, clazz);
   }
 
-  @CheckReturnValue
   public BugCheckerRefactoringTestHelper.ExpectOutput addInput(String inputFilename) {
     return new ExpectOutput(fileManager.forResource(inputFilename));
   }
 
-  @CheckReturnValue
   public BugCheckerRefactoringTestHelper.ExpectOutput addInputLines(String path, String... input) {
     String inputPath = getPath("in/", path);
     assertThat(fileManager.exists(inputPath)).isFalse();
     return new ExpectOutput(fileManager.forSourceLines(inputPath, input));
   }
 
-  @CheckReturnValue
   public BugCheckerRefactoringTestHelper setFixChooser(FixChooser chooser) {
     this.fixChooser = chooser;
     return this;
   }
 
-  @CheckReturnValue
   public BugCheckerRefactoringTestHelper setArgs(String... args) {
     this.options = ImmutableList.copyOf(args);
     return this;
   }
 
   /** If set, fixes that produce output that doesn't compile are allowed. Off by default. */
-  @CheckReturnValue
   public BugCheckerRefactoringTestHelper allowBreakingChanges() {
     allowBreakingChanges = true;
     return this;
   }
 
-  @CheckReturnValue
   public BugCheckerRefactoringTestHelper setImportOrder(String importOrder) {
     this.importOrder = importOrder;
     return this;
@@ -217,6 +212,7 @@ public class BugCheckerRefactoringTestHelper {
     }
   }
 
+  @CanIgnoreReturnValue
   private JCCompilationUnit doCompile(
       final JavaFileObject input, Iterable<JavaFileObject> files, Context context)
       throws IOException {
@@ -299,11 +295,10 @@ public class BugCheckerRefactoringTestHelper {
   public class ExpectOutput {
     private final JavaFileObject input;
 
-    public ExpectOutput(JavaFileObject input) {
+    private ExpectOutput(JavaFileObject input) {
       this.input = input;
     }
 
-    @CheckReturnValue
     public BugCheckerRefactoringTestHelper addOutputLines(String path, String... output) {
       String outputPath = getPath("out/", path);
       if (fileManager.exists(outputPath)) {
@@ -312,12 +307,10 @@ public class BugCheckerRefactoringTestHelper {
       return addInputAndOutput(input, fileManager.forSourceLines(outputPath, output));
     }
 
-    @CheckReturnValue
     public BugCheckerRefactoringTestHelper addOutput(String outputFilename) {
       return addInputAndOutput(input, fileManager.forResource(outputFilename));
     }
 
-    @CheckReturnValue
     public BugCheckerRefactoringTestHelper expectUnchanged() {
       return addInputAndOutput(input, input);
     }

--- a/test_helpers/src/main/java/com/google/errorprone/CompilationTestHelper.java
+++ b/test_helpers/src/main/java/com/google/errorprone/CompilationTestHelper.java
@@ -57,6 +57,7 @@ import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
 
 /** Helps test Error Prone bug checkers and compilations. */
+@CheckReturnValue
 public class CompilationTestHelper {
   private static final ImmutableList<String> DEFAULT_ARGS =
       ImmutableList.of(
@@ -98,7 +99,6 @@ public class CompilationTestHelper {
    * @param scannerSupplier the {@link ScannerSupplier} to test
    * @param clazz the class to use to locate file resources
    */
-  @CheckReturnValue
   public static CompilationTestHelper newInstance(ScannerSupplier scannerSupplier, Class<?> clazz) {
     return new CompilationTestHelper(scannerSupplier, null, clazz);
   }
@@ -109,7 +109,6 @@ public class CompilationTestHelper {
    * @param checker the {@link BugChecker} to test
    * @param clazz the class to use to locate file resources
    */
-  @CheckReturnValue
   public static CompilationTestHelper newInstance(
       Class<? extends BugChecker> checker, Class<?> clazz) {
     ScannerSupplier scannerSupplier = ScannerSupplier.fromBugCheckerClasses(checker);
@@ -179,7 +178,6 @@ public class CompilationTestHelper {
    */
   // TODO(eaftan): We could eliminate this path parameter and just infer the path from the
   // package and class name
-  @CheckReturnValue
   public CompilationTestHelper addSourceLines(String path, String... lines) {
     this.sources.add(fileManager.forSourceLines(path, lines));
     return this;
@@ -192,7 +190,6 @@ public class CompilationTestHelper {
    *
    * @param path the path to the source file
    */
-  @CheckReturnValue
   public CompilationTestHelper addSourceFile(String path) {
     this.sources.add(fileManager.forResource(path));
     return this;
@@ -205,7 +202,6 @@ public class CompilationTestHelper {
    *
    * @param classes the class(es) to use as the classpath
    */
-  @CheckReturnValue
   public CompilationTestHelper withClasspath(Class<?>... classes) {
     this.overrideClasspath = ImmutableList.copyOf(classes);
     return this;
@@ -215,7 +211,6 @@ public class CompilationTestHelper {
    * Sets custom command-line arguments for the compilation. These will be appended to the default
    * compilation arguments.
    */
-  @CheckReturnValue
   public CompilationTestHelper setArgs(List<String> args) {
     this.extraArgs = ImmutableList.copyOf(args);
     return this;
@@ -226,7 +221,6 @@ public class CompilationTestHelper {
    * source file contains bug markers. Useful for testing that a check is actually disabled when the
    * proper command-line argument is passed.
    */
-  @CheckReturnValue
   public CompilationTestHelper expectNoDiagnostics() {
     this.expectNoDiagnostics = true;
     return this;
@@ -237,7 +231,6 @@ public class CompilationTestHelper {
    * javac errors. This behaviour can be disabled to test the interaction between Error Prone checks
    * and javac diagnostics.
    */
-  @CheckReturnValue
   public CompilationTestHelper ignoreJavacErrors() {
     this.checkWellFormed = false;
     return this;
@@ -248,7 +241,6 @@ public class CompilationTestHelper {
    * tested. This behaviour can be disabled to test the interaction between Error Prone checks and
    * javac diagnostics.
    */
-  @CheckReturnValue
   public CompilationTestHelper matchAllDiagnostics() {
     this.lookForCheckNameInDiagnostic = LookForCheckNameInDiagnostic.NO;
     return this;
@@ -258,7 +250,6 @@ public class CompilationTestHelper {
    * Tells the compilation helper to expect a specific result from the compilation, e.g. success or
    * failure.
    */
-  @CheckReturnValue
   public CompilationTestHelper expectResult(Result result) {
     expectedResult = Optional.of(result);
     return this;
@@ -278,7 +269,6 @@ public class CompilationTestHelper {
    *
    * <p>Error message keys that don't match any diagnostics will cause test to fail.
    */
-  @CheckReturnValue
   public CompilationTestHelper expectErrorMessage(String key, Predicate<? super String> matcher) {
     diagnosticHelper.expectErrorMessage(key, matcher);
     return this;
@@ -325,17 +315,17 @@ public class CompilationTestHelper {
           .isTrue();
     }
 
-    if (expectedResult.isPresent()) {
-      assertWithMessage(
-              String.format(
-                  "Expected compilation result %s, but was %s\n%s\n%s",
-                  expectedResult.get(),
-                  result,
-                  Joiner.on('\n').join(diagnosticHelper.getDiagnostics()),
-                  outputStream))
-          .that(result)
-          .isEqualTo(expectedResult.get());
-    }
+    expectedResult.ifPresent(
+        expected ->
+            assertWithMessage(
+                    String.format(
+                        "Expected compilation result %s, but was %s\n%s\n%s",
+                        expected,
+                        result,
+                        Joiner.on('\n').join(diagnosticHelper.getDiagnostics()),
+                        outputStream))
+                .that(result)
+                .isEqualTo(expected));
   }
 
   private Result compile() {

--- a/test_helpers/src/main/java/com/google/errorprone/CompilationTestHelper.java
+++ b/test_helpers/src/main/java/com/google/errorprone/CompilationTestHelper.java
@@ -285,7 +285,6 @@ public class CompilationTestHelper {
   }
 
   /** Performs a compilation and checks that the diagnostics and result match the expectations. */
-  // TODO(eaftan): any way to ensure that this is actually called?
   public void doTest() {
     Preconditions.checkState(!sources.isEmpty(), "No source files to compile");
     Result result = compile();


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Replace google.github.io/dagger with dagger.dev

7ac474b4f39fceb1a3396f1abb4284a5da188dee

-------

<p> Flag instances of Duration.of(long, ChronoUnit) where the ChronoUnit is not an exact duration.

RELNOTES: Flag instances of Duration.of(long, ChronoUnit) where the ChronoUnit is not an exact duration.

be8c5e96be7fd3f5491ca34470b06b7e08b68b4b

-------

<p> Fix an incorrect UnnecessaryAnonymousClass refactoring

don't refactor anonymous classes that implement the FI via a superclass.

c7759849712b6eb13c260f9b9f1ec66605f73a45

-------

<p> Fix NPE on JDK13+ when InconsistentHashCode visits a break statement with a label.

Fixes #1287

RELNOTES: n/a

3da5535a7ae27393fcdbb1795328b9cac6dbf3b6

-------

<p> Expand SelfAssignment to cover the Precondition-style APIs in c.g.c.time.Durations,c.g.protobuf.util.{Durations,Timestamps}.

5d2be022fe34a41dfb0c376a03965391805a5f47

-------

<p> Allow ChronoUnit.DAYS explicitly in Duration.of(long, TemporalUnit).

(It's explicitly called out in the javadocs, but I missed it the first read.)

Also turn off the checker for desugar'ed java.time.

44286ab793890645c8391579eb0aba52a1238f9c

-------

<p> Rename DurationOfLongTemporalUnit to DurationTemporalUnit and cover duration.plus(long, TemporalUnit) and duration.minus(long, TemporalUnit).

Also ban calls to Instant APIs where the TemporalUnit is not supported.

cbd97a01bbc8ce0a701adb34884848191d83db0c

-------

<p> Provide an example of using proto3's primitive wrappers.

900d5c735c9cf8c2da529a10602e837bbb4b60e5

-------

<p> Migrate org.mockito.Matchers#any* to org.mockito.ArgumentMatchers

The former is deprecated and replaced by the latter in Mockito 2. However, there is a
functional difference: ArgumentMatchers will reject `null` and check the type
if the matcher specified a type (e.g. `any(Class)` or `anyInt()`). `any()` will
remain to accept anything.

ded8db5fe432c1417ec4dc1bcddc9b5d1c99d3c4

-------

<p> Optimize VisitorState.inferBinaryName() by iterating directly over the chars of the class name.

This saves the need to create temporary strings for each piece of a package/each simple name of a type, uses StringBuilder.append(char) instead of append(String), and avoids some of the Iterable/Iterator/CharMatcher overhead. It also lends itself to easily checking if any replacement is necessary, which is one of the biggest savings this change brings.

RELNOTES: Performance improvements

040304727379ccfe55e4be252728ae4b71ae6aa4

-------

<p> Replace google.github.io/dagger with dagger.dev

33bbfcf7af89a32c40b48838dc7ec8fe6076b670

-------

<p> Cache references to "JavacSingletonType.instance(context)" references within ErrorProne. Expose them as methods on VisitorState and only request them once

On their own, these seem insignificant, but in aggregate they're timing is noticeable.

dcde6fc14ce839705188b2a9ead090a8649042c6

-------

<p> Update docs for the Truth migration from an `actual()` method to an `actual` field.

4b3fed84ebf7ca2e10aefa97dacd669e51ad4f6b

-------

<p> Use the latest checker framework dataflow version

e2d348da80cdb90a0b734b78a80138911fd88bb3

-------

<p> Remove the custom link from UnusedException.

This already had documentation, which I guess wasn't being linked to. Winning.

05bf1e9174b6fb2c585fc4ed5b5a054bc72c4187

-------

<p> Add valueOf to list of BadImport static imports

https://github.com/google/error-prone/issues/1284

ab574525e5027bde1ba2d109f3caea3c2e9af681

-------

<p> Make LocalDate.plus/minus(Duration) a compile-time error.

f5e3c4281fe3622cb1f50327f48157f574d1f871

-------

<p> Add Class to list of bad imports.

61afa5a77f3637288945c218f0572b6a7f4e03d7

-------

<p> Update to Truth 0.45, and address deprecations.

Renames may include:
- containsAllOf => containsAtLeast
- containsAllIn => containsAtLeastElementsIn
- isSameAs => isSameInstanceAs
- isOrdered => isInOrder
- isStrictlyOrdered => isInStrictOrder

The other major change is to change custom subjects to extend raw Subject instead of supplying type parameters. The type parameters are being removed from Subject. This CL will temporarily produce rawtypes warnings, which will go away when I remove the type parameters (as soon as this batch of CLs is submitted).

Some CLs in this batch also migrate calls away from actualAsString(). Its literal replacement is `"<" + actual + ">"` (unless an object overrides actualCustomStringRepresentation()), but usually I've made a larger change, such as switching from an old-style "Not true that..." failure message to one generated with the Fact API. In that case, the new code usually contains a direct reference to this.actual (a field that I occasionally had to create). Another larger change I sometimes made is to switch from a manual check-and-fail approach to instead use check(...). And sometimes I just remove a withMessage() call that's no longer necessary now that the code uses check(...), or I introduce a check(...) call. (An assertion made with check(...) automatically includes the actual value from the original subject, so there's no need to set it again with withMessage().)

Finally, there's one CL in this batch in which I migrate a Correspondence subclass to instead use Correspondence.from.

e1c9375e1f6e76ae9e07fc21a7ff3ec4e949f531

-------

<p> Remove obsolete todo

d36818181de74145613cfd8e400af6ee0b6138b0

-------

<p> Recommend Period in the LocalDateTemporalAmount summary.

575b5ec6cdba7ae77b4c514038a8690900322972

-------

<p> Replace some for loops with stream operatoins

It reads more nicely without the builders, and I don't think it's in some performance-sensitive area where we should worry about the slight cost of a stream.

d9e56022edb4e16639269b4a8ef86e3eb4223f03

-------

<p> Cleanups in CheckReturnValue

- Anonymous class to lambda
- Guava Optional to j.u.Optional
  - Replace ifPresent/get pairs with orElseGet chain
- Fix spelling mistakes in comments
- Remove an UnnecessaryLambda(TM)
- Remove some unused parameters

041d43d6f3adc22e02eeb644184b2981da780e68

-------

<p> Move @CheckReturnValue to the class level

2c3541475c6572ae3b95245c6b9a5e292fd16df4