### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
@@ -31,11 +31,9 @@ import java.io.ObjectInputStream;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -105,7 +103,7 @@ public class ErrorProneOptions {
       return inPlace() || !baseDirectory().isEmpty();
     }
 
-    abstract Set<String> namedCheckers();
+    abstract ImmutableSet<String> namedCheckers();
 
     abstract boolean inPlace();
 
@@ -119,14 +117,14 @@ public class ErrorProneOptions {
       return new AutoValue_ErrorProneOptions_PatchingOptions.Builder()
           .baseDirectory("")
           .inPlace(false)
-          .namedCheckers(Collections.emptySet())
+          .namedCheckers(ImmutableSet.of())
           .importOrganizer(ImportOrganizer.STATIC_FIRST_ORGANIZER);
     }
 
     @AutoValue.Builder
     abstract static class Builder {
 
-      abstract Builder namedCheckers(Set<String> checkers);
+      abstract Builder namedCheckers(ImmutableSet<String> checkers);
 
       abstract Builder inPlace(boolean inPlace);
 

--- a/check_api/src/main/java/com/google/errorprone/matchers/WaitMatchers.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/WaitMatchers.java
@@ -39,11 +39,12 @@ public class WaitMatchers {
   /** Matches wait/await methods that have a timeout. */
   public static final Matcher<MethodInvocationTree> waitMethodWithTimeout =
       anyOf(
-          instanceMethod().onExactClass(OBJECT_FQN).withSignature("wait(long)"),
-          instanceMethod().onExactClass(OBJECT_FQN).withSignature("wait(long,int)"),
+          instanceMethod().onExactClass(OBJECT_FQN).named("wait").withParameters("long"),
+          instanceMethod().onExactClass(OBJECT_FQN).named("wait").withParameters("long", "int"),
           instanceMethod()
               .onDescendantOf(CONDITION_FQN)
-              .withSignature("await(long,java.util.concurrent.TimeUnit)"),
+              .named("await")
+              .withParameters("long", "java.util.concurrent.TimeUnit"),
           instanceMethod().onDescendantOf(CONDITION_FQN).named("awaitNanos"),
           instanceMethod().onDescendantOf(CONDITION_FQN).named("awaitUntil"));
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -454,6 +454,8 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <version>2.19.1</version>
             <configuration>
+              <forkCount>4</forkCount>
+              <reuseForks>true</reuseForks>
               <!-- set heap size to work around http://github.com/travis-ci/travis-ci/issues/3396 -->
               <!-- put javac.jar on bootclasspath when executing tests -->
               <argLine>-Xmx1g -Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</argLine>

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DefaultCharset.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DefaultCharset.java
@@ -155,7 +155,7 @@ public class DefaultCharset extends BugChecker
       staticMethod().onClass("com.google.protobuf.ByteString").named("copyFrom");
 
   private static final Matcher<ExpressionTree> STRING_GET_BYTES =
-      instanceMethod().onExactClass(String.class.getName()).withSignature("getBytes()");
+      instanceMethod().onExactClass(String.class.getName()).named("getBytes").withParameters();
 
   private static final Matcher<ExpressionTree> FILE_NEW_WRITER =
       staticMethod()

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InvalidPatternSyntax.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InvalidPatternSyntax.java
@@ -81,19 +81,24 @@ public class InvalidPatternSyntax extends BugChecker implements MethodInvocation
           anyOf(
               instanceMethod()
                   .onDescendantOf("java.lang.String")
-                  .withSignature("matches(java.lang.String)"),
+                  .named("matches")
+                  .withParameters("java.lang.String"),
               instanceMethod()
                   .onDescendantOf("java.lang.String")
-                  .withSignature("replaceAll(java.lang.String,java.lang.String)"),
+                  .named("replaceAll")
+                  .withParameters("java.lang.String", "java.lang.String"),
               instanceMethod()
                   .onDescendantOf("java.lang.String")
-                  .withSignature("replaceFirst(java.lang.String,java.lang.String)"),
+                  .named("replaceFirst")
+                  .withParameters("java.lang.String", "java.lang.String"),
               instanceMethod()
                   .onDescendantOf("java.lang.String")
-                  .withSignature("split(java.lang.String)"),
+                  .named("split")
+                  .withParameters("java.lang.String"),
               instanceMethod()
                   .onDescendantOf("java.lang.String")
-                  .withSignature("split(java.lang.String,int)"),
+                  .named("split")
+                  .withParameters("java.lang.String", "int"),
               staticMethod().onClass("java.util.regex.Pattern").named("matches"),
               staticMethod().onClass("com.google.common.base.Splitter").named("onPattern")),
           argument(0, BAD_REGEX_LITERAL));

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InvalidTimeZoneID.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InvalidTimeZoneID.java
@@ -50,7 +50,8 @@ public class InvalidTimeZoneID extends BugChecker implements MethodInvocationTre
       Matchers.methodInvocation(
           MethodMatchers.staticMethod()
               .onClass("java.util.TimeZone")
-              .withSignature("getTimeZone(java.lang.String)"));
+              .named("getTimeZone")
+              .withParameters("java.lang.String"));
 
   // https://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html
   // "a custom time zone ID can be specified to produce a TimeZone".

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InvalidZoneId.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InvalidZoneId.java
@@ -47,7 +47,8 @@ public class InvalidZoneId extends BugChecker implements MethodInvocationTreeMat
   private static final Matcher<ExpressionTree> METHOD_MATCHER =
       MethodMatchers.staticMethod()
           .onClass("java.time.ZoneId")
