### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/bugpatterns/BugChecker.java
+++ b/check_api/src/main/java/com/google/errorprone/bugpatterns/BugChecker.java
@@ -259,9 +259,7 @@ public abstract class BugChecker implements Suppressible, Serializable {
    * bug checker.
    */
   public boolean isSuppressed(Tree tree) {
-    SuppressWarnings suppression = ASTHelpers.getAnnotation(tree, SuppressWarnings.class);
-    return suppression != null
-        && !Collections.disjoint(Arrays.asList(suppression.value()), allNames());
+    return isSuppressed(ASTHelpers.getAnnotation(tree, SuppressWarnings.class));
   }
 
   /**
@@ -269,7 +267,10 @@ public abstract class BugChecker implements Suppressible, Serializable {
    * this bug checker.
    */
   public boolean isSuppressed(Symbol symbol) {
-    SuppressWarnings suppression = ASTHelpers.getAnnotation(symbol, SuppressWarnings.class);
+    return isSuppressed(ASTHelpers.getAnnotation(symbol, SuppressWarnings.class));
+  }
+
+  private boolean isSuppressed(SuppressWarnings suppression) {
     return suppression != null
         && !Collections.disjoint(Arrays.asList(suppression.value()), allNames());
   }

--- a/check_api/src/main/java/com/google/errorprone/dataflow/AccessPath.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/AccessPath.java
@@ -61,7 +61,8 @@ import org.checkerframework.javacutil.TreeUtils;
 public abstract class AccessPath {
 
   /** If present, base of access path is contained Element; if absent, base is `this` */
-  public abstract @Nullable Element base();
+  @Nullable
+  public abstract Element base();
 
   public abstract ImmutableList<String> path();
 

--- a/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/NullnessPropagationTransfer.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/NullnessPropagationTransfer.java
@@ -244,7 +244,7 @@ class NullnessPropagationTransfer extends AbstractNullnessPropagationTransfer
   private transient CompilationUnitTree compilationUnit;
 
   /** Cached local inference results for nullability annotations on type parameters */
-  private transient @Nullable InferredNullability inferenceResults;
+  @Nullable private transient InferredNullability inferenceResults;
 
   @Override
   public AccessPathStore<Nullness> initialStore(
@@ -912,7 +912,7 @@ class NullnessPropagationTransfer extends AbstractNullnessPropagationTransfer
       return false;
     }
     return types.isSameType(sym.type, symtab.objectType)
-        && (!variablesAtIndexes(ImmutableSet.of(0), arguments).isEmpty());
+        && !variablesAtIndexes(ImmutableSet.of(0), arguments).isEmpty();
   }
 
   private static List<LocalVariableNode> variablesAtIndexes(

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeLocal.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeLocal.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
+import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.AssignmentTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.tree.JCTree;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.lang.model.element.ElementKind;
+
+/** Flags fields which can be replaced with local variables. */
+@BugPattern(
+    name = "FieldCanBeLocal",
+    altNames = {"unused", "Unused"},
+    summary = "This field can be replaced with a local variable in the methods that use it.",
+    severity = SUGGESTION,
+    providesFix = REQUIRES_HUMAN_ATTENTION,
+    documentSuppression = false)
+public final class FieldCanBeLocal extends BugChecker implements CompilationUnitTreeMatcher {
+
+  @Override
+  public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {
+    Map<VarSymbol, TreePath> potentialFields = new HashMap<>();
+    Multimap<VarSymbol, TreePath> unconditionalAssignments = HashMultimap.create();
+    Multimap<VarSymbol, Tree> uses = HashMultimap.create();
+
+    new TreePathScanner<Void, Void>() {
+      @Override
+      public Void visitVariable(VariableTree variableTree, Void unused) {
+        VarSymbol symbol = getSymbol(variableTree);
+        if (symbol != null
+            && symbol.getKind() == ElementKind.FIELD
+            && symbol.isPrivate()
+            && !isSuppressed(variableTree)
+        ) {
+          potentialFields.put(symbol, getCurrentPath());
+        }
+        return null;
+      }
+
+    }.scan(state.getPath(), null);
+
+    new TreePathScanner<Void, Void>() {
+      boolean inMethod = false;
+
+      @Override
+      public Void visitClass(ClassTree classTree, Void unused) {
+        if (isSuppressed(classTree)) {
+          return null;
+        }
+        inMethod = false;
+        return super.visitClass(classTree, unused);
+      }
+
+      @Override
+      public Void visitMethod(MethodTree methodTree, Void unused) {
+        if (methodTree.getBody() == null) {
+          return null;
+        }
+        handleMethodLike(new TreePath(getCurrentPath(), methodTree.getBody()));
+
+        inMethod = true;
+        super.visitMethod(methodTree, null);
+        inMethod = false;
+        return null;
+      }
+
+      @Override
+      public Void visitLambdaExpression(LambdaExpressionTree lambdaExpressionTree, Void unused) {
+        if (lambdaExpressionTree.getBody() == null) {
+          return null;
+        }
+        handleMethodLike(new TreePath(getCurrentPath(), lambdaExpressionTree.getBody()));
+        inMethod = true;
+        super.visitLambdaExpression(lambdaExpressionTree, null);
+        inMethod = false;
+        return null;
+      }
+
+      private void handleMethodLike(TreePath treePath) {
+        int depth = Iterables.size(getCurrentPath());
+        new TreePathScanner<Void, Void>() {
+          Set<VarSymbol> unconditionallyAssigned = new HashSet<>();
+
+          @Override
+          public Void visitAssignment(AssignmentTree assignmentTree, Void unused) {
+            scan(assignmentTree.getExpression(), null);
+            Symbol symbol = getSymbol(assignmentTree.getVariable());
+            if (!(symbol instanceof VarSymbol)) {
+              return scan(assignmentTree.getVariable(), null);
+            }
+            VarSymbol varSymbol = (VarSymbol) symbol;
+            if (!potentialFields.containsKey(varSymbol)) {
+              return scan(assignmentTree.getVariable(), null);
+            }
+            // An unconditional assignment in a MethodTree is three levels deeper than the
+            // MethodTree itself.
+            if (Iterables.size(getCurrentPath()) == depth + 3) {
+              unconditionallyAssigned.add(varSymbol);
+              unconditionalAssignments.put(varSymbol, getCurrentPath());
+            }
+            return scan(assignmentTree.getVariable(), null);
+          }
+
+          @Override
+          public Void visitIdentifier(IdentifierTree identifierTree, Void unused) {
+            handleIdentifier(identifierTree);
+            return super.visitIdentifier(identifierTree, null);
+          }
+
+          @Override
+          public Void visitMemberSelect(MemberSelectTree memberSelectTree, Void unused) {
+            handleIdentifier(memberSelectTree);
+            return super.visitMemberSelect(memberSelectTree, null);
+          }
+
+          private void handleIdentifier(Tree tree) {
+            Symbol symbol = getSymbol(tree);
+            if (!(symbol instanceof VarSymbol)) {
+              return;
+            }
+            VarSymbol varSymbol = (VarSymbol) symbol;
+            uses.put(varSymbol, tree);
+            if (!unconditionallyAssigned.contains(varSymbol)) {
+              potentialFields.remove(varSymbol);
+            }
+          }
+
+          @Override
+          public Void visitMethod(MethodTree methodTree, Void unused) {
+            return null;
+          }
+
+          @Override
+          public Void visitLambdaExpression(
+              LambdaExpressionTree lambdaExpressionTree, Void unused) {
+            return null;
+          }
+        }.scan(treePath, null);
+      }
+
+      @Override
+      public Void visitIdentifier(IdentifierTree identifierTree, Void unused) {
+        if (!inMethod) {
+          potentialFields.remove(getSymbol(identifierTree));
+        }
+        return null;
+      }
+
+      @Override
+      public Void visitMemberSelect(MemberSelectTree memberSelectTree, Void unused) {
+        if (!inMethod) {
+          potentialFields.remove(getSymbol(memberSelectTree));
+        }
+        return null;
+      }
+    }.scan(state.getPath(), null);
+
+    for (Map.Entry<VarSymbol, TreePath> entry : potentialFields.entrySet()) {
+      VarSymbol varSymbol = entry.getKey();
+      TreePath declarationSite = entry.getValue();
+
+      Collection<TreePath> assignmentLocations = unconditionalAssignments.get(varSymbol);
+      if (assignmentLocations.isEmpty()) {
+        continue;
+      }
+      SuggestedFix.Builder fix = SuggestedFix.builder();
+      String type = state.getSourceForNode(((VariableTree) declarationSite.getLeaf()).getType());
+      fix.delete(declarationSite.getLeaf());
+      Set<Tree> deletedTrees = new HashSet<>();
+      for (TreePath assignmentSite : assignmentLocations) {
+        AssignmentTree assignmentTree = (AssignmentTree) assignmentSite.getLeaf();
+        Symbol rhsSymbol = getSymbol(assignmentTree.getExpression());
+
+        // If the RHS of the assignment is a variable with the same name as the field, just remove
+        // the assignment.
+        String assigneeName = getSymbol(assignmentTree.getVariable()).getSimpleName().toString();
+        if (rhsSymbol != null
+            && assignmentTree.getExpression() instanceof IdentifierTree
+            && rhsSymbol.getSimpleName().contentEquals(assigneeName)) {
+          deletedTrees.add(assignmentTree.getVariable());
+          fix.delete(assignmentSite.getParentPath().getLeaf());
+        } else {
+          fix.prefixWith(assignmentSite.getLeaf(), type + " ");
+        }
+      }
+      // Strip "this." off any uses of the field.
+      for (Tree usage : uses.get(varSymbol)) {
+        if (deletedTrees.contains(usage)
+            || usage.getKind() == Kind.IDENTIFIER
+            || usage.getKind() != Kind.MEMBER_SELECT) {
+          continue;
+        }
+        ExpressionTree selected = ((MemberSelectTree) usage).getExpression();
+        if (!(selected instanceof IdentifierTree)) {
+          continue;
+        }
+        IdentifierTree ident = (IdentifierTree) selected;
+        if (ident.getName().contentEquals("this")) {
+          fix.replace(((JCTree) ident).getStartPosition(), state.getEndPosition(ident) + 1, "");
+        }
+      }
+      state.reportMatch(describeMatch(declarationSite.getLeaf(), fix.build()));
+    }
+    return Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/WithSignatureDiscouraged.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/WithSignatureDiscouraged.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.Matchers.instanceMethod;
+
+import com.google.common.base.Ascii;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.tree.JCTree;
+import java.util.stream.Collectors;
+
+/**
+ * {@link
+ * com.google.errorprone.matchers.method.MethodMatchers.MethodClassMatcher#withSignature(String)} is
+ * discouraged: most usages should use .named and/or .withParameters instead.
+ *
+ * @author amalloy@google.com (Alan Malloy)
+ */
+@BugPattern(
+    name = "WithSignatureDiscouraged",
+    summary = "withSignature is discouraged. Prefer .named and/or .withParameters where possible.",
+    providesFix = REQUIRES_HUMAN_ATTENTION,
+    severity = WARNING)
+public class WithSignatureDiscouraged extends BugChecker implements MethodInvocationTreeMatcher {
+  private static final Matcher<ExpressionTree> WITH_SIGNATURE =
+      instanceMethod()
+          .onExactClass("com.google.errorprone.matchers.method.MethodMatchers.MethodClassMatcher")
+          .named("withSignature")
+          .withParameters("java.lang.String");
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (!WITH_SIGNATURE.matches(tree, state)) {
+      return NO_MATCH;
+    }
+    ExpressionTree argument = tree.getArguments().get(0);
+    String sig = ASTHelpers.constValue(argument, String.class);
+    if (sig == null) {
+      // Non-const arguments to withSignature are a bit weird but there's not much we can do.
+      return NO_MATCH;
+    }
+    if (sig.contains("...") || sig.contains("<")) {
+      // We don't have a migration strategy to suggest for varargs or generics.
+      return NO_MATCH;
+    }
+
+    int firstParenIndex = sig.indexOf('(');
+    if (firstParenIndex == -1) {
+      // .withSignature("toString") => .named("toString")
+      return describeMatch(tree, SuggestedFixes.renameMethodInvocation(tree, "named", state));
+    }
+
+    // .withSignature("valueOf(java.lang.String,int)")
+    //      =>
+    // .named("valueOf").withParameters("java.lang.String", "int")
+    if (!(tree instanceof JCTree)) {
+      // We can't easily compute offsets to replace a whole method chain based on just the public
+      // Tree API.
+      return NO_MATCH;
+    }
+    String methodName = sig.substring(0, firstParenIndex);
+    String paramList = sig.substring(firstParenIndex + 1, sig.length() - 1);
+    return fixWithParameters((JCTree) tree, state, methodName, paramList);
+  }
+
+  private Description fixWithParameters(
+      JCTree tree, VisitorState state, String methodName, String paramList) {
+    ImmutableList<String> paramTypes =
+        ImmutableList.copyOf(Splitter.on(',').omitEmptyStrings().split(paramList));
+    if (paramTypes.stream().anyMatch(type -> isProbableTypeParameter(type) || isArrayType(type))) {
+      // We can't migrate references to type parameters or arrays, because withParameters doesn't
+      // handle those.
+      return NO_MATCH;
+    }
+
+    // A single string representing all the args to withParameters
+    String withParamsArgList =
+        paramTypes.stream()
+            .map(type -> String.format("\"%s\"", type))
+            .collect(Collectors.joining(", "));
+    int treeStart = tree.getStartPosition();
+    String source = state.getSourceForNode(tree);
+    if (source == null) {
+      // Not clear how this could happen, but if it does we may as well give up.
+      return NO_MATCH;
+    }
+    // Technically too restrictive, but will handle google-java-format'ed code okay.
+    int offset = source.indexOf(".withSignature");
+    if (offset == -1) {
+      return NO_MATCH;
+    }
+    int startPosition = treeStart + offset;
+    int endPosition = state.getEndPosition(tree);
+    String replacementText =
+        String.format(".named(\"%s\").withParameters(%s)", methodName, withParamsArgList);
+    return describeMatch(tree, SuggestedFix.replace(startPosition, endPosition, replacementText));
+  }
+
+  private static boolean isArrayType(String type) {
+    return type.contains("[");
+  }
+
+  private static boolean isProbableTypeParameter(String type) {
+    // This is a reasonable heuristic for references to type parameters:
+    // they have no . in them, and are not all-lowercase.
+    return !type.contains(".") && !type.equals(Ascii.toLowerCase(type));
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferDurationOverload.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferDurationOverload.java
@@ -17,6 +17,7 @@ package com.google.errorprone.bugpatterns.time;
 
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.constructor;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
@@ -87,6 +88,10 @@ public final class PreferDurationOverload extends BugChecker
           .put(DAYS, "%s.ofDays(%s)")
           .build();
 
+  private static final Matcher<ExpressionTree> IGNORED_APIS =
+      anyOf(
+          );
+
   private static final ImmutableMap<Matcher<ExpressionTree>, TimeUnit>
       JODA_DURATION_FACTORY_MATCHERS =
           new ImmutableMap.Builder<Matcher<ExpressionTree>, TimeUnit>()
@@ -102,6 +107,11 @@ public final class PreferDurationOverload extends BugChecker
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    // we return no match for a set of explicitly ignored APIs
+    if (IGNORED_APIS.matches(tree, state)) {
+      return Description.NO_MATCH;
+    }
+
     List<? extends ExpressionTree> arguments = tree.getArguments();
 
     // TODO(glorioso): Add support for methods with > 2 parameters. E.g.,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -307,6 +307,7 @@ import com.google.errorprone.bugpatterns.VarTypeName;
 import com.google.errorprone.bugpatterns.VariableNameSameAsType;
 import com.google.errorprone.bugpatterns.WaitNotInLoop;
 import com.google.errorprone.bugpatterns.WildcardImport;
+import com.google.errorprone.bugpatterns.WithSignatureDiscouraged;
 import com.google.errorprone.bugpatterns.WrongParameterPackage;
 import com.google.errorprone.bugpatterns.android.BinderIdentityRestoredDangerously;
 import com.google.errorprone.bugpatterns.android.BundleDeserializationCast;
@@ -756,7 +757,8 @@ public class BuiltInCheckerSuppliers {
           UseCorrectAssertInTests.class,
           VariableNameSameAsType.class,
           WaitNotInLoop.class,
-          WakelockReleasedDangerously.class);
+          WakelockReleasedDangerously.class,
+          WithSignatureDiscouraged.class);
 
   /** A list of all checks that are off by default. */
   public static final ImmutableSet<BugCheckerInfo> DISABLED_CHECKS =

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -105,6 +105,7 @@ import com.google.errorprone.bugpatterns.ExpectedExceptionRefactoring;
 import com.google.errorprone.bugpatterns.ExtendingJUnitAssert;
 import com.google.errorprone.bugpatterns.FallThrough;
 import com.google.errorprone.bugpatterns.FieldCanBeFinal;
+import com.google.errorprone.bugpatterns.FieldCanBeLocal;
 import com.google.errorprone.bugpatterns.Finally;
 import com.google.errorprone.bugpatterns.FloatCast;
 import com.google.errorprone.bugpatterns.FloatingPointAssertionWithinEpsilon;
@@ -791,6 +792,7 @@ public class BuiltInCheckerSuppliers {
           ExpectedExceptionChecker.class,
           ExpectedExceptionRefactoring.class,
           FieldCanBeFinal.class,
+          FieldCanBeLocal.class,
           FieldMissingNullable.class,
           FunctionalInterfaceClash.class,
           FuzzyEqualsShouldNotBeUsedInEqualsMethod.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/FieldCanBeLocalTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/FieldCanBeLocalTest.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link FieldCanBeLocal}. */
+@RunWith(JUnit4.class)
+public final class FieldCanBeLocalTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(FieldCanBeLocal.class, getClass());
+
+  private final BugCheckerRefactoringTestHelper refactoringTestHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new FieldCanBeLocal(), getClass());
+
+  @Test
+  public void simplePositive() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  // BUG: Diagnostic contains:",
+            "  private int a;",
+            "  int foo() {",
+            "    a = 1;",
+            "    return a;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void suppressedOnMethod() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  @SuppressWarnings(\"FieldCanBeLocal\")",
+            "  private int a;",
+            "  int foo() {",
+            "    a = 1;",
+            "    return a;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void suppressedOnClass() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "@SuppressWarnings(\"FieldCanBeLocal\")",
+            "class Test {",
+            "  private int a;",
+            "  int foo() {",
+            "    a = 1;",
+            "    return a;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void inlineConditional_noWarning() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  private int a;",
+            "  int foo(int b) {",
+            "    a = b > 2 ? a : b;",
+            "    return a;",
+            "  }",
+            "  int bar(int b) {",
+            "    a = b;",
+            "    return a;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void fieldIsPublic_noMatch() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  public int a;",
+            "  int foo() {",
+            "    a = 1;",
+            "    return a;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void usedBeforeAssigment_noMatch() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  public int a;",
+            "  int foo() {",
+            "    if (a < 0) {",
+            "      return 0;",
+            "    }",
+            "    a = 1;",
+            "    return a;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void usedInMultipleMethods_alwaysAssignedFirst_positive() {
+    refactoringTestHelper
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  private int a;",
+            "  int foo() {",
+            "    a = 1;",
+            "    return a;",
+            "  }",
+            "  int bar() {",
+            "    a = 2;",
+            "    return a;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "class Test {",
+            "  int foo() {",
+            "    int a = 1;",
+            "    return a;",
+            "  }",
+            "  int bar() {",
+            "    int a = 2;",
+            "    return a;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void qualifiedWithThis_refactoringRemovesThis() {
+    refactoringTestHelper
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  private int a;",
+            "  int foo() {",
+            "    this.a = 1;",
+            "    return a;",
+            "  }",
+            "  int bar() {",
+            "    this.a = 2;",
+            "    return a;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "class Test {",
+            "  int foo() {",
+            "    int a = 1;",
+            "    return a;",
+            "  }",
+            "  int bar() {",
+            "    int a = 2;",
+            "    return a;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void assignmentToFieldOfSameName_isRemoved() {
+    refactoringTestHelper
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  private int a;",
+            "  Test(int a) {",
+            "    this.a = a;",
+            "    int b = a + 2;",
+            "  }",
+            "  int foo() {",
+            "    this.a = 1;",
+            "    return a;",
+            "  }",
+            "  int bar() {",
+            "    this.a = 2;",
+            "    return a;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "class Test {",
+            "  Test(int a) {",
+            "    int b = a + 2;",
+            "  }",
+            "  int foo() {",
+            "    int a = 1;",
+            "    return a;",
+            "  }",
+            "  int bar() {",
+            "    int a = 2;",
+            "    return a;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void usedBeforeReassignment_noMatch() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  private int a;",
+            "  int foo() {",
+            "    a = a + 1;",
+            "    return a;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void fieldAssignedOnField() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  class Sub {",
+            "    private int a;",
+            "    int a() {",
+            "      return a;",
+            "    }",
+            "  }",
+            "  private Sub sub;",
+            "  Test(Sub sub) {",
+            "    this.sub = sub;",
+            "  }",
+            "  void foo() {",
+            "    sub.a = 1;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void usedWithinClassScope_noMatch() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.function.Predicate;",
+            "class Test {",
+            "  private Integer a;",
+            "  Predicate<Integer> predicate = b -> a == b;",
+            "  Test(int a) {",
+            "    this.a = a;",
+            "  }",
+            "  public void set(int a) {",
+            "    this.a = a;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void usedWithinLambda_noWarning() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.function.Predicate;",
+            "class Test {",
+            "  private Integer a;",
+            "  Test(int a) {",
+            "    this.a = a;",
+            "  }",
+            "  public Predicate<Integer> set(int a) {",
+            "    this.a = a;",
+            // No warning.
+            "    return x -> x == this.a;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void usedInStaticInitializer() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  static {",
+            "    Test[] tests = new Test[0];",
+            "    for (Test test : tests) {",
+            "      int b = test.a;",
+            "    }",
+            "  }",
+            "  private Integer a;",
+            "  Test(int a) {",
+            "    this.a = a;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/WithSignatureDiscouragedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/WithSignatureDiscouragedTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** @author amalloy@google.com (Alan Malloy) */
+@RunWith(JUnit4.class)
+public class WithSignatureDiscouragedTest {
+  private final BugCheckerRefactoringTestHelper refactoringTestHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new WithSignatureDiscouraged(), getClass());
+
+  @Test
+  public void named() {
+    refactoringTestHelper
+        .addInputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.instanceMethod;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.ExpressionTree;",
+            "public class Test {",
+            "  private static final Matcher<ExpressionTree> TO_STRING = ",
+            "    instanceMethod()",
+            "      .anyClass()",
+            "      .withSignature(\"toString\");",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.instanceMethod;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.ExpressionTree;",
+            "public class Test {",
+            "  private static final Matcher<ExpressionTree> TO_STRING = ",
+            "    instanceMethod()",
+            "      .anyClass()",
+            "      .named(\"toString\");",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void withEmptyParameterList() {
+    refactoringTestHelper
+        .addInputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.instanceMethod;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.ExpressionTree;",
+            "public class Test {",
+            "  private static final Matcher<ExpressionTree> TO_STRING = ",
+            "    instanceMethod()",
+            "      .anyClass()",
+            "      .withSignature(\"toString()\");",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.instanceMethod;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.ExpressionTree;",
+            "public class Test {",
+            "  private static final Matcher<ExpressionTree> TO_STRING = ",
+            "    instanceMethod()",
+            "      .anyClass()",
+            "      .named(\"toString\")",
+            "      .withParameters();",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void withParameters() {
+    refactoringTestHelper
+        .addInputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.instanceMethod;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.ExpressionTree;",
+            "public class Test {",
+            "  private static final Matcher<ExpressionTree> VALUE_OF = ",
+            "    instanceMethod()",
+            "      .anyClass()",
+            "      .withSignature(\"valueOf(double)\");",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.instanceMethod;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.ExpressionTree;",
+            "public class Test {",
+            "  private static final Matcher<ExpressionTree> VALUE_OF = ",
+            "    instanceMethod()",
+            "      .anyClass()",
+            "      .named(\"valueOf\")",
+            "      .withParameters(\"double\");",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void leaveVarargs() {
+    refactoringTestHelper
+        .addInputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.staticMethod;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.ExpressionTree;",
+            "public class Test {",
+            "  private static final Matcher<ExpressionTree> STRING_FORMAT = ",
+            "    staticMethod()",
+            "      .onClass(\"java.lang.String\")",
+            "      .withSignature(\"format(java.lang.String,java.lang.Object...)\");",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
+
+  @Test
+  public void leaveGenerics() {
+    refactoringTestHelper
+        .addInputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.staticMethod;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.ExpressionTree;",
+            "public class Test {",
+            "  private static final Matcher<ExpressionTree> TO_STRING = ",
+            "    staticMethod()",
+            "      .onClass(\"com.google.common.collect.ImmutableList\")",
+            "      .withSignature(\"<E>builder()\");",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
+
+  @Test
+  public void dontMigrateArrays() {
+    refactoringTestHelper
+        .addInputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.staticMethod;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.ExpressionTree;",
+            "public class Test {",
+            "  private static final Matcher<ExpressionTree> TO_STRING = ",
+            "    staticMethod()",
+            "      .onClass(\"java.lang.String\")",
+            "      .withSignature(\"copyValueOf(char[])\");",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
@@ -251,4 +251,8 @@ public class PreferDurationOverloadTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void ignoredApisAreExcluded() {
+  }
 }

--- a/docs/bugpattern/FieldCanBeLocal.md
+++ b/docs/bugpattern/FieldCanBeLocal.md
@@ -1,0 +1,38 @@
+A field which is always assigned before being used from every method that reads
+it may be better expressed as a local variable. Using a field in such cases
+gives the impression of mutable state in the class where it isn't necessary.
+
+```java {.bad}
+class Frobnicator {
+  private int sum = 0;
+
+  int sum(int a, int b) {
+    sum = a + b;
+    return sum;
+  }
+
+  int sum(int a, int b, int c) {
+    sum = a + b + c;
+    return sum;
+  }
+```
+
+```java {.good}
+class Frobnicator {
+  int sum(int a, int b) {
+    int sum = a + b;
+    return sum;
+  }
+
+  int sum(int a, int b, int c) {
+    int sum = a + b + c;
+    return sum;
+  }
+```
+
+## Suppression
+
+This check is suppressed by `@SuppressWarnings("FieldCanBeLocal")` as well as
+the same suppression mechanisms as `UnusedVariable`
+(`@SuppressWarnings("unused")`.
+


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix 3 Error Prone - Style findings

These fixes are automatically created by various analysis tools, but have been manually triggered to be applied.

* @Nullable is not a type annotation, so should appear before any modifiers and after Javadocs.
* Unnecessary use of grouping parentheses

bc298fbd69d1a5dd7871447e743bbd8fcd41c998

-------

<p> New checker to discourage .withSignature()

In most cases, there is a more readable alternative to suggest.

8111764526ea9e9e93c7afc4425e6a0938c2aa80

-------

<p> FieldCanBeLocal: flag fields which can be replaced by a local variable in possibly multiple methods.

717b906f073ba199db1f4acb2b7134da24fbb52d

-------

<p> Don't match com.google.monitoring.streamz.EventMetric0.record(Duration) in PreferDurationOverload

7e755c2b76735fcebb4e33bada968b5f81caea07

-------

<p> Flyby cleanup

8885625c5c58bdc98064f1b7cd2868bc77b41227