### PR TITLE
Change method name 'relative' to 'getRelativePath'

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/apply/PatchFileDestination.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/PatchFileDestination.java
@@ -59,7 +59,7 @@ public final class PatchFileDestination implements FileDestination {
       List<String> originalLines = LINE_SPLITTER.splitToList(oldSource);
 
       Patch<String> diff = DiffUtils.diff(originalLines, LINE_SPLITTER.splitToList(newSource));
-      String relativePath = relativize(sourceFilePath);
+      String relativePath = getRelativePath(sourceFilePath);
       List<String> unifiedDiff =
           DiffUtils.generateUnifiedDiff(relativePath, relativePath, originalLines, diff, 2);
 
@@ -68,7 +68,7 @@ public final class PatchFileDestination implements FileDestination {
     }
   }
 
-  private String relativize(Path sourceFilePath) {
+  private String getRelativePath(Path sourceFilePath) {
     return baseDir.relativize(sourceFilePath).toString();
   }
 


### PR DESCRIPTION
This class is used to represent PatchFileDestination.  This method named 'relativize' is to get relative path. Thus, the method name 'getRelativePath' is more intuitive than 'relativize'.