### PR TITLE
Clear diagnostics after testing in CompilationTestHelper

### DIFF
--- a/test_helpers/src/main/java/com/google/errorprone/CompilationTestHelper.java
+++ b/test_helpers/src/main/java/com/google/errorprone/CompilationTestHelper.java
@@ -326,6 +326,8 @@ public class CompilationTestHelper {
                         outputStream))
                 .that(result)
                 .isEqualTo(expected));
+
+    diagnosticHelper.clearDiagnostics();
   }
 
   private Result compile() {

--- a/test_helpers/src/test/java/com/google/errorprone/CompilationTestHelperTest.java
+++ b/test_helpers/src/test/java/com/google/errorprone/CompilationTestHelperTest.java
@@ -377,6 +377,35 @@ public class CompilationTestHelperTest {
     assertThat(expected).hasMessageThat().contains("No expected error message with key [X]");
   }
 
+  @Test
+  public void doTestClearsDiagnostics() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "public class Test {",
+            "  public boolean doIt() {",
+            "    // BUG: Diagnostic contains: Method may return normally",
+            "    return true;",
+            "  }",
+            "}")
+        .doTest();
+
+    AssertionError expected =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                compilationHelper
+                    .addSourceLines(
+                      "Test.java",
+                      "public class Test {",
+                      "  public void doIt() {",
+                      "    // BUG: Diagnostic contains: Method may return normally",
+                      "  }",
+                      "}")
+                    .doTest());
+    assertThat(expected.getMessage()).contains("Did not see an error on line 4");
+  }
+
   @BugPattern(
       name = "ReturnTreeChecker",
       summary = "Method may return normally.",


### PR DESCRIPTION
When a `CompilationTestHelper` is reused after a positive test case, it is possible for a false positive test case to pass. This is because we do not clear the `DiagnosticTestHelper` after calling `doTest`. So a subsequent false positive test will pass if the diagnostics is that same as the previous positive test case.