### PR TITLE
Moe Sync

### DIFF
--- a/check_api/pom.xml
+++ b/check_api/pom.xml
@@ -145,7 +145,7 @@
       <!-- Apache 2.0 -->
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>2.2.6</version>
+      <version>${caffeine.version}</version>
     </dependency>
   </dependencies>
 

--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -321,10 +321,7 @@ public class ASTHelpers {
 
   /** Removes any enclosing parentheses from the tree. */
   public static Tree stripParentheses(Tree tree) {
-    while (tree instanceof ParenthesizedTree) {
-      tree = ((ParenthesizedTree) tree).getExpression();
-    }
-    return tree;
+    return tree instanceof ExpressionTree ? stripParentheses((ExpressionTree) tree) : tree;
   }
 
   /** Given an ExpressionTree, removes any enclosing parentheses. */

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TreeToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TreeToString.java
@@ -47,8 +47,9 @@ import java.util.Optional;
     name = "TreeToString",
     summary =
         "Tree#toString shouldn't be used for Trees deriving from the code being compiled, as it"
-            + " discards whitespace and comments. If this code is within an ErrorProne check,"
-            + " consider VisitorState#getSourceForNode.",
+            + " discards whitespace and comments. If this code is within an Error Prone check,"
+            + " using VisitorState#getSourceForNode will give you the original source text. Note"
+            + " that for synthetic trees (e.g.: implicit constructors), that source may be null.",
     severity = WARNING,
     providesFix = NO_FIX)
 public class TreeToString extends AbstractToString {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatString.java
@@ -44,12 +44,20 @@ public class FormatString extends BugChecker implements MethodInvocationTreeMatc
       anyOf(
           instanceMethod()
               .onDescendantOfAny(
-                  "java.io.PrintStream", "java.io.PrintWriter", "java.util.Formatter")
+                  "java.io.PrintStream",
+                  "java.io.PrintWriter",
+                  "java.util.Formatter",
+                  "java.io.Console")
               .namedAnyOf("format", "printf"),
           staticMethod().onClass("java.lang.String").named("format"),
+          // Exclude zero-arg java.io.Console.readPassword from format methods.
           instanceMethod()
               .onExactClass("java.io.Console")
-              .namedAnyOf("format", "printf", "readLine", "readPassword"));
+              .withSignature("readPassword(java.lang.String,java.lang.Object...)"),
+          // Exclude zero-arg method java.io.Console.readLine from format methods.
+          instanceMethod()
+              .onExactClass("java.io.Console")
+              .withSignature("readLine(java.lang.String,java.lang.Object...)"));
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, final VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringValidation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringValidation.java
@@ -19,6 +19,7 @@ package com.google.errorprone.bugpatterns.formatstring;
 import static com.google.common.collect.Iterables.getOnlyElement;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.util.ASTHelpers;
