### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ArrayToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ArrayToString.java
@@ -55,7 +55,12 @@ public class ArrayToString extends AbstractToString {
   protected Optional<Fix> implicitToStringFix(ExpressionTree tree, VisitorState state) {
     // e.g. println(theArray) -> println(Arrays.toString(theArray))
     // or:  "" + theArray -> "" + Arrays.toString(theArray)
-    return fix(tree, tree, state);
+    return toStringFix(tree, tree, state);
+  }
+
+  @Override
+  protected boolean allowableToStringKind(ToStringKind toStringKind) {
+    return toStringKind == ToStringKind.FLOGGER;
   }
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnored.java
@@ -99,6 +99,9 @@ public final class FutureReturnValueIgnored extends AbstractReturnValueIgnored
               .onDescendantOf("io.netty.channel.ChannelFuture")
               .namedAnyOf("addListener", "addListeners"),
           instanceMethod()
+              .onDescendantOf("io.netty.channel.ChannelPromise")
+              .namedAnyOf("setSuccess", "setFailure"),
+          instanceMethod()
               .onExactClass("java.util.concurrent.CompletableFuture")
               .namedAnyOf("exceptionally", "completeAsync", "orTimeout", "completeOnTimeout"));
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MethodCanBeStatic.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MethodCanBeStatic.java
@@ -16,12 +16,10 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.fixes.SuggestedFixes.addModifiers;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
-import static com.google.errorprone.util.ASTHelpers.isSameType;
-import static com.google.errorprone.util.ASTHelpers.isSubtype;
+import static com.google.errorprone.matchers.Matchers.SERIALIZATION_METHODS;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -119,7 +117,7 @@ public class MethodCanBeStatic extends BugChecker implements CompilationUnitTree
           nodes.put(sym, new MethodDetails(tree, true, ImmutableSet.of()));
         } else {
           CanBeStaticResult result = CanBeStaticAnalyzer.canBeStaticResult(tree, sym, state);
-          boolean isExcluded = isExcluded(sym, state);
+          boolean isExcluded = isExcluded(tree, state);
           nodes.put(
               sym,
               new MethodDetails(
@@ -225,7 +223,8 @@ public class MethodCanBeStatic extends BugChecker implements CompilationUnitTree
     return builder.build();
   }
 
-  private static boolean isExcluded(MethodSymbol sym, VisitorState state) {
+  private static boolean isExcluded(MethodTree tree, VisitorState state) {
+    MethodSymbol sym = ASTHelpers.getSymbol(tree);
     if (sym == null) {
       return true;
     }
@@ -249,37 +248,7 @@ public class MethodCanBeStatic extends BugChecker implements CompilationUnitTree
       case ANONYMOUS:
         return true;
     }
-    if (isSubtype(sym.owner.enclClass().type, state.getSymtab().serializableType, state)) {
-      switch (sym.getSimpleName().toString()) {
-        case "readObject":
-          if (sym.getParameters().size() == 1
-              && isSameType(
-                  getOnlyElement(sym.getParameters()).type,
-                  state.getTypeFromString("java.io.ObjectInputStream"),
-                  state)) {
-            return true;
-          }
-          break;
-        case "writeObject":
-          if (sym.getParameters().size() == 1
-              && isSameType(
-                  getOnlyElement(sym.getParameters()).type,
-                  state.getTypeFromString("java.io.ObjectOutputStream"),
-                  state)) {
-            return true;
-          }
-          break;
-        case "readObjectNoData":
-        case "readResolve":
-        case "writeReplace":
-          if (sym.getParameters().isEmpty()) {
-            return true;
-          }
-          break;
-        default: // fall out
-      }
-    }
-    return false;
+    return SERIALIZATION_METHODS.matches(tree, state);
   }
 
   /** Information about a {@link MethodSymbol} and whether it can be made static. */

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
@@ -24,6 +24,7 @@ import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.SERIALIZATION_METHODS;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 import static com.google.errorprone.util.ASTHelpers.getType;
 import static com.google.errorprone.util.ASTHelpers.isSubtype;
@@ -650,6 +651,9 @@ public final class UnusedVariable extends BugChecker implements CompilationUnitT
 
     @Override
     public Void visitMethod(MethodTree tree, Void unused) {
+      if (SERIALIZATION_METHODS.matches(tree, state)) {
+        return scan(tree.getBody(), null);
+      }
       return isSuppressed(tree) ? null : super.visitMethod(tree, unused);
     }
   }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringAnnotationChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringAnnotationChecker.java
@@ -49,7 +49,7 @@ public final class FormatStringAnnotationChecker extends BugChecker
 
   /**
    * Matches a method or constructor invocation. The input symbol should match the invoked method or
-   * contructor and the args should be the parameters in the invocation.
+   * constructor and the args should be the parameters in the invocation.
    */
   private Description matchInvocation(
       ExpressionTree tree,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/StrictFormatStringValidation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/StrictFormatStringValidation.java
@@ -152,7 +152,7 @@ public class StrictFormatStringValidation {
                       + "with an @FormatString must match the types of the format arguments in "
                       + "the @FormatMethod header where the format string was declared.\n\t"
                       + "Format arg types passed: %s\n\tFormat arg types expected: %s",
-                  calleeFormatArgTypes.toArray(), ownerFormatArgTypes.toArray()));
+                  calleeFormatArgTypes, ownerFormatArgTypes));
         }
       }
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/JavadocTag.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/JavadocTag.java
@@ -29,6 +29,7 @@ abstract class JavadocTag {
           blockTag("apiNote"),
           blockTag("attr"), // commonly used by Android
           blockTag("contact"),
+          blockTag("fails"), // commonly used tag for denoting async failure modes
           blockTag("hide"),
           blockTag("implNote"),
           blockTag("implSpec"),

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationToLongTimeUnit.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationToLongTimeUnit.java
@@ -129,7 +129,7 @@ public final class DurationToLongTimeUnit extends BugChecker
     return Description.NO_MATCH;
   }
 
