### PR TITLE
Moe Sync

### DIFF
--- a/annotations/src/main/java/com/google/errorprone/annotations/MustBeClosed.java
+++ b/annotations/src/main/java/com/google/errorprone/annotations/MustBeClosed.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  * be closed.
  *
  * <p>Note that Android SDK versions prior to 19 do not support try-with-resources, so the
- * annotation should be avoided on APIs that may be used on Android.
+ * annotation should be avoided on APIs that may be used on Android, unless desugaring is used.
  */
 @Documented
 @Target({CONSTRUCTOR, METHOD})

--- a/check_api/pom.xml
+++ b/check_api/pom.xml
@@ -15,7 +15,9 @@
   limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <!-- Added this because the JSR 305 dependency wouldn't download from the
@@ -138,6 +140,12 @@
       <groupId>com.github.kevinstern</groupId>
       <artifactId>software-and-algorithms</artifactId>
       <version>1.0</version>
+    </dependency>
+    <dependency>
+      <!-- Apache 2.0 -->
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>2.2.6</version>
     </dependency>
   </dependencies>
 

--- a/check_api/src/main/java/com/google/errorprone/VisitorState.java
+++ b/check_api/src/main/java/com/google/errorprone/VisitorState.java
@@ -220,7 +220,23 @@ public class VisitorState {
         sharedState);
   }
 