@@ -95,6 +96,10 @@ public class FormatStringValidation {
       @Nullable MethodSymbol formatMethodSymbol,
       Collection<? extends ExpressionTree> arguments,
       final VisitorState state) {
+    Preconditions.checkArgument(
+        !arguments.isEmpty(),
+        "A format method should have one or more arguments, but Method(%s) has zero arguments.",
+        formatMethodSymbol);
 
     Deque<ExpressionTree> args = new ArrayDeque<>(arguments);
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
@@ -66,7 +66,8 @@ import java.util.concurrent.TimeUnit;
 
 /** This check suggests the use of {@code java.time}-based APIs, when available. */
 @BugPattern(
-    name = "PreferDurationOverload",
+    name = "PreferJavaTimeOverload",
+    altNames = {"PreferDurationOverload"},
     summary =
         "Prefer using java.time-based APIs when available. Note that this checker does"
             + " not and cannot guarantee that the overloads have equivalent semantics, but that is"
@@ -82,7 +83,7 @@ import java.util.concurrent.TimeUnit;
             + " semantic meaning; 4) decomposing a duration into a <long, TimeUnit> is dangerous"
             + " because of unit mismatch and/or excessive truncation.",
     providesFix = REQUIRES_HUMAN_ATTENTION)
-public final class PreferDurationOverload extends BugChecker
+public final class PreferJavaTimeOverload extends BugChecker
     implements MethodInvocationTreeMatcher {
 
   private static final String JAVA_DURATION = "java.time.Duration";

--- a/core/src/main/java/com/google/errorprone/refaster/LocalVarBinding.java
+++ b/core/src/main/java/com/google/errorprone/refaster/LocalVarBinding.java
@@ -41,7 +41,7 @@ public abstract class LocalVarBinding {
   }
 
   @Override
-  public String toString() {
+  public final String toString() {
     return getSymbol().getSimpleName().toString();
   }
 }

--- a/core/src/main/java/com/google/errorprone/refaster/StringName.java
+++ b/core/src/main/java/com/google/errorprone/refaster/StringName.java
@@ -35,7 +35,7 @@ public abstract class StringName
   abstract String contents();
 
   @Override
-  public String toString() {
+  public final String toString() {
     return contents();
   }
 

--- a/core/src/main/java/com/google/errorprone/refaster/UAnnotation.java
+++ b/core/src/main/java/com/google/errorprone/refaster/UAnnotation.java
@@ -46,7 +46,7 @@ abstract class UAnnotation extends UExpression implements AnnotationTree {
   public abstract UTree<?> getAnnotationType();
 
   @Override
-  public abstract List<UExpression> getArguments();
+  public abstract ImmutableList<UExpression> getArguments();
 
   @Override
   @Nullable

--- a/core/src/main/java/com/google/errorprone/refaster/UBlock.java
+++ b/core/src/main/java/com/google/errorprone/refaster/UBlock.java
@@ -43,7 +43,7 @@ abstract class UBlock extends USimpleStatement implements BlockTree {
   }
 
   @Override
-  public abstract List<UStatement> getStatements();
+  public abstract ImmutableList<UStatement> getStatements();
 
   static Choice<Unifier> unifyStatementList(
       Iterable<? extends UStatement> statements,

--- a/core/src/main/java/com/google/errorprone/refaster/UClassType.java
+++ b/core/src/main/java/com/google/errorprone/refaster/UClassType.java
@@ -44,7 +44,7 @@ public abstract class UClassType extends UType {
 
   abstract StringName fullyQualifiedClass();
 
-  abstract List<UType> typeArguments();
+  abstract ImmutableList<UType> typeArguments();
 
   @Override
   public Choice<Unifier> visitClassType(ClassType classType, Unifier unifier) {

--- a/core/src/main/java/com/google/errorprone/refaster/UForAll.java
+++ b/core/src/main/java/com/google/errorprone/refaster/UForAll.java
@@ -34,7 +34,7 @@ public abstract class UForAll extends UType {
     return new AutoValue_UForAll(ImmutableList.copyOf(typeVars), quantifiedType);
   }
 
-  public abstract List<UTypeVar> getTypeVars();
+  public abstract ImmutableList<UTypeVar> getTypeVars();
 
   public abstract UType getQuantifiedType();
 

--- a/core/src/main/java/com/google/errorprone/refaster/UForLoop.java
+++ b/core/src/main/java/com/google/errorprone/refaster/UForLoop.java
@@ -25,7 +25,6 @@ import com.sun.source.tree.TreeVisitor;
 import com.sun.tools.javac.tree.JCTree.JCExpressionStatement;
 import com.sun.tools.javac.tree.JCTree.JCForLoop;
 import com.sun.tools.javac.tree.JCTree.JCStatement;
-import java.util.List;
 import javax.annotation.Nullable;
 
 /**
@@ -49,14 +48,14 @@ abstract class UForLoop extends USimpleStatement implements ForLoopTree {
   }
 
   @Override
-  public abstract List<UStatement> getInitializer();
+  public abstract ImmutableList<UStatement> getInitializer();
 
   @Override
   @Nullable
   public abstract UExpression getCondition();
 
   @Override
-  public abstract List<UExpressionStatement> getUpdate();
+  public abstract ImmutableList<UExpressionStatement> getUpdate();
 
   @Override
   public abstract USimpleStatement getStatement();

--- a/core/src/main/java/com/google/errorprone/refaster/UMethodInvocation.java
+++ b/core/src/main/java/com/google/errorprone/refaster/UMethodInvocation.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 @AutoValue
 public abstract class UMethodInvocation extends UExpression implements MethodInvocationTree {
   public static UMethodInvocation create(UExpression methodSelect, List<UExpression> arguments) {
-    return new AutoValue_UMethodInvocation(methodSelect, arguments);
+    return new AutoValue_UMethodInvocation(methodSelect, ImmutableList.copyOf(arguments));
   }
 
   public static UMethodInvocation create(UExpression methodSelect, UExpression... arguments) {
@@ -46,7 +46,7 @@ public abstract class UMethodInvocation extends UExpression implements MethodInv
   public abstract UExpression getMethodSelect();
 
   @Override
-  public abstract List<UExpression> getArguments();
+  public abstract ImmutableList<UExpression> getArguments();
 
   @Override
   @Nullable

--- a/core/src/main/java/com/google/errorprone/refaster/UTypeVar.java
+++ b/core/src/main/java/com/google/errorprone/refaster/UTypeVar.java
@@ -63,7 +63,7 @@ public class UTypeVar extends UType {
     }
 
     @Override
-    public String toString() {
+    public final String toString() {
       return type().toString();
     }
   }

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -415,7 +415,7 @@ import com.google.errorprone.bugpatterns.time.LocalDateTemporalAmount;
 import com.google.errorprone.bugpatterns.time.PeriodFrom;
 import com.google.errorprone.bugpatterns.time.PeriodGetTemporalUnit;
 import com.google.errorprone.bugpatterns.time.PeriodTimeMath;
-import com.google.errorprone.bugpatterns.time.PreferDurationOverload;
+import com.google.errorprone.bugpatterns.time.PreferJavaTimeOverload;
 import com.google.errorprone.bugpatterns.time.ProtoDurationGetSecondsGetNano;
 import com.google.errorprone.bugpatterns.time.ProtoTimestampGetSecondsGetNano;
 import com.google.errorprone.bugpatterns.time.TemporalAccessorGetChronoField;
@@ -715,7 +715,7 @@ public class BuiltInCheckerSuppliers {
           ParameterName.class,
           PreconditionsCheckNotNullRepeated.class,
           PreconditionsInvalidPlaceholder.class,
-          PreferDurationOverload.class,
+          PreferJavaTimeOverload.class,
           ProtoRedundantSet.class,
           ProtoDurationGetSecondsGetNano.class,
           ProtoTimestampGetSecondsGetNano.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringTest.java
@@ -280,6 +280,19 @@ public class FormatStringTest {
   }
 
   @Test
+  public void testPrintfMethods_ConsoleFormat_noErrorsWithEmptyArgs() throws Exception {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void f() {",
+            "    System.console().readLine();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void testPrintfMethods_ConsoleReadline() throws Exception {
     testFormat("", "System.console().readLine(\"%d\", \"hello\");");
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverloadTest.java
@@ -20,11 +20,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link PreferDurationOverload}. */
+/** Tests for {@link PreferJavaTimeOverload}. */
 @RunWith(JUnit4.class)
-public class PreferDurationOverloadTest {
+public class PreferJavaTimeOverloadTest {
   private final CompilationTestHelper helper =
-      CompilationTestHelper.newInstance(PreferDurationOverload.class, getClass());
+      CompilationTestHelper.newInstance(PreferJavaTimeOverload.class, getClass());
 
   @Test
   public void callingLongTimeUnitMethodWithDurationOverload_microseconds() {

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <dataflow.version>2.8.1</dataflow.version>
     <mockito.version>2.25.0</mockito.version>
     <compile.testing.version>0.18</compile.testing.version>
+    <caffeine.version>2.7.0</caffeine.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Rename PreferDurationOverload to PreferJavaTimeOverload, as it now covers Instant as well.

RELNOTES: Rename PreferDurationOverload to PreferJavaTimeOverload, as it now covers Instant as well.

ef6fe4236d6e4de0434940cf59ac8eedc5457563

-------

<p> Add further caveat about VisitorState.getSourceForNode.

Per comment in #1316

47167894bf3e94ddc9c96a28d601d685a6f7eced

-------

<p> Fix AutoValueFinalMethods warnings in refaster code

93af397f40351d71a440dcb00c883a1d3011ea22

-------

<p> Fix FormatString Checker crash on Console.readLine()

e4361a4117e246e5639448dfdc9bf24fdbbc6602

-------

<p> Consolidate stripParentheses implementations

84ed4f03d4b1f0181ce932caa6b30520acb8603e

-------

<p> Upgrade to Caffeine version 2.7.0 as requested by Ben Maines: https://github.com/google/error-prone/pull/1316#commitcomment-34487169

1cb86f9f554243ecd008c2be9fc2dfb1d08ff45f

-------

<p> Fix some AutoValueImmutableFields warning in refaster code

237f657fb50f56a96a6e5bb2a930459b1f789b63