### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
@@ -162,6 +162,11 @@ public class Matchers {
     return (tree, state) -> tree.getKind() == kind;
   }
 
+  /** Matches an AST node of a given kind, for example, an Annotation or a switch block. */
+  public static <T extends Tree> Matcher<T> kindAnyOf(Set<Kind> kinds) {
+    return (tree, state) -> kinds.contains(tree.getKind());
+  }
+
   /** Matches an AST node which is the same object reference as the given node. */
   public static <T extends Tree> Matcher<T> isSame(Tree t) {
     return (tree, state) -> tree == t;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FloatingPointAssertionWithinEpsilon.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FloatingPointAssertionWithinEpsilon.java
@@ -32,7 +32,6 @@ import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
-import com.google.errorprone.matchers.method.MethodMatchers.MethodNameMatcher;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LiteralTree;
@@ -150,11 +149,16 @@ public final class FloatingPointAssertionWithinEpsilon extends BugChecker
                       .onDescendantOf(subjectClass)
                       .namedAnyOf("isWithin", "isNotWithin")
                       .withParameters(typeName)));
-      MethodNameMatcher junitAssert =
-          staticMethod().onClass("org.junit.Assert").named("assertEquals");
-      junitWithoutMessage = junitAssert.withParameters(typeName, typeName, typeName);
+      junitWithoutMessage =
+          staticMethod()
+              .onClass("org.junit.Assert")
+              .named("assertEquals")
+              .withParameters(typeName, typeName, typeName);
       junitWithMessage =
-          junitAssert.withParameters("java.lang.String", typeName, typeName, typeName);
+          staticMethod()
+              .onClass("org.junit.Assert")
+              .named("assertEquals")
+              .withParameters("java.lang.String", typeName, typeName, typeName);
     }
 
     abstract Number nextNumber(Number actual);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ForOverrideChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ForOverrideChecker.java
@@ -119,7 +119,19 @@ public class ForOverrideChecker extends BugChecker
       List<MethodSymbol> overriddenMethods = getOverriddenMethods(state, method);
 
       if (!overriddenMethods.isEmpty()) {
-        String customMessage = MESSAGE_BASE + "must have protected or package-private visibility";
+        MethodSymbol nearestForOverrideMethod = overriddenMethods.get(0);
+        String customMessage = "must have protected or package-private visibility";
+        if (nearestForOverrideMethod.equals(method)) {
+          // The method itself is @ForOverride but is too visible
+          customMessage = MESSAGE_BASE + customMessage;
+
+        } else {
+          // The method overrides an @ForOverride method and expands its visibility
+          customMessage =
+              String.format(
+                  "Method overrides @ForOverride method %s.%s, so it %s",
+                  nearestForOverrideMethod.enclClass(), nearestForOverrideMethod, customMessage);
+        }
         return buildDescription(tree).setMessage(customMessage).build();
       }
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnored.java
@@ -96,10 +96,18 @@ public final class FutureReturnValueIgnored extends AbstractReturnValueIgnored
           // ChannelFuture#addListener(s) returns itself for chaining. Any exception during the
           // future execution should be dealt by the listener(s).
           instanceMethod()
-              .onDescendantOf("io.netty.channel.ChannelFuture")
-              .namedAnyOf("addListener", "addListeners"),
+              .onDescendantOf("io.netty.util.concurrent.Future")
+              .namedAnyOf(
+                  "addListener",
+                  "addListeners",
+                  "removeListener",
+                  "removeListeners",
+                  "sync",
+                  "syncUninterruptibly",
+                  "await",
+                  "awaitUninterruptibly"),
           instanceMethod()