+  @Deprecated // TODO(amalloy): Delete after next error-prone release.
   public VisitorState withPathAndSuppression(TreePath path, SuppressedState suppressedState) {
+    return new VisitorState(
+        context,
+        descriptionListener,
+        severityMap,
+        errorProneOptions,
+        statisticsCollector,
+        path,
+        suppressedState,
+        sharedState);
+  }
+
+  public VisitorState withSuppression(SuppressedState suppressedState) {
+    if (suppressedState == this.suppressedState) {
+      return this;
+    }
     return new VisitorState(
         context,
         descriptionListener,

--- a/check_api/src/main/java/com/google/errorprone/VisitorState.java
+++ b/check_api/src/main/java/com/google/errorprone/VisitorState.java
@@ -356,8 +356,16 @@ public class VisitorState {
   // TODO(cushon): deal with binary compat issues and return ClassSymbol
   @Nullable
   public Symbol getSymbolFromString(String symStr) {
-    symStr = inferBinaryName(symStr);
-    Name name = getName(symStr);
+    return getSymbolFromName(getName(inferBinaryName(symStr)));
+  }
+
+  /**
+   * Look up the class symbol for a given Name.
+   *
+   * @param name the name to look up, which must be in binary form (i.e. with $ for nested classes).
+   */
+  @Nullable
+  public Symbol getSymbolFromName(Name name) {
     boolean modular = sharedState.modules.getDefaultModule() != getSymtab().noModule;
     if (!modular) {
       return getSymbolFromString(getSymtab().noModule, name);

--- a/check_api/src/main/java/com/google/errorprone/apply/SourceFile.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/SourceFile.java
@@ -59,7 +59,7 @@ public class SourceFile {
     try {
       return CharSource.wrap(sourceBuilder).readLines();
     } catch (IOException e) {
-      throw new AssertionError("IOException not possible, as the string is in-memory");
+      throw new AssertionError("IOException not possible, as the string is in-memory", e);
     }
   }
 
@@ -114,7 +114,7 @@ public class SourceFile {
       }
       return lines;
     } catch (IOException e) {
-      throw new AssertionError("Wrapped StringReader should not produce I/O exceptions");
+      throw new AssertionError("Wrapped StringReader should not produce I/O exceptions", e);
     }
   }
 

--- a/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
@@ -1280,10 +1280,9 @@ public class Matchers {
   }
 
   private static final Matcher<ExpressionTree> ASSERT_EQUALS =
-      anyOf(
-          staticMethod().onClass("org.junit.Assert").named("assertEquals"),
-          staticMethod().onClass("junit.framework.Assert").named("assertEquals"),
-          staticMethod().onClass("junit.framework.TestCase").named("assertEquals"));
+      staticMethod()
+          .onClassAny("org.junit.Assert", "junit.framework.Assert", "junit.framework.TestCase")
+          .named("assertEquals");
 
   /**
    * Matches calls to the method {@code org.junit.Assert#assertEquals} and corresponding methods in
@@ -1294,10 +1293,9 @@ public class Matchers {
   }
 
   private static final Matcher<ExpressionTree> ASSERT_NOT_EQUALS =
-      anyOf(
-          staticMethod().onClass("org.junit.Assert").named("assertNotEquals"),
-          staticMethod().onClass("junit.framework.Assert").named("assertNotEquals"),
-          staticMethod().onClass("junit.framework.TestCase").named("assertNotEquals"));
+      staticMethod()
+          .onClassAny("org.junit.Assert", "junit.framework.Assert", "junit.framework.TestCase")
+          .named("assertNotEquals");
 
   /**
    * Matches calls to the method {@code org.junit.Assert#assertNotEquals} and corresponding methods

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/BaseMethodMatcher.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/BaseMethodMatcher.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.matchers.method;
 
-import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -26,10 +25,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 interface BaseMethodMatcher {
   @Nullable
-  MatchState match(ExpressionTree tree, VisitorState state);
+  MatchState match(ExpressionTree tree);
 
   BaseMethodMatcher METHOD =
-      (tree, state) -> {
+      tree -> {
         Symbol sym = ASTHelpers.getSymbol(tree);
         if (!(sym instanceof MethodSymbol)) {
           return null;
@@ -45,7 +44,7 @@ interface BaseMethodMatcher {
       };
 
   BaseMethodMatcher CONSTRUCTOR =
-      (tree, state) -> {
+      tree -> {
         switch (tree.getKind()) {
           case NEW_CLASS:
           case METHOD_INVOCATION:

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/MethodMatcherImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/MethodMatcherImpl.java
@@ -193,7 +193,7 @@ final class MethodMatcherImpl
 
   @Override
   public boolean matches(ExpressionTree tree, VisitorState state) {
-    MatchState method = baseMatcher.match(tree, state);
+    MatchState method = baseMatcher.match(tree);
     if (method == null) {
       return false;
     }

--- a/check_api/src/main/java/com/google/errorprone/matchers/method/MethodMatcherImpl.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/MethodMatcherImpl.java
@@ -351,7 +351,7 @@ final class MethodMatcherImpl
 
   @Override
   public MethodNameMatcher namedAnyOf(String... names) {
-    return namedAnyOf(ImmutableList.copyOf(names));
+    return namedAnyOf(ImmutableSet.copyOf(names));
   }
 
   @Override

--- a/check_api/src/main/java/com/google/errorprone/predicates/TypePredicates.java
+++ b/check_api/src/main/java/com/google/errorprone/predicates/TypePredicates.java
@@ -16,8 +16,8 @@
 
 package com.google.errorprone.predicates;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
+import static com.google.errorprone.suppliers.Suppliers.fromStrings;
+
 import com.google.errorprone.predicates.type.Any;
 import com.google.errorprone.predicates.type.Array;
 import com.google.errorprone.predicates.type.DescendantOf;
@@ -51,17 +51,9 @@ public final class TypePredicates {
     return new Exact(type);
   }
 
-  private static final Function<String, Supplier<Type>> GET_TYPE =
-      new Function<String, Supplier<Type>>() {
-        @Override
-        public Supplier<Type> apply(String input) {
-          return Suppliers.typeFromString(input);
-        }
-      };
-
   /** Match types that are exactly equal to any of the given types. */
   public static TypePredicate isExactTypeAny(Iterable<String> types) {
-    return new ExactAny(Iterables.transform(types, GET_TYPE));
+    return new ExactAny(fromStrings(types));
   }
 
   /** Match sub-types of the given type. */
@@ -71,7 +63,7 @@ public final class TypePredicates {
 
   /** Match types that are a sub-type of one of the given types. */
   public static TypePredicate isDescendantOfAny(Iterable<String> types) {
-    return new DescendantOfAny(Iterables.transform(types, GET_TYPE));
+    return new DescendantOfAny(fromStrings(types));
   }
 
   /** Match sub-types of the given type. */

--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -693,8 +693,12 @@ public class ASTHelpers {
   }
 
   private static boolean hasAttribute(Symbol sym, Name annotationName) {
-    return sym.getRawAttributes().stream()
-        .anyMatch(a -> a.type.tsym.getQualifiedName().equals(annotationName));
+    for (Compound a : sym.getRawAttributes()) {
+      if (a.type.tsym.getQualifiedName().equals(annotationName)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AbstractToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AbstractToString.java
@@ -87,7 +87,7 @@ public abstract class AbstractToString extends BugChecker
       Tree parent, ExpressionTree expression, VisitorState state);
 
   private static final Matcher<ExpressionTree> TO_STRING =
-      instanceMethod().anyClass().withSignature("toString()");
+      instanceMethod().anyClass().named("toString").withParameters();
 
   private static final Matcher<ExpressionTree> FLOGGER_LOG =
       instanceMethod().onDescendantOf("com.google.common.flogger.LoggingApi").named("log");
@@ -98,7 +98,10 @@ public abstract class AbstractToString extends BugChecker
           staticMethod().onClass("java.lang.String").named("format"));
 
   private static final Matcher<ExpressionTree> VALUE_OF =
-      staticMethod().onClass("java.lang.String").withSignature("valueOf(java.lang.Object)");
+      staticMethod()
+          .onClass("java.lang.String")
+          .named("valueOf")
+          .withParameters("java.lang.Object");
 
   private static final Matcher<ExpressionTree> PRINT_STRING =
       anyOf(

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ByteBufferBackingArray.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ByteBufferBackingArray.java
@@ -63,9 +63,7 @@ public class ByteBufferBackingArray extends BugChecker implements MethodInvocati
       anyOf(instanceMethod().onDescendantOf(ByteBuffer.class.getName()).named("arrayOffset"));
 
   private static final Matcher<ExpressionTree> BYTE_BUFFER_ALLOWED_INITIALIZERS_MATCHER =
-      anyOf(
-          staticMethod().onClass(ByteBuffer.class.getName()).named("allocate"),
-          staticMethod().onClass(ByteBuffer.class.getName()).named("wrap"));
+      staticMethod().onClass(ByteBuffer.class.getName()).namedAnyOf("allocate", "wrap");
 
   private static final Matcher<ExpressionTree> BYTE_BUFFER_MATCHER = isSameType(ByteBuffer.class);
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InconsistentHashCode.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InconsistentHashCode.java
@@ -77,13 +77,11 @@ public final class InconsistentHashCode extends BugChecker implements ClassTreeM
 
   /** Non-static methods that we might expect to see in #hashCode, and allow. */
   private static final Matcher<ExpressionTree> HASH_CODE_METHODS =
-      instanceMethod().onDescendantOf("java.lang.Object").named("hashCode").withParameters();
+      instanceMethod().anyClass().named("hashCode").withParameters();
 
   /** Non-static methods that we might expect to see in #equals, and allow. */
   private static final Matcher<ExpressionTree> EQUALS_METHODS =
-      anyOf(
-          instanceMethod().onDescendantOf("java.lang.Object").named("getClass"),
-          instanceEqualsInvocation());
+      anyOf(instanceMethod().anyClass().named("getClass"), instanceEqualsInvocation());
 
   @Override
   public Description matchClass(ClassTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InvalidPatternSyntax.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InvalidPatternSyntax.java
@@ -80,25 +80,17 @@ public class InvalidPatternSyntax extends BugChecker implements MethodInvocation
       allOf(
           anyOf(
               instanceMethod()
-                  .onDescendantOf("java.lang.String")
-                  .named("matches")
+                  .onExactClass("java.lang.String")
+                  .namedAnyOf("matches", "split")
                   .withParameters("java.lang.String"),
               instanceMethod()
-                  .onDescendantOf("java.lang.String")
-                  .named("replaceAll")
-                  .withParameters("java.lang.String", "java.lang.String"),
-              instanceMethod()
-                  .onDescendantOf("java.lang.String")
-                  .named("replaceFirst")
-                  .withParameters("java.lang.String", "java.lang.String"),
-              instanceMethod()
-                  .onDescendantOf("java.lang.String")
-                  .named("split")
-                  .withParameters("java.lang.String"),
-              instanceMethod()
-                  .onDescendantOf("java.lang.String")
+                  .onExactClass("java.lang.String")
                   .named("split")
                   .withParameters("java.lang.String", "int"),
+              instanceMethod()
+                  .onExactClass("java.lang.String")
+                  .namedAnyOf("replaceFirst", "replaceAll")
+                  .withParameters("java.lang.String", "java.lang.String"),
               staticMethod().onClass("java.util.regex.Pattern").named("matches"),
               staticMethod().onClass("com.google.common.base.Splitter").named("onPattern")),
           argument(0, BAD_REGEX_LITERAL));

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InvalidTimeZoneID.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InvalidTimeZoneID.java
@@ -26,7 +26,6 @@ import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.matchers.method.MethodMatchers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
@@ -47,11 +46,10 @@ public class InvalidTimeZoneID extends BugChecker implements MethodInvocationTre
       ImmutableSet.copyOf(TimeZone.getAvailableIDs());
 
   private static final Matcher<ExpressionTree> METHOD_MATCHER =
-      Matchers.methodInvocation(
-          MethodMatchers.staticMethod()
-              .onClass("java.util.TimeZone")
-              .named("getTimeZone")
-              .withParameters("java.lang.String"));
+      MethodMatchers.staticMethod()
+          .onClass("java.util.TimeZone")
+          .named("getTimeZone")
+          .withParameters("java.lang.String");
 
   // https://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html
   // "a custom time zone ID can be specified to produce a TimeZone".

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MethodCanBeStatic.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MethodCanBeStatic.java
@@ -229,7 +229,9 @@ public class MethodCanBeStatic extends BugChecker implements CompilationUnitTree
     if (sym == null) {
       return true;
     }
-    if (sym.isConstructor() || sym.getModifiers().contains(Modifier.NATIVE)) {
+    if (sym.isConstructor()
+        || sym.getModifiers().contains(Modifier.NATIVE)
+        || sym.getModifiers().contains(Modifier.SYNCHRONIZED)) {
       return true;
     }
     if (!sym.isPrivate()) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingFail.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingFail.java
@@ -161,7 +161,7 @@ public class MissingFail extends BugChecker implements TryTreeMatcher {
       Matchers.allOf(
           ASSERT_CALL, Matchers.not(Matchers.anyOf(ASSERT_FALSE_FALSE, ASSERT_TRUE_TRUE)));
   private static final Matcher<ExpressionTree> VERIFY_CALL =
-      methodInvocation(staticMethod().onClass("org.mockito.Mockito").named("verify"));
+      staticMethod().onClass("org.mockito.Mockito").named("verify");
   private static final MultiMatcher<TryTree, Tree> ASSERT_LAST_CALL_IN_TRY =
       new ChildOfTryMatcher(
           MatchType.LAST,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OrphanedFormatString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OrphanedFormatString.java
@@ -60,21 +60,18 @@ public class OrphanedFormatString extends BugChecker implements LiteralTreeMatch
               constructor().forClass("java.lang.StringBuilder"),
               allOf(
                   constructor()
-                      .forClass(TypePredicates.isDescendantOf((s) -> s.getSymtab().throwableType)),
+                      .forClass(TypePredicates.isDescendantOf(s -> s.getSymtab().throwableType)),
                   (tree, state) -> {
                     Symbol sym = ASTHelpers.getSymbol(tree);
                     return sym instanceof MethodSymbol && !((MethodSymbol) sym).isVarArgs();
                   }),
-              instanceMethod().onDescendantOf("java.io.PrintStream").namedAnyOf("print", "println"),
-              instanceMethod().onDescendantOf("java.io.PrintWriter").namedAnyOf("print", "println"),
+              instanceMethod()
+                  .onDescendantOfAny("java.io.PrintStream", "java.io.PrintWriter")
+                  .namedAnyOf("print", "println"),
               instanceMethod()
                   .onExactClass("java.lang.StringBuilder")
                   .named("append")
-                  .withParameters("java.lang.CharSequence", "int", "int"),
-              instanceMethod()
-                  .onExactClass("java.lang.StringBuilder")
-                  .named("append")
-                  .withParameters("char[]", "int", "int")));
+                  .withParameters("java.lang.CharSequence", "int", "int")));
 
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TreeToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TreeToString.java
@@ -46,8 +46,9 @@ import java.util.Optional;
 @BugPattern(
     name = "TreeToString",
     summary =
-        "Tree#toString shouldn't be used for Trees deriving from the code being "
-            + "compiled, as it discards whitespace and comments.",
+        "Tree#toString shouldn't be used for Trees deriving from the code being compiled, as it"
+            + " discards whitespace and comments. If this code is within an ErrorProne check,"
+            + " consider VisitorState#getSourceForNode.",
     severity = WARNING,
     providesFix = NO_FIX)
 public class TreeToString extends AbstractToString {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryMethodInvocationMatcher.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryMethodInvocationMatcher.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.Matchers.staticMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers.MethodMatcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.code.Type;
+import java.util.List;
+
+/**
+ * {@link Matchers#methodInvocation(Matcher)} is not exactly deprecated, but it is legacy, and in
+ * particular is not needed when the argument is a MethodMatcher, since MethodMatcher already does
+ * the unwrapping that methodInvocation does.
+ *
+ * @author amalloy@google.com (Alan Malloy)
+ */
+@BugPattern(
+    name = "UnnecessaryMethodInvocationMatcher",
+    summary = "It is not necessary to wrap a MethodMatcher with methodInvocation().",
+    providesFix = REQUIRES_HUMAN_ATTENTION,
+    severity = WARNING)
+public class UnnecessaryMethodInvocationMatcher extends BugChecker
+    implements MethodInvocationTreeMatcher {
+
+  private static final String MATCHERS = Matchers.class.getCanonicalName();
+  private static final Matcher<ExpressionTree> METHOD_INVOCATION =
+      staticMethod().onClass(MATCHERS).named("methodInvocation");
+  private static final Matcher<ExpressionTree> COMBINATOR =
+      staticMethod().onClass(MATCHERS).namedAnyOf("allOf", "anyOf", "not");
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (!METHOD_INVOCATION.matches(tree, state)) {
+      return NO_MATCH;
+    }
+    List<? extends ExpressionTree> arguments = tree.getArguments();
+    if (arguments.size() != 1) {
+      // We can only unwrap if they haven't specified additional behavior.
+      return NO_MATCH;
+    }
+    Type methodMatcherType = state.getTypeFromString(MethodMatcher.class.getCanonicalName());
+    ExpressionTree argument = arguments.get(0);
+    if (!containsOnlyMethodMatchers(argument, methodMatcherType, state)) {
+      return NO_MATCH;
+    }
+    return describeMatch(tree, SuggestedFix.replace(tree, state.getSourceForNode(argument)));
+  }
+
+  private static boolean containsOnlyMethodMatchers(
+      ExpressionTree expressionTree, Type methodMatcherType, VisitorState state) {
+    if (ASTHelpers.isSubtype(ASTHelpers.getType(expressionTree), methodMatcherType, state)) {
+      return true;
+    }
+    if (!COMBINATOR.matches(expressionTree, state)) {
+      return false;
+    }
+    for (ExpressionTree argument : ((MethodInvocationTree) expressionTree).getArguments()) {
+      if (!containsOnlyMethodMatchers(argument, methodMatcherType, state)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/ArgumentSelectionDefectChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/ArgumentSelectionDefectChecker.java
@@ -60,7 +60,7 @@ import java.util.function.Function;
 public class ArgumentSelectionDefectChecker extends BugChecker
     implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
 
-  private final ArgumentChangeFinder argumentchangeFinder;
+  private final ArgumentChangeFinder argumentChangeFinder;
 
   public ArgumentSelectionDefectChecker() {
     this(
@@ -76,7 +76,7 @@ public class ArgumentSelectionDefectChecker extends BugChecker
 
   @VisibleForTesting
   ArgumentSelectionDefectChecker(ArgumentChangeFinder argumentChangeFinder) {
-    this.argumentchangeFinder = argumentChangeFinder;
+    this.argumentChangeFinder = argumentChangeFinder;
   }
 
   @Override
@@ -112,7 +112,7 @@ public class ArgumentSelectionDefectChecker extends BugChecker
 
   private Description visitNewClassOrMethodInvocation(InvocationInfo invocationInfo) {
 
-    Changes changes = argumentchangeFinder.findChanges(invocationInfo);
+    Changes changes = argumentChangeFinder.findChanges(invocationInfo);
 
     if (changes.isEmpty()) {
       return Description.NO_MATCH;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatString.java
@@ -42,9 +42,10 @@ public class FormatString extends BugChecker implements MethodInvocationTreeMatc
   // TODO(cushon): add support for additional printf methods, maybe with an annotation
   private static final Matcher<ExpressionTree> FORMAT_METHOD =
       anyOf(
-          instanceMethod().onDescendantOf("java.io.PrintStream").namedAnyOf("format", "printf"),
-          instanceMethod().onDescendantOf("java.io.PrintWriter").namedAnyOf("format", "printf"),
-          instanceMethod().onDescendantOf("java.util.Formatter").named("format"),
+          instanceMethod()
+              .onDescendantOfAny(
+                  "java.io.PrintStream", "java.io.PrintWriter", "java.util.Formatter")
+              .namedAnyOf("format", "printf"),
           staticMethod().onClass("java.lang.String").named("format"),
           staticMethod()
               .onClass("java.io.Console")

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -289,6 +289,7 @@ import com.google.errorprone.bugpatterns.UnnecessaryAnonymousClass;
 import com.google.errorprone.bugpatterns.UnnecessaryBoxedVariable;
 import com.google.errorprone.bugpatterns.UnnecessaryDefaultInEnumSwitch;
 import com.google.errorprone.bugpatterns.UnnecessaryLambda;
+import com.google.errorprone.bugpatterns.UnnecessaryMethodInvocationMatcher;
 import com.google.errorprone.bugpatterns.UnnecessaryParentheses;
 import com.google.errorprone.bugpatterns.UnnecessarySetDefault;
 import com.google.errorprone.bugpatterns.UnnecessaryStaticImport;
@@ -747,6 +748,7 @@ public class BuiltInCheckerSuppliers {
           UndefinedEquals.class,
           UnnecessaryAnonymousClass.class,
           UnnecessaryLambda.class,
+          UnnecessaryMethodInvocationMatcher.class,
           UnnecessaryParentheses.class,
           UnsafeFinalization.class,
           UnsafeReflectiveConstructionCast.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MethodCanBeStaticTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MethodCanBeStaticTest.java
@@ -215,6 +215,19 @@ public class MethodCanBeStaticTest {
   }
 
   @Test
+  public void negativeSynchronized() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  private synchronized String frobnicate() {",
+            "    return \"\";",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void negativeSuppressed() {
     testHelper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryMethodInvocationMatcherTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryMethodInvocationMatcherTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** @author amalloy@google.com (Alan Malloy) */
+@RunWith(JUnit4.class)
+public class UnnecessaryMethodInvocationMatcherTest {
+  private final BugCheckerRefactoringTestHelper refactoringTestHelper =
+      BugCheckerRefactoringTestHelper.newInstance(
+          new UnnecessaryMethodInvocationMatcher(), getClass());
+
+  @Test
+  public void replace() {
+    refactoringTestHelper
+        .addInputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.*;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.ExpressionTree;",
+            "public class Test {",
+            "  private static final Matcher<ExpressionTree> TO_STRING = ",
+            "    methodInvocation(",
+            "      instanceMethod()",
+            "        .anyClass()",
+            "        .named(\"toString\"));",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.*;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.ExpressionTree;",
+            "public class Test {",
+            "  private static final Matcher<ExpressionTree> TO_STRING = ",
+            "    instanceMethod()",
+            "      .anyClass()",
+            "      .named(\"toString\");",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void descendIntoCombinators() {
+    refactoringTestHelper
+        .addInputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.*;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.ExpressionTree;",
+            "public class Test {",
+            "  private static final Matcher<ExpressionTree> STRINGIFY = ",
+            "    methodInvocation(",
+            "      anyOf(",
+            "        instanceMethod()",
+            "          .anyClass()",
+            "          .named(\"toString\"),",
+            "        allOf(",
+            "          staticMethod())));",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.*;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.ExpressionTree;",
+            "public class Test {",
+            "  private static final Matcher<ExpressionTree> STRINGIFY = ",
+            "    anyOf(",
+            "      instanceMethod()",
+            "        .anyClass()",
+            "        .named(\"toString\"),",
+            "      allOf(",
+            "        staticMethod()));",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void onlyChangeMethodMatchers() {
+    refactoringTestHelper
+        .addInputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.*;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.ExpressionTree;",
+            "public class Test {",
+            "  private static final Matcher<ExpressionTree> STRINGIFY = ",
+            "    methodInvocation(",
+            "      anyOf(",
+            "        instanceMethod()",
+            "          .anyClass()",
+            "          .named(\"toString\"),",
+            "        allOf(",
+            "          hasAnnotation(\"java.lang.SuppressWarnings\"))));",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
+
+  @Test
+  public void permitWithArguments() {
+    refactoringTestHelper
+        .addInputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.ALL;",
+            "import static com.google.errorprone.matchers.Matchers.*;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.ExpressionTree;",
+            "public class Test {",
+            "  private static final Matcher<ExpressionTree> TO_STRING = ",
+            "    methodInvocation(",
+            "      instanceMethod()",
+            "        .anyClass()",
+            "        .named(\"toString\"),",
+            "      ALL,",
+            "      isVariable());",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryMethodInvocationMatcherTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryMethodInvocationMatcherTest.java
@@ -135,4 +135,37 @@ public class UnnecessaryMethodInvocationMatcherTest {
         .expectUnchanged()
         .doTest();
   }
+
+  @Test
+  public void expressionStatement() {
+    refactoringTestHelper
+        .addInputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.*;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.StatementTree;",
+            "public class Test {",
+            "  private static final Matcher<StatementTree> TARGETED =",
+            "      expressionStatement(",
+            "          methodInvocation(",
+            "              instanceMethod()",
+            "                  .onDescendantOfAny(",
+            "                      \"java.lang.Class\",",
+            "                      \"java.lang.String\")));",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import static com.google.errorprone.matchers.Matchers.*;",
+            "import com.google.errorprone.matchers.Matcher;",
+            "import com.sun.source.tree.StatementTree;",
+            "public class Test {",
+            "  private static final Matcher<StatementTree> TARGETED =",
+            "      expressionStatement(",
+            "          instanceMethod()",
+            "              .onDescendantOfAny(",
+            "                  \"java.lang.Class\",",
+            "                  \"java.lang.String\"));",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
@@ -350,4 +350,8 @@ public class PreferDurationOverloadTest {
   @Test
   public void ignoredApisAreExcluded() {
   }
+
+  @Test
+  public void b138221392() {
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
@@ -148,7 +148,7 @@ public class PreferDurationOverloadTest {
   }
 
   @Test
-  public void callingJodaDurationMethodWithDurationOverload_privateMethod_jodaMillis() {
+  public void callingJodaDurationMethodWithDurationOverload_privateMethod_jodaDurationMillis() {
     helper
         .addSourceLines(
             "TestClass.java",
@@ -161,6 +161,44 @@ public class PreferDurationOverloadTest {
             "  public void foo() {",
             "    // BUG: Diagnostic contains: bar(Duration.ofMillis(42));",
             "    bar(org.joda.time.Duration.millis(42));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void callingJodaDurationMethodWithDurationOverload_privateMethod_jodaDurationCtor() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Duration;",
+            "public class TestClass {",
+            "  private void bar(org.joda.time.Duration d) {",
+            "  }",
+            "  private void bar(Duration d) {",
+            "  }",
+            "  public void foo() {",
+            "    // BUG: Diagnostic contains: bar(Duration.ofMillis(42));",
+            "    bar(new org.joda.time.Duration(42));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void callingJodaInstantMethodWithInstantOverload_privateMethod_jodaInstantCtor() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.Instant;",
+            "public class TestClass {",
+            "  private void bar(org.joda.time.Instant i) {",
+            "  }",
+            "  private void bar(Instant i) {",
+            "  }",
+            "  public void foo() {",
+            "    // BUG: Diagnostic contains: bar(Instant.ofEpochMilli(42));",
+            "    bar(new org.joda.time.Instant(42));",
             "  }",
             "}")
         .doTest();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
@@ -253,6 +253,24 @@ public class PreferDurationOverloadTest {
   }
 
   @Test
+  public void callingNumericPrimitiveMethodWithInstantOverload() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "public class TestClass {",
+            "  private void bar(java.time.Instant i) {",
+            "  }",
+            "  private void bar(long timestamp) {",
+            "  }",
+            "  public void foo() {",
+            "    // BUG: Diagnostic contains: call bar(Instant) instead",
+            "    bar(42);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void ignoredApisAreExcluded() {
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferDurationOverloadTest.java
@@ -60,6 +60,45 @@ public class PreferDurationOverloadTest {
   }
 
   @Test
+  public void callingLongTimeUnitMethodWithDurationOverload_durationDecompose() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import com.google.common.cache.CacheBuilder;",
+            "import java.time.Duration;",
+            "import java.util.concurrent.TimeUnit;",
+            "public class TestClass {",
+            "  public CacheBuilder foo(CacheBuilder builder) {",
+            "    Duration duration = Duration.ofMillis(12345);",
+            "    // BUG: Diagnostic contains: builder.expireAfterAccess(duration);",
+            "    return builder.expireAfterAccess(duration.getSeconds(), TimeUnit.SECONDS);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void callingLongTimeUnitMethodWithDurationOverload_durationHashCode() {
+    // this is admittedly a _very_ weird case, but we should _not_ suggest re-writing to:
+    // builder.expireAfterAccess(duration)
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import com.google.common.cache.CacheBuilder;",
+            "import java.time.Duration;",
+            "import java.util.concurrent.TimeUnit;",
+            "public class TestClass {",
+            "  public CacheBuilder foo(CacheBuilder builder) {",
+            "    Duration duration = Duration.ofMillis(12345);",
+            "    // BUG: Diagnostic contains: return"
+                + " builder.expireAfterAccess(Duration.ofSeconds(duration.hashCode()));",
+            "    return builder.expireAfterAccess(duration.hashCode(), TimeUnit.SECONDS);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void callingLongTimeUnitMethodWithDurationOverload_intParam() {
     helper
         .addSourceLines(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update javadoc to cover desugaring

45553cf498f97bfc7dc1e169caab0c48f22920b9

-------

<p> New checker to discourage extraneous uses of methodInvocation()

Many uses are leftovers from a time before MethodMatcher existed, and can simply
be removed.

b4b8896d88a5c9cf0a13124ac7b08d429befafa1

-------

<p> Optimize InvalidPatternSyntax checker

Combining common cases and removing onDescendantOf doubles the speed of
this checker, and shaves 0.2% off of total javac time.

b554a1e6bb384dcff8aa5374f8730acc90d74cf2

-------

<p> Fix InconsistentCapitalization errorprone warning

b30aba8f47579222239b141b3e097c3f37740e25

-------

<p> Add a hint to use VisitorState#getSourceForNode in TreeToString.

This is already used in a SuggestedFix if possible, but mentioning it in the description seems potentially useful.

Fixes external #1308

398d837a0e12eb95cc94eae22e60bf2ddccecdbd

-------

<p> Make FieldCanBeLocal respect annotations.

That is: copy them, and don't propose making fields local if they have annotations that can't be used on local variables.

113a19010da65204a39cae346f13e37b06bd3c39

-------

<p> Add preliminary support for preferring java.time.Instant-based APIs.

553b8f4040db48d24c8d779e2009f5bde93fee6b

-------

<p> Clean up various misguided method matchers

Mostly, unnecessary uses of onDescendantOf

8aefe67ef823e67c8039734b8034152d40c4c8ae

-------

<p> Convert from stream to a for loop in hasAttribute

It's called more often than you might guess, and it's so short that
85% of its time was spent on stream overhead.

01515b0fd73063c972a4e004a07a5e96b15d7cf7

-------

<p> Allocate fewer VisitorState objects

Most of these can be shared among matchers for the AST node they're
processing - the only thing that (rarely) differs is the
SuppressionState.  Adding a check to decide whether we need to
allocate a new object reduces time spent allocating (including the new
time spent deciding) by 75%, from around 1.2% of javac time to 0.35% of
javac time.

3e5af8e2ea7138e883543893fad17ca75f26390f

-------

<p> Fix WithSignatureDiscouraged errorprone warnings

df450d17dbaa7f2a034f03160014c696da984775

-------

<p> Remove extraneous uses of methodInvocation()

Many uses are leftovers from a time before MethodMatcher existed, and can simply
be removed.

265cab5030268e51fb9350778fe1c3e5e4167029

-------

<p> Add a warning if calling a org.joda.time.Instant-based API when a java.time.Instant-based overload exists.

Also fix a bug where Duration constructor invocations were not being properly re-written.

3d887607fde445c480bdbbc6340251b8014f927a

-------

<p> Copy straight to set, instead of going through list

9f0ec32f44fe04447ed59e03415c52dab5b87ed3

-------

<p> Convert from String to Supplier<Type> only once per string

Iterables.transform is fairly expensive if you're going to iterate over the
result more than once, because it performs the transformation each time.

The speedup from this is pretty insignificant, but it's not nothing.

73c063a9fb053a1b01068b95e1c779ccdced1db3

-------

<p> Rewrite foo(javaDuration.getSeconds(), SECONDS) -> foo(javaDuration).

9aa023da5a7ae703e9e779741f9fbfcc1e47d30e

-------

<p> Add a test about being embedded inside another expression

f2cb45f76f53ed98448a043f199f5a4765cd22e1

-------

<p> Add a cache around ASTHelpers.isInherited

This is called quite often, and with a very small number of distinct
arguments. I'd like to speed up the actual implementation, or avoid
calling it so often, but for starters introducing a cache speeds up
the method by around 80%, shaving 2% off of the entire javac action.

This adds a new dependency on Caffeine; I considered using a Guava
Cache since we already depend on Guava, but Caffeine's version is 3
times as fast for this use case.

e1acde927336e52bfcde8343979feff7ed84630a

-------

<p> Short circuit inside PreferDurationOverload when scanning for an acceptable overload.

e87656227ea31e64d88a0f324ddfd72a3c221e97

-------

<p> Fix UnusedException warnings in SourceFile.java

899d205470d8ee93b7a9e54f3ee862be93b52a6c

-------

<p> MethodCanBeStatic: don't match synchronized methods, as that's behaviour-changing.

e3b24b9e4b7a89f04de489edea9efc49cbe3b8bb

-------

<p> Fix a bug in PreferDurationOverload that was triggering it for every invocation not-inside a method body.

bf3ec8f9b610914fb906ef138b88e11a22964e23

-------

<p> Remove unused parameter

80eed45ea51159367a68de0abfc66af91db14e17