-  private static Optional<TimeUnit> getTimeUnit(ExpressionTree timeUnit) {
+  static Optional<TimeUnit> getTimeUnit(ExpressionTree timeUnit) {
     if (timeUnit instanceof IdentifierTree) { // e.g., SECONDS
       return Enums.getIfPresent(TimeUnit.class, ((IdentifierTree) timeUnit).getName().toString());
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferDurationOverload.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferDurationOverload.java
@@ -17,9 +17,18 @@ package com.google.errorprone.bugpatterns.time;
 
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.constructor;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 import static com.google.errorprone.util.ASTHelpers.isSameType;
 import static com.google.errorprone.util.ASTHelpers.isSubtype;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -30,6 +39,7 @@ import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -38,6 +48,7 @@ import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.tree.JCTree;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
 /** This check suggests the use of {@code java.time.Duration}-based APIs, when available. */
@@ -60,18 +71,32 @@ import java.util.concurrent.TimeUnit;
 public final class PreferDurationOverload extends BugChecker
     implements MethodInvocationTreeMatcher {
 
-  private static final String DURATION = "java.time.Duration";
+  private static final String JAVA_DURATION = "java.time.Duration";
+  private static final String JODA_DURATION = "org.joda.time.Duration";
 
   private static final ImmutableMap<TimeUnit, String> TIMEUNIT_TO_DURATION_FACTORY =
       new ImmutableMap.Builder<TimeUnit, String>()
-          .put(TimeUnit.NANOSECONDS, "%s.ofNanos(%s)")
-          .put(TimeUnit.MICROSECONDS, "%s.of(%s, %s)")
-          .put(TimeUnit.MILLISECONDS, "%s.ofMillis(%s)")
-          .put(TimeUnit.SECONDS, "%s.ofSeconds(%s)")
-          .put(TimeUnit.MINUTES, "%s.ofMinutes(%s)")
-          .put(TimeUnit.HOURS, "%s.ofHours(%s)")
-          .put(TimeUnit.DAYS, "%s.ofDays(%s)")
+          .put(NANOSECONDS, "%s.ofNanos(%s)")
+          .put(MICROSECONDS, "%s.of(%s, %s)")
+          .put(MILLISECONDS, "%s.ofMillis(%s)")
+          .put(SECONDS, "%s.ofSeconds(%s)")
+          .put(MINUTES, "%s.ofMinutes(%s)")
+          .put(HOURS, "%s.ofHours(%s)")
+          .put(DAYS, "%s.ofDays(%s)")
           .build();
+
+  private static final ImmutableMap<Matcher<ExpressionTree>, TimeUnit>
+      JODA_DURATION_FACTORY_MATCHERS =
+          new ImmutableMap.Builder<Matcher<ExpressionTree>, TimeUnit>()
+              .put(constructor().forClass(JODA_DURATION).withParameters("long"), MILLISECONDS)
+              .put(staticMethod().onClass(JODA_DURATION).named("millis"), MILLISECONDS)
+              .put(staticMethod().onClass(JODA_DURATION).named("standardSeconds"), SECONDS)
+              .put(staticMethod().onClass(JODA_DURATION).named("standardMinutes"), MINUTES)
+              .put(staticMethod().onClass(JODA_DURATION).named("standardHours"), HOURS)
+              .put(staticMethod().onClass(JODA_DURATION).named("standardDays"), DAYS)
+              .build();
+
+  // TODO(kak): Add support for constructors that accept a <long, TimeUnit> or JodaTime Duration
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
@@ -87,10 +112,15 @@ public final class PreferDurationOverload extends BugChecker
           String durationFactory = TIMEUNIT_TO_DURATION_FACTORY.get(optionalTimeUnit.get());
           if (durationFactory != null) {
             SuggestedFix.Builder fix = SuggestedFix.builder();
-            String qualifiedDuration = SuggestedFixes.qualifyType(state, fix, DURATION);
+            String qualifiedDuration = SuggestedFixes.qualifyType(state, fix, JAVA_DURATION);
             String value = state.getSourceForNode(arguments.get(0));
             String replacement;
-            if (optionalTimeUnit.get() == TimeUnit.MICROSECONDS) {
+
+            // TODO(kak): Add support for:
+            //   foo(javaDuration.getSeconds(), SECONDS);
+            //   foo(javaDuration.toMillis(), MILLISECONDS);
+
+            if (optionalTimeUnit.get() == MICROSECONDS) {
               String qualifiedChronoUnit =
                   SuggestedFixes.qualifyType(state, fix, "java.time.temporal.ChronoUnit");
               replacement =
@@ -114,21 +144,40 @@ public final class PreferDurationOverload extends BugChecker
     }
 
     if (isJodaDurationMethodCall(tree, state)) {
+      ExpressionTree arg0 = arguments.get(0);
       if (javaDurationOverloadExists(tree, state)) {
         SuggestedFix.Builder fix = SuggestedFix.builder();
         // TODO(kak): Maybe only emit a match if Duration doesn't have to be fully qualified?
-        String qualifiedType = SuggestedFixes.qualifyType(state, fix, DURATION);
+        String qualifiedDuration = SuggestedFixes.qualifyType(state, fix, JAVA_DURATION);
+
+        // TODO(kak): Add support for org.joda.time.Duration.ZERO -> java.time.Duration.ZERO
+
+        // If the Joda Duration is being constructed inline, then unwrap it.
+        for (Entry<Matcher<ExpressionTree>, TimeUnit> entry :
+            JODA_DURATION_FACTORY_MATCHERS.entrySet()) {
+          if (entry.getKey().matches(arg0, state)) {
+            if (arg0 instanceof MethodInvocationTree) {
+              MethodInvocationTree jodaDurationCreation = (MethodInvocationTree) arg0;
+              String value = state.getSourceForNode(jodaDurationCreation.getArguments().get(0));
+
+              String durationFactory = TIMEUNIT_TO_DURATION_FACTORY.get(entry.getValue());
+              if (durationFactory != null) {
+                String replacement = String.format(durationFactory, qualifiedDuration, value);
+
+                fix.replace(arg0, replacement);
+                return describeMatch(tree, fix.build());
+              }
+            }
+          }
+        }
 
         // We could suggest using JavaTimeConversions.toJavaDuration(jodaDuration), but that
         // requires an additional dependency and isn't open-sourced.
-
-        // TODO(kak): Extract the numeric primitive if the Joda Duration is being constructed
-        // inline. E.g., foo(Duration.standardSeconds(42)) -> foo(Duration.ofSeconds(42))
         fix.replace(
             arguments.get(0),
             String.format(
                 "%s.ofMillis(%s.getMillis())",
-                qualifiedType, state.getSourceForNode(arguments.get(0))));
+                qualifiedDuration, state.getSourceForNode(arguments.get(0))));
         return describeMatch(tree, fix.build());
       }
     }
@@ -158,7 +207,7 @@ public final class PreferDurationOverload extends BugChecker
 
   private static boolean javaDurationOverloadExists(MethodInvocationTree tree, VisitorState state) {
     MethodSymbol methodSymbol = getSymbol(tree);
-    Type durationType = state.getTypeFromString(DURATION);
+    Type durationType = state.getTypeFromString(JAVA_DURATION);
     return !ASTHelpers.findMatchingMethods(
             methodSymbol.name,
             input ->

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferDurationOverload.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferDurationOverload.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.google.errorprone.util.ASTHelpers.isSameType;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.tree.JCTree;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/** This check suggests the use of {@code java.time.Duration}-based APIs, when available. */
+@BugPattern(
+    name = "PreferDurationOverload",
+    summary =
+        "Prefer using java.time.Duration-based APIs when available. Note that this checker does"
+            + " not and cannot guarantee that the overloads have equivalent semantics, but that is"
+            + " generally the case with overloaded methods.",
+    severity = WARNING,
+    explanation =
+        "APIs that require a <long, TimeUnit> pair suffer from a number of problems: 1) they may"
+            + " require plumbing 2 parameters through various layers of your application; 2)"
+            + " overflows are possible when doing any duration math; 3) they lack semantic"
+            + " meaning; 4) decomposing a duration into a <long, TimeUnit> is dangerous because of"
+            + " unit mismatch and/or excessive truncation.",
+    providesFix = REQUIRES_HUMAN_ATTENTION)
+public final class PreferDurationOverload extends BugChecker
+    implements MethodInvocationTreeMatcher {
+
+  private static final String DURATION = "java.time.Duration";
+
+  private static final ImmutableMap<TimeUnit, String> TIMEUNIT_TO_DURATION_FACTORY =
+      new ImmutableMap.Builder<TimeUnit, String>()
+          .put(TimeUnit.NANOSECONDS, "%s.ofNanos(%s)")
+          // TODO(kak): Do we want to handle MICROSECONDS? We'd need to either use
+          // Duration.of(%s, MICROSECONDS) or com.google.common.time.Durations.ofMicros(%s)
+          .put(TimeUnit.MILLISECONDS, "%s.ofMillis(%s)")
+          .put(TimeUnit.SECONDS, "%s.ofSeconds(%s)")
+          .put(TimeUnit.MINUTES, "%s.ofMinutes(%s)")
+          .put(TimeUnit.HOURS, "%s.ofHours(%s)")
+          .put(TimeUnit.DAYS, "%s.ofDays(%s)")
+          .build();
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    // TODO(kak): Add support for methods with > 2 parameters. E.g.,
+    // foo(String, long, TimeUnit, Frobber) -> foo(String, Duration, Frobber)
+    if (isLongTimeUnitMethod(tree, state)) {
+      List<? extends ExpressionTree> arguments = tree.getArguments();
+      Optional<TimeUnit> optionalTimeUnit = DurationToLongTimeUnit.getTimeUnit(arguments.get(1));
+      if (optionalTimeUnit.isPresent()) {
+        if (durationOverloadExists(tree, state)) {
+          String durationFactory = TIMEUNIT_TO_DURATION_FACTORY.get(optionalTimeUnit.get());
+          if (durationFactory != null) {
+            SuggestedFix.Builder fix = SuggestedFix.builder();
+            String qualifiedType = SuggestedFixes.qualifyType(state, fix, DURATION);
+            fix.replace(
+                ((JCTree) arguments.get(0)).getStartPosition(),
+                state.getEndPosition(arguments.get(1)),
+                String.format(
+                    durationFactory, qualifiedType, state.getSourceForNode(arguments.get(0))));
+            return describeMatch(tree, fix.build());
+          }
+        }
+      }
+    }
+    // TODO(kak): Add support for Joda Durations. I.e., if (isJodaDurationMethod(tree, state)) { }
+    return Description.NO_MATCH;
+  }
+
+  private static boolean isLongTimeUnitMethod(MethodInvocationTree tree, VisitorState state) {
+    Type longType = state.getSymtab().longType;
+    Type timeUnitType = state.getTypeFromString("java.util.concurrent.TimeUnit");
+    List<VarSymbol> params = getSymbol(tree).getParameters();
+    if (params.size() == 2) {
+      return isSameType(params.get(0).asType(), longType, state)
+          && isSameType(params.get(1).asType(), timeUnitType, state);
+    }
+    return false;
+  }
+
+  private static boolean durationOverloadExists(MethodInvocationTree tree, VisitorState state) {
+    MethodSymbol methodSymbol = getSymbol(tree);
+    Type durationType = state.getTypeFromString(DURATION);
+    return !ASTHelpers.findMatchingMethods(
+            methodSymbol.name,
+            input ->
+                !input.equals(methodSymbol)
+                    // TODO(kak): Do we want to check return types too?
+                    && input.isStatic() == methodSymbol.isStatic()
+                    && input.getParameters().size() == 1
+                    && isSameType(input.getParameters().get(0).asType(), durationType, state),
+            ASTHelpers.enclosingClass(methodSymbol).asType(),
+            state.getTypes())
+        .isEmpty();
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -413,6 +413,7 @@ import com.google.errorprone.bugpatterns.time.LocalDateTemporalAmount;
 import com.google.errorprone.bugpatterns.time.PeriodFrom;
 import com.google.errorprone.bugpatterns.time.PeriodGetTemporalUnit;
 import com.google.errorprone.bugpatterns.time.PeriodTimeMath;
+import com.google.errorprone.bugpatterns.time.PreferDurationOverload;
 import com.google.errorprone.bugpatterns.time.ProtoDurationGetSecondsGetNano;
 import com.google.errorprone.bugpatterns.time.ProtoTimestampGetSecondsGetNano;
 import com.google.errorprone.bugpatterns.time.TemporalAccessorGetChronoField;
@@ -713,6 +714,7 @@ public class BuiltInCheckerSuppliers {
           ParameterName.class,
           PreconditionsCheckNotNullRepeated.class,
           PreconditionsInvalidPlaceholder.class,
+          PreferDurationOverload.class,
           ProtoRedundantSet.class,
           ProtoDurationGetSecondsGetNano.class,
           ProtoTimestampGetSecondsGetNano.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/LiteProtoToStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/LiteProtoToStringTest.java
@@ -100,4 +100,58 @@ public final class LiteProtoToStringTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void floggerAtWarning_error() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.flogger.GoogleLogger;",
+            "import com.google.protobuf.GeneratedMessageLite;",
+            "class Test {",
+            "  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();",
+            "  private void test(GeneratedMessageLite message) {",
+            "    // BUG: Diagnostic contains:",
+            "    logger.atWarning().log(message);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void floggerAtVerbose_noWarning() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.flogger.GoogleLogger;",
+            "import com.google.protobuf.GeneratedMessageLite;",
+            "class Test {",
+            "  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();",
+            "  private void test(GeneratedMessageLite message) {",
+            "    logger.atFine().log(message);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void customFormatMethod() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.errorprone.annotations.FormatMethod;",
+            "import com.google.protobuf.GeneratedMessageLite;",
+            "class Test {",
+            "  private void test(GeneratedMessageLite message) {",
+            "    // BUG: Diagnostic contains:",
+            "    format(null, \"%s\", message);",
+            "    format(message, \"%s\", 1);",
+            "  }",
+            "  @FormatMethod",
+            "  String format(Object tag, String format, Object... args) {",
+            "    return String.format(format, args);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/LiteProtoToStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/LiteProtoToStringTest.java
@@ -101,38 +101,6 @@ public final class LiteProtoToStringTest {
         .doTest();
   }
 
-  @Test
-  public void floggerAtWarning_error() {
-    compilationHelper
-        .addSourceLines(
-            "Test.java",
-            "import com.google.common.flogger.GoogleLogger;",
-            "import com.google.protobuf.GeneratedMessageLite;",
-            "class Test {",
-            "  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();",
-            "  private void test(GeneratedMessageLite message) {",
-            "    // BUG: Diagnostic contains:",
-            "    logger.atWarning().log(message);",
-            "  }",
-            "}")
-        .doTest();
-  }
-
-  @Test
-  public void floggerAtVerbose_noWarning() {
-    compilationHelper
-        .addSourceLines(
-            "Test.java",
-            "import com.google.common.flogger.GoogleLogger;",
-            "import com.google.protobuf.GeneratedMessageLite;",
-            "class Test {",
-            "  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();",
-            "  private void test(GeneratedMessageLite message) {",
-            "    logger.atFine().log(message);",
-            "  }",
-            "}")
-        .doTest();
-  }
 
   @Test
   public void customFormatMethod() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/StreamToStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/StreamToStringTest.java
@@ -69,6 +69,7 @@ public class StreamToStringTest {
             "      .map(String::valueOf).collect(Collectors.joining(\", \")));",
             "    String s = \"\" + Arrays.asList(42).stream()",
             "      .map(String::valueOf).collect(Collectors.joining(\", \"));",
+            "    String.format(\"%s %s\", null, null);",
             "  }",
             "}")
         .doTest();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedMethodTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedMethodTest.java
@@ -83,7 +83,7 @@ public final class UnusedMethodTest {
             "package unusedvars;",
             "import java.io.IOException;",
             "import java.io.ObjectStreamException;",
-            "public class Unuseds {",
+            "public class Unuseds implements java.io.Serializable {",
             "  private void readObject(java.io.ObjectInputStream in) throws IOException {",
             "    in.hashCode();",
             "  }",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedVariableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedVariableTest.java
@@ -1269,4 +1269,23 @@ public class UnusedVariableTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void exemptedMethods() {
+    helper
+        .addSourceLines(
+            "Unuseds.java",
+            "package unusedvars;",
+            "import java.io.IOException;",
+            "import java.io.ObjectStreamException;",
+            "public class Unuseds implements java.io.Serializable {",
+            "  private void readObject(java.io.ObjectInputStream in) throws IOException {}",
+            "  private void writeObject(java.io.ObjectOutputStream out) throws IOException {}",
+            "  private Object readResolve() {",
+            "    return null;",
+            "  }",
+            "  private void readObjectNoData() throws ObjectStreamException {}",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UnnecessaryBoxedVariableCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UnnecessaryBoxedVariableCases.java
@@ -18,6 +18,7 @@ package com.google.errorprone.bugpatterns.testdata;
 
 import java.util.List;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 /** @author awturner@google.com (Andy Turner) */
 class UnnecessaryBoxedVariableCases {
@@ -80,8 +81,8 @@ class UnnecessaryBoxedVariableCases {
     for (Integer i : array) {}
   }
 
-  final void negative_invokeMethod(Integer i) {
-    i.toString();
+  final void negative_invokeMethod(Integer i) throws InterruptedException {
+    i.wait(0);
   }
 
   final Object[] negative_objectArray(Long l) {
@@ -151,6 +152,38 @@ class UnnecessaryBoxedVariableCases {
   void negative_methodReference() {
     Integer myVariable = 0;
     Stream<Integer> stream = Stream.of(1).filter(myVariable::equals);
+  }
+
+  static void positive_parameter_staticMethod(Boolean b) {
+    boolean a = b;
+  }
+
+  static void negative_parameter_staticMethod(Boolean b) {
+    System.out.println("a " + b);
+  }
+
+  static boolean positive_parameter_returnType(Boolean b) {
+    return b;
+  }
+
+  void negative_parameter_instanceMethod_nonFinal(Boolean b) {
+    boolean a = b;
+  }
+
+  final void negative_parameter_instanceMethod_final(Boolean b) {
+    boolean a = b;
+  }
+
+  static void negative_parameter_unused(Integer i) {}
+
+  static void positive_removeNullable_parameter(@Nullable Integer i) {
+    int j = i;
+  }
+
+  static void positive_removeNullable_localVariable() {
+    @Nullable Integer i = 0;
+    @javax.annotation.Nullable Integer j = 0;
+    int k = i + j;
   }
 
   private void methodPrimitiveArg(int i) {}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UnnecessaryBoxedVariableCases_expected.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UnnecessaryBoxedVariableCases_expected.java
@@ -18,6 +18,7 @@ package com.google.errorprone.bugpatterns.testdata;
 
 import java.util.List;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 /** @author awturner@google.com (Andy Turner) */
 class UnnecessaryBoxedVariableCases {
@@ -80,8 +81,8 @@ class UnnecessaryBoxedVariableCases {
     for (int i : array) {}
   }
 
-  final void negative_invokeMethod(Integer i) {
-    i.toString();
+  final void negative_invokeMethod(Integer i) throws InterruptedException {
+    i.wait(0);
   }
 
   final Object[] negative_objectArray(Long l) {
@@ -150,6 +151,38 @@ class UnnecessaryBoxedVariableCases {
   void negative_methodReference() {
     Integer myVariable = 0;
     Stream<Integer> stream = Stream.of(1).filter(myVariable::equals);
+  }
+
+  static void positive_parameter_staticMethod(boolean b) {
+    boolean a = b;
+  }
+
+  static void negative_parameter_staticMethod(Boolean b) {
+    System.out.println("a " + b);
+  }
+
+  static boolean positive_parameter_returnType(boolean b) {
+    return b;
+  }
+
+  void negative_parameter_instanceMethod_nonFinal(Boolean b) {
+    boolean a = b;
+  }
+
+  final void negative_parameter_instanceMethod_final(boolean b) {
+    boolean a = b;
+  }
+
+  static void negative_parameter_unused(Integer i) {}
+
+  static void positive_removeNullable_parameter(int i) {
+    int j = i;
+  }
+
+  static void positive_removeNullable_localVariable() {
+    int i = 0;
+    int j = 0;
+    int k = i + j;
   }
 
   private void methodPrimitiveArg(int i) {}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
@@ -27,7 +27,7 @@ public class PreferDurationOverloadTest {
       CompilationTestHelper.newInstance(PreferDurationOverload.class, getClass());
 
   @Test
-  public void callingMethodWithDurationOverload() {
+  public void callingLongTimeUnitMethodWithDurationOverload() {
     helper
         .addSourceLines(
             "TestClass.java",
@@ -43,7 +43,7 @@ public class PreferDurationOverloadTest {
   }
 
   @Test
-  public void callingMethodWithDurationOverload_intParam() {
+  public void callingLongTimeUnitMethodWithDurationOverload_intParam() {
     helper
         .addSourceLines(
             "TestClass.java",
@@ -59,7 +59,7 @@ public class PreferDurationOverloadTest {
   }
 
   @Test
-  public void callingMethodWithDurationOverload_privateMethod() {
+  public void callingLongTimeUnitMethodWithDurationOverload_privateMethod() {
     helper
         .addSourceLines(
             "TestClass.java",
@@ -79,7 +79,7 @@ public class PreferDurationOverloadTest {
   }
 
   @Test
-  public void callingMethodWithoutDurationOverload() {
+  public void callingLongTimeUnitMethodWithoutDurationOverload() {
     helper
         .addSourceLines(
             "TestClass.java",
@@ -88,6 +88,74 @@ public class PreferDurationOverloadTest {
             "public class TestClass {",
             "  public String foo(Future<String> future) throws Exception {",
             "    return future.get(42L, TimeUnit.SECONDS);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void callingJodaDurationMethodWithDurationOverload_privateMethod() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "public class TestClass {",
+            "  private void bar(org.joda.time.Duration d) {",
+            "  }",
+            "  private void bar(Duration d) {",
+            "  }",
+            "  public void foo(org.joda.time.Duration jodaDuration) {",
+            "    // BUG: Diagnostic contains: bar(Duration.ofMillis(jodaDuration.getMillis()));",
+            "    bar(jodaDuration);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void callingJodaDurationMethodWithoutDurationOverload() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "public class TestClass {",
+            "  private void bar(org.joda.time.Duration d) {",
+            "  }",
+            "  public void foo(org.joda.time.Duration jodaDuration) {",
+            "    bar(jodaDuration);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void callingJodaReadableDurationMethodWithDurationOverload_privateMethod() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "public class TestClass {",
+            "  private void bar(org.joda.time.ReadableDuration d) {",
+            "  }",
+            "  private void bar(Duration d) {",
+            "  }",
+            "  public void foo(org.joda.time.Duration jodaDuration) {",
+            "    // BUG: Diagnostic contains: bar(Duration.ofMillis(jodaDuration.getMillis()));",
+            "    bar(jodaDuration);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void callingJodaReadableDurationMethodWithoutDurationOverload() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "public class TestClass {",
+            "  private void bar(org.joda.time.ReadableDuration d) {",
+            "  }",
+            "  public void foo(org.joda.time.Duration jodaDuration) {",
+            "    bar(jodaDuration);",
             "  }",
             "}")
         .doTest();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
@@ -27,6 +27,23 @@ public class PreferDurationOverloadTest {
       CompilationTestHelper.newInstance(PreferDurationOverload.class, getClass());
 
   @Test
+  public void callingLongTimeUnitMethodWithDurationOverload_microseconds() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import com.google.common.cache.CacheBuilder;",
+            "import java.util.concurrent.TimeUnit;",
+            "public class TestClass {",
+            "  public CacheBuilder foo(CacheBuilder builder) {",
+            "    // BUG: Diagnostic contains: builder.expireAfterAccess(Duration.of(42,"
+                + " ChronoUnit.MICROSECONDS));",
+            "    return builder.expireAfterAccess(42, TimeUnit.MICROSECONDS);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void callingLongTimeUnitMethodWithDurationOverload() {
     helper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
@@ -130,6 +130,44 @@ public class PreferDurationOverloadTest {
   }
 
   @Test
+  public void callingJodaDurationMethodWithDurationOverload_privateMethod_jodaMillis() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "public class TestClass {",
+            "  private void bar(org.joda.time.Duration d) {",
+            "  }",
+            "  private void bar(Duration d) {",
+            "  }",
+            "  public void foo() {",
+            "    // BUG: Diagnostic contains: bar(Duration.ofMillis(42));",
+            "    bar(org.joda.time.Duration.millis(42));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void callingJodaDurationMethodWithDurationOverload_privateMethod_jodaSeconds() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "public class TestClass {",
+            "  private void bar(org.joda.time.Duration d) {",
+            "  }",
+            "  private void bar(Duration d) {",
+            "  }",
+            "  public void foo() {",
+            "    // BUG: Diagnostic contains: bar(Duration.ofSeconds(42));",
+            "    bar(org.joda.time.Duration.standardSeconds(42));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void callingJodaDurationMethodWithoutDurationOverload() {
     helper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link PreferDurationOverload}. */
+@RunWith(JUnit4.class)
+public class PreferDurationOverloadTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(PreferDurationOverload.class, getClass());
+
+  @Test
+  public void callingMethodWithDurationOverload() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import com.google.common.cache.CacheBuilder;",
+            "import java.util.concurrent.TimeUnit;",
+            "public class TestClass {",
+            "  public CacheBuilder foo(CacheBuilder builder) {",
+            "    // BUG: Diagnostic contains: builder.expireAfterAccess(Duration.ofSeconds(42L));",
+            "    return builder.expireAfterAccess(42L, TimeUnit.SECONDS);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void callingMethodWithDurationOverload_intParam() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import com.google.common.cache.CacheBuilder;",
+            "import java.util.concurrent.TimeUnit;",
+            "public class TestClass {",
+            "  public CacheBuilder foo(CacheBuilder builder) {",
+            "    // BUG: Diagnostic contains: builder.expireAfterAccess(Duration.ofSeconds(42));",
+            "    return builder.expireAfterAccess(42, TimeUnit.SECONDS);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void callingMethodWithDurationOverload_privateMethod() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.util.concurrent.TimeUnit;",
+            "public class TestClass {",
+            "  private void bar(long v, TimeUnit tu) {",
+            "  }",
+            "  private void bar(Duration d) {",
+            "  }",
+            "  public void foo() {",
+            "    // BUG: Diagnostic contains: bar(Duration.ofSeconds(42L));",
+            "    bar(42L, TimeUnit.SECONDS);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void callingMethodWithoutDurationOverload() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.util.concurrent.Future;",
+            "import java.util.concurrent.TimeUnit;",
+            "public class TestClass {",
+            "  public String foo(Future<String> future) throws Exception {",
+            "    return future.get(42L, TimeUnit.SECONDS);",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/docs/bugpattern/ChainedAssertionLosesContext.md
+++ b/docs/bugpattern/ChainedAssertionLosesContext.md
@@ -4,7 +4,9 @@ use [`check`], not `assertThat`.
 Before:
 
 ```
-class MyProtoSubject {
+class MyProtoSubject extends Subject {
+  ...
+
   public void hasFoo(Foo expected) {
     assertThat(actual.foo()).isEqualTo(expected);
   }
@@ -14,7 +16,9 @@ class MyProtoSubject {
 After:
 
 ```
-class MyProtoSubject {
+class MyProtoSubject extends Subject {
+  ...
+
   public void hasFoo(Foo expected) {
     check("foo()").that(actual.foo()).isEqualTo(expected);
   }

--- a/docs/bugpattern/DateFormatConstant.md
+++ b/docs/bugpattern/DateFormatConstant.md
@@ -24,7 +24,7 @@ If the field is never accessed by multiple threads, rename it to use
 `lowerCamelCase`.
 
 ```java
-@NotThreadSafe
+// not thread safe
 private static final DateFormat dateFormat =
     new SimpleDateFormat("yyyy-MM-dd HH:mm");
 

--- a/docs/bugpattern/ThrowsUncheckedException.md
+++ b/docs/bugpattern/ThrowsUncheckedException.md
@@ -1,4 +1,4 @@
-Effective Java Item 62 says:
+Effective Java Item 70 says:
 
 > Use the Javadoc `@throws` tag to document each unchecked exception that a
 > method can throw, but do not use the throws keyword to include unchecked


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add PreferDurationOverload which suggests using a Duration-based overload instead of a (long, TimeUnit)-based overload. For example, if an API has both overloads:
  setDeadline(long, TimeUnit)
  setDeadline(Duration)
then this checker will suggest callers invoke the Duration-based overload instead of the (long, TimeUnit)-based overload.

ab119165558a7b9c4ab627c0e6d94b8c3ed59d38

-------

<p> Extend UnnecessaryBoxedVariable to cover parameters of non-overriding/overrideable methods.

e2dca61d8869dc580febd0c399cd11d8feccb524

-------

<p> Add support for JodaDuration -> JavaDuration suggestions to PreferDurationOverload.

fd6ee23666af13de814bc5f9dc8a88584e95969e

-------

<p> Add TimeUnit.MICROSECONDS support to PreferDurationOverload.

a22ae925e92211e97c2df5321e9f4991f5349b8f

-------

<p> Add support for unwrapping Joda Durations that are created inline. For example:

foo(org.joda.time.Duration.standardSeconds(42)) -> foo(java.time.Duration.ofSeconds(42)).

68938cd85561dc139eb18cfab4c0bc68d348e188

-------

<p> Make example code look more like a real Subject.

in response to:
https://github.com/google/error-prone/pull/1294#discussion_r293021750

7dbad8caf04132822ab6cf776c4fb5023e667443

-------

<p> "Use checked exceptions for recoverable conditions ..." is item 70 in Effective Java 3rd edition.

f6a0168e067aaf8df95c0e2b33fc6e971208f75f

-------

<p> Remove an example annotation

0f8d73f56d66fb479d4804758f2936dd88c73da8

-------

<p> Fix typo

616782d51a2f614e289250598ee1435471c7ace4

-------

<p> Add @fails as an invalid block tag which will be ignored.

This is pretty popular (generally for Promises) and led to a right flurry of not useful clicks.

a1f929c993e87688a9465a7c3eb77507e7847eaf

-------

<p> Fix use of array toString.

bdd8eccf4fdb88d74e9a8b3f887054244f118118

-------

<p> AbstractToString: match #log calls in Flogger and @FormatMethods.

Invert the operation of the check so it looks for methods that implicitly toString, and then matches the arguments, rather than attempting to do it the other way around.

83b813f6eff75a366ffca07598a5d1caa8c6fa7c

-------

<p> Silence more Netty methods in FutureReturnValueIgnored

33c9e1ea86374b2c14fed35d0b2f9f43c79f0ec9

-------

<p> Consolidate handling of serializable methods between UnusedVariable, UnusedMethod, and MethodCanBeStatic.

Fixes #1271

c2a0ed1d2da13ffc989d712dadbeffa108d47164

-------

<p> Remove tests that apply to google-internal APIs

6152123cb5004b8cba01ec2ff4bc9870c9c62153