-              .onDescendantOf("io.netty.channel.ChannelPromise")
+              .onDescendantOf("io.netty.util.concurrent.Promise")
               .namedAnyOf("setSuccess", "setFailure"),
           instanceMethod()
               .onExactClass("java.util.concurrent.CompletableFuture")

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingSuperCall.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingSuperCall.java
@@ -244,7 +244,13 @@ public class MissingSuperCall extends BugChecker
   }
 
   private static boolean isSuper(ExpressionTree tree) {
-    return tree.getKind() == Kind.IDENTIFIER
-        && ((IdentifierTree) tree).getName().contentEquals("super");
+    switch (tree.getKind()) {
+      case IDENTIFIER:
+        return ((IdentifierTree) tree).getName().contentEquals("super");
+      case MEMBER_SELECT:
+        return ((MemberSelectTree) tree).getIdentifier().contentEquals("super");
+      default:
+        return false;
+    }
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ProtoTruthMixedDescriptors.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ProtoTruthMixedDescriptors.java
@@ -61,7 +61,9 @@ public final class ProtoTruthMixedDescriptors extends BugChecker
 
   private static final Matcher<ExpressionTree> IGNORING =
       instanceMethod()
-          .onDescendantOf("com.google.common.truth.extensions.proto.ProtoFluentAssertion")
+          .onDescendantOfAny(
+              "com.google.common.truth.extensions.proto.ProtoFluentAssertion",
+              "com.google.common.truth.extensions.proto.ProtoSubject")
           .named("ignoringFields");
 
   private static final Matcher<ExpressionTree> ASSERT_THAT =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
@@ -23,13 +23,11 @@ import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MemberSelectTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.tools.javac.code.Symbol;
-import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
-import com.sun.tools.javac.tree.JCTree.JCExpression;
-import com.sun.tools.javac.tree.TreeMaker;
 import javax.lang.model.element.ElementKind;
 
 /** @author cushon@google.com (Liam Miller-Cushon) */
@@ -37,6 +35,7 @@ import javax.lang.model.element.ElementKind;
     name = "TypeParameterQualifier",
     summary = "Type parameter used as type qualifier",
     severity = ERROR,
+    suppressionAnnotations = {},
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class TypeParameterQualifier extends BugChecker implements MemberSelectTreeMatcher {
 
@@ -46,9 +45,8 @@ public class TypeParameterQualifier extends BugChecker implements MemberSelectTr
     if (baseSym == null || baseSym.getKind() != ElementKind.TYPE_PARAMETER) {
       return Description.NO_MATCH;
     }
-    TreeMaker make =
-        state.getTreeMaker().forToplevel((JCCompilationUnit) state.getPath().getCompilationUnit());
-    JCExpression qual = make.QualIdent(ASTHelpers.getSymbol(tree));
-    return describeMatch(tree, SuggestedFix.replace(tree, qual.toString()));
+    SuggestedFix.Builder fix = SuggestedFix.builder();
+    fix.replace(tree, SuggestedFixes.qualifyType(state, fix, ASTHelpers.getSymbol(tree)));
+    return describeMatch(tree, fix.build());
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/UnnecessaryCheckNotNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/UnnecessaryCheckNotNull.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.nullness;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.argument;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.Fix;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree.Kind;
+
+/**
+ * Checks for {@code Preconditions.checkNotNull} and {@code Verify.verifyNotNull} with a new
+ * class/array argument.
+ *
+ * @author awturner@google.com (Andy Turner)
+ * @author bhagwani@google.com (Sumit Bhagwani)
+ */
+@BugPattern(
+    name = "UnnecessaryCheckNotNull",
+    summary =
+        "By specification, a constructor cannot return a null value, so invoking "
+            + "Preconditions.checkNotNull(...) or Verify.verifyNotNull(...) is redundant",
+    severity = ERROR,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+public class UnnecessaryCheckNotNull extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private static final Matcher<MethodInvocationTree> CHECK_NOT_NULL_MATCHER =
+      allOf(
+          Matchers.<MethodInvocationTree>anyOf(
+              staticMethod().onClass("com.google.common.base.Preconditions").named("checkNotNull"),
+              staticMethod().onClass("com.google.common.base.Verify").named("verifyNotNull")),
+          argument(
+              0,
+              Matchers.<ExpressionTree>kindAnyOf(ImmutableSet.of(Kind.NEW_CLASS, Kind.NEW_ARRAY))));
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (!CHECK_NOT_NULL_MATCHER.matches(tree, state) || tree.getArguments().isEmpty()) {
+      return Description.NO_MATCH;
+    }
+    Fix fix = SuggestedFix.replace(tree, state.getSourceForNode(tree.getArguments().get(0)));
+    return describeMatch(tree, fix);
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -379,6 +379,7 @@ import com.google.errorprone.bugpatterns.nullness.FieldMissingNullable;
 import com.google.errorprone.bugpatterns.nullness.NullableDereference;
 import com.google.errorprone.bugpatterns.nullness.ParameterNotNullable;
 import com.google.errorprone.bugpatterns.nullness.ReturnMissingNullable;
+import com.google.errorprone.bugpatterns.nullness.UnnecessaryCheckNotNull;
 import com.google.errorprone.bugpatterns.overloading.InconsistentOverloads;
 import com.google.errorprone.bugpatterns.threadsafety.DoubleCheckedLocking;
 import com.google.errorprone.bugpatterns.threadsafety.GuardedByChecker;
@@ -594,6 +595,7 @@ public class BuiltInCheckerSuppliers {
           TruthSelfEquals.class,
           TryFailThrowable.class,
           TypeParameterQualifier.class,
+          UnnecessaryCheckNotNull.class,
           UnnecessaryTypeArgument.class,
           UnusedAnonymousClass.class,
           UnusedCollectionModifiedInPlace.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ForOverrideCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ForOverrideCheckerTest.java
@@ -80,7 +80,8 @@ public class ForOverrideCheckerTest {
             "package test;",
             "import com.google.errorprone.annotations.ForOverride;",
             "public class Test {",
-            "  // BUG: Diagnostic contains: must have protected or package-private visibility",
+            "  // BUG: Diagnostic contains: @ForOverride must have protected or package-private"
+                + " visibility",
             "  @ForOverride public void myMethod() {}",
             "}")
         .doTest();
@@ -94,7 +95,8 @@ public class ForOverrideCheckerTest {
             "package test;",
             "import com.google.errorprone.annotations.ForOverride;",
             "public class Test {",
-            "  // BUG: Diagnostic contains: must have protected or package-private visibility",
+            "  // BUG: Diagnostic contains: @ForOverride must have protected or package-private"
+                + " visibility",
             "  @ForOverride private void myMethod() {}",
             "}")
         .doTest();
@@ -108,7 +110,8 @@ public class ForOverrideCheckerTest {
             "package test;",
             "import com.google.errorprone.annotations.ForOverride;",
             "public interface Test {",
-            "  // BUG: Diagnostic contains: must have protected or package-private visibility",
+            "  // BUG: Diagnostic contains: @ForOverride must have protected or package-private"
+                + " visibility",
             "  @ForOverride void myMethod();",
             "}")
         .doTest();
@@ -264,7 +267,7 @@ public class ForOverrideCheckerTest {
             "test/Test.java",
             "package test2;",
             "public class Test extends test.ExtendMe {",
-            "  // BUG: Diagnostic contains: must have protected or package-private visibility",
+            "  // BUG: Diagnostic contains: overrides @ForOverride method test.ExtendMe.overrideMe",
             "  public int overrideMe() {",
             "    System.err.println(\"Capybaras are rodents.\");",
             "    return 1;",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MissingSuperCallTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MissingSuperCallTest.java
@@ -160,6 +160,26 @@ public class MissingSuperCallTest {
   }
 
   @Test
+  public void negativeDoesCallInterfaceSuper() {
+    compilationHelper
+        .addSourceLines(
+            "Super.java",
+            "import android.support.annotation.CallSuper;",
+            "public interface Super {",
+            "  @CallSuper default void doIt() {}",
+            "}")
+        .addSourceLines(
+            "Sub.java",
+            "import java.util.Objects;",
+            "public class Sub implements Super {",
+            "  @Override public void doIt() {",
+            "    Super.super.doIt();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void positiveTwoLevelsApart() {
     compilationHelper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/UnnecessaryCheckNotNullTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/UnnecessaryCheckNotNullTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.nullness;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link UnnecessaryCheckNotNull} check.
+ *
+ * @author bhagwani@google.com (Sumit Bhagwani)
+ */
+@RunWith(JUnit4.class)
+public class UnnecessaryCheckNotNullTest {
+
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(UnnecessaryCheckNotNull.class, getClass());
+
+  @Test
+  public void positive_newClass() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.base.Preconditions;",
+            "import com.google.common.base.Verify;",
+            "class Test {",
+            " void positive() {",
+            "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
+            "Preconditions.checkNotNull(new String(\"\"));",
+            "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
+            "Preconditions.checkNotNull(new String(\"\"), new Object());",
+            "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
+            "Preconditions.checkNotNull(new String(\"\"), \"Message %s\", \"template\");",
+            "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
+            "String pa = Preconditions.checkNotNull(new String(\"\"));",
+            "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
+            "String pb = Preconditions.checkNotNull(new String(\"\"), new Object());",
+            "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
+            "String pc = Preconditions.checkNotNull(new String(\"\"), \"Message %s\","
+                + " \"template\");",
+            "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
+            "Verify.verifyNotNull(new String(\"\"));",
+            "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
+            "Verify.verifyNotNull(new String(\"\"), \"Message\");",
+            "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
+            "Verify.verifyNotNull(new String(\"\"), \"Message %s\", \"template\");",
+            "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
+            "String va = Verify.verifyNotNull(new String(\"\"));",
+            "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
+            "String vb = Verify.verifyNotNull(new String(\"\"), \"Message\");",
+            "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
+            "String vc = Verify.verifyNotNull(new String(\"\"), \"Message %s\", \"template\");",
+            "}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positive_newArray() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.base.Preconditions;",
+            "import com.google.common.base.Verify;",
+            "class Test {",
+            " void positive() {",
+            "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
+            "Preconditions.checkNotNull(new int[3]);",
+            "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
+            "Preconditions.checkNotNull(new int[]{1, 2, 3});",
+            "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
+            "Preconditions.checkNotNull(new int[5][2]);",
+            "}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.base.Preconditions;",
+            "import com.google.common.base.Verify;",
+            "class Test {",
+            "void negative() {",
+            "Preconditions.checkNotNull(new String(\"\").substring(0, 0));",
+            "Verify.verifyNotNull(new String(\"\").substring(0, 0));",
+            "}",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
@@ -76,6 +76,24 @@ public class PreferDurationOverloadTest {
   }
 
   @Test
+  public void callLongTimeUnitInsideImpl() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "import java.util.concurrent.TimeUnit;",
+            "public class TestClass {",
+            "  private void bar(long d, TimeUnit u) {",
+            "  }",
+            "  private void bar(Duration d) {",
+            //  Would normally flag, but we're avoiding recursive suggestions
+            "    bar(d.toMillis(), TimeUnit.MILLISECONDS);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void callingLongTimeUnitMethodWithDurationOverload_privateMethod() {
     helper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
@@ -233,4 +233,22 @@ public class PreferDurationOverloadTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void callingNumericPrimitiveMethodWithDurationOverload() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "public class TestClass {",
+            "  private void bar(java.time.Duration d) {",
+            "  }",
+            "  private void bar(long d) {",
+            "  }",
+            "  public void foo() {",
+            "    // BUG: Diagnostic contains: call bar(Duration) instead",
+            "    bar(42);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/docs/bugpattern/TypeParameterQualifier.md
+++ b/docs/bugpattern/TypeParameterQualifier.md
@@ -3,15 +3,15 @@ equivalent to referencing the type parameter's upper bound directly.
 
 For example, this signature:
 
-```java
+```java {.bad}
 static <T extends Message> T populate(T.Builder builder) {}
 ```
 
 Is identical to the following:
 
-```java
+```java {.good}
 static <T extends Message> T populate(Message.Builder builder) {}
 ```
 
-The use of `T.Builder` is unnecessary and misleading, so referring to the type
-by its canonical name should always be preferred.
+The use of `T.Builder` is unnecessary and misleading. Always refer to the type
+by its canonical name `Message.Builder` instead.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix an instance of TypeParameterQualifier

and make the check unsuppressible.

The behaviour of `P.Builder` and `Message.Builder` is identical at compile
time and at run time.

39949935f360d1c9a19b6e30fa2790f2bfed3f77

-------

<p> Avoid references to internal Error Prone matcher interfaces

b172701a6d1818fc43669a589a62465c54c97da9

-------

<p> Don't suggest an infinite recursion when PreferDurationOverload
suggests calling a method inside its implementation.

80cff85fb7b4520daadd96aafa7d4b806febc196

-------

<p> Prepare static analysis for when ProtoSubject no longer extends ProtoFluentAssertion.

That change will bring ProtoSubject in line with IterableOfProtosSubject and the other types in its package.

8c8e2735e9bde205161b64c00468c77111a058fc

-------

<p> Recognize calls of default interface methods

101c13abb2258c5175d30c2524a8bbc1b665460d

-------

<p> Add a ERROR ErrorProne check when new object/array creation is wrapped in
checkNotNull or verifyNotNull

RELNOTES: new ERROR which flags when new object/array creation is wrapped in
checkNotNull or verifyNotNull

fa767ca1879d7afecb33cbc7cefd7117688e76d7

-------

<p> Report different errors depending on whether the @ForOverride method is the current method or a parent.

b010f24f8a4b1033fa1d65b49ed21c25a38c4ce3

-------

<p> Issue a warning for users calling someMethod(<numeric primitive>) when a someMethod(Duration) overload exists.

a6c226485f54d5cacb2c66186696c595eb0cde51

-------

<p> Ignore Futures and Promises for netty that return themselves.

4a9b1484876d2c852db8c1534706e4d0059d2be3

-------

<p> Optimize ImmutableModification

Instead of doing a linear scan over many matchers, we do a map lookup first
to decide which types, if any, we need to scan for. This reduces time spent
checking ImmutableModification by around 80%.

27497b058e39f101f2ea9d424497f81ac4a3b76d