-          .withSignature("of(java.lang.String)");
+          .named("of")
+          .withParameters("java.lang.String");
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, final VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JdkObsolete.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JdkObsolete.java
@@ -144,17 +144,21 @@ public class JdkObsolete extends BugChecker
           // a pre-JDK-8039124 concession
           instanceMethod()
               .onExactClass("java.util.regex.Matcher")
-              .withSignature("appendTail(java.lang.StringBuffer)"),
+              .named("appendTail")
+              .withParameters("java.lang.StringBuffer"),
           instanceMethod()
               .onExactClass("java.util.regex.Matcher")
-              .withSignature("appendReplacement(java.lang.StringBuffer,java.lang.String)"),
+              .named("appendReplacement")
+              .withParameters("java.lang.StringBuffer", "java.lang.String"),
           // TODO(cushon): back this out if https://github.com/google/re2j/pull/44 happens
           instanceMethod()
               .onExactClass("com.google.re2j.Matcher")
-              .withSignature("appendTail(java.lang.StringBuffer)"),
+              .named("appendTail")
+              .withParameters("java.lang.StringBuffer"),
           instanceMethod()
               .onExactClass("com.google.re2j.Matcher")
-              .withSignature("appendReplacement(java.lang.StringBuffer,java.lang.String)"));
+              .named("appendReplacement")
+              .withParameters("java.lang.StringBuffer", "java.lang.String"));
 
   @Override
   public Description matchNewClass(NewClassTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LiteProtoToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LiteProtoToString.java
@@ -40,7 +40,7 @@ import java.util.Optional;
 @BugPattern(
     name = "LiteProtoToString",
     summary =
-        "#toString on lite protos will not generate a useful representation of the proto from"
+        "toString() on lite protos will not generate a useful representation of the proto from"
             + " optimized builds. Consider whether using some subset of fields instead would"
             + " provide useful information.",
     severity = WARNING,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MockitoUsage.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MockitoUsage.java
@@ -53,7 +53,7 @@ public class MockitoUsage extends BugChecker implements MethodInvocationTreeMatc
               .withSignature("<T>verify(T,org.mockito.verification.VerificationMode)"));
 
   private static final Matcher<ExpressionTree> NEVER_METHOD =
-      staticMethod().onClass("org.mockito.Mockito").withSignature("never()");
+      staticMethod().onClass("org.mockito.Mockito").named("never").withParameters();
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RandomModInteger.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RandomModInteger.java
@@ -40,7 +40,10 @@ import com.sun.source.tree.Tree.Kind;
 public class RandomModInteger extends BugChecker implements BinaryTreeMatcher {
 
   private static final Matcher<ExpressionTree> RANDOM_NEXT_INT =
-      Matchers.instanceMethod().onDescendantOf("java.util.Random").withSignature("nextInt()");
+      Matchers.instanceMethod()
+          .onDescendantOf("java.util.Random")
+          .named("nextInt")
+          .withParameters();
 
   @Override
   public Description matchBinary(BinaryTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StringSplitter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StringSplitter.java
@@ -60,7 +60,10 @@ import java.util.Optional;
 public class StringSplitter extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> MATCHER =
-      instanceMethod().onExactClass("java.lang.String").withSignature("split(java.lang.String)");
+      instanceMethod()
+          .onExactClass("java.lang.String")
+          .named("split")
+          .withParameters("java.lang.String");
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThreeLetterTimeZoneID.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThreeLetterTimeZoneID.java
@@ -50,12 +50,14 @@ public class ThreeLetterTimeZoneID extends BugChecker implements MethodInvocatio
   private static final Matcher<ExpressionTree> METHOD_MATCHER =
       MethodMatchers.staticMethod()
           .onClass("java.util.TimeZone")
-          .withSignature("getTimeZone(java.lang.String)");
+          .named("getTimeZone")
+          .withParameters("java.lang.String");
 
   private static final Matcher<ExpressionTree> JODATIME_METHOD_MATCHER =
       MethodMatchers.staticMethod()
           .onClass("org.joda.time.DateTimeZone")
-          .withSignature("forTimeZone(java.util.TimeZone)");
+          .named("forTimeZone")
+          .withParameters("java.util.TimeZone");
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, final VisitorState state) {

--- a/docgen/src/main/java/com/google/errorprone/BugPatternFileGenerator.java
+++ b/docgen/src/main/java/com/google/errorprone/BugPatternFileGenerator.java
@@ -50,6 +50,8 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.representer.Representer;
 
 /**
  * Reads each line of the bugpatterns.txt tab-delimited data file, and generates a GitHub Jekyll
@@ -196,7 +198,7 @@ class BugPatternFileGenerator implements LineProcessor<List<BugPatternInstance>>
                 .build();
         DumperOptions options = new DumperOptions();
         options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-        Yaml yaml = new Yaml(options);
+        Yaml yaml = new Yaml(new SafeConstructor(), new Representer(), options);
         Writer yamlWriter = new StringWriter();
         yamlWriter.write("---\n");
         yaml.dump(frontmatterData, yamlWriter);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Refactor error-prone matchers to avoid discouraged usage modes of .withSignature

Specifically, we apply the following transformations:

.withSignature("toString")
=>
.named("toString")

.withSignature("valueOf(java.lang.String,int)")
=>
.named("valueOf").withParameters("java.lang.String", "int")

84015294a8b0877c46c63215cf153b3a153ddb33

-------

<p> Remove leading # from LiteProtoToString summary

Some other bug pattern descriptions have # in them, but none of them in a
leading position, so this is the only one showing the issue.

d45803aeed2aa295fe2f128e0ade0aa3b83b6624

-------

<p> Fix AutoValueImmutableFields warning in ErrorProneOptions - Make PatchingOptions immutable

RELNOTES : Fix AutoValueImmutableFields warning in ErrorProneOptions - Make PatchingOptions immutable

6199bea82f7a76db6a34debaf0b10240effdea3d

-------

<p> Update Error Prone's tests to use 4 forks and reuse forks to speed up execution on machines with more CPU's.

RELNOTES: n/a

GOOGLE: And use the shared maven_test script to avoid duplicate code

bc90587bd3ecc1e8cdf1b82f066a963e3945bdf5

-------

<p> FieldCanBeFinal: pass a VisitorState around to avoid using a deprecated VisitorState factory.

(And drive-by tighten visibilities.)

3bd0113deea6fd10824392492889767cbf6adbab

-------

<p> Switch to SnakeYAMLs SafeConstructor to avoid risk of object deserialization.

This is a non functional change for code that dumps YAML and for parsing that doesn't use the insecure object serialization feature.

f1582fe14f91b60c75b0bf131c22f9f9b5519daf