### PR TITLE
[core] Add support for ConcurrentHashMap in AbstractAsKeyOfSetOrMap

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/AbstractAsKeyOfSetOrMap.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AbstractAsKeyOfSetOrMap.java
@@ -67,6 +67,7 @@ public abstract class AbstractAsKeyOfSetOrMap extends BugChecker
               .onClass("com.google.common.collect.Maps")
               .named("newLinkedHashMap"),
           Matchers.constructor().forClass("java.util.LinkedHashMap"),
+          Matchers.constructor().forClass("java.util.concurrent.ConcurrentHashMap"),
           MethodMatchers.staticMethod()
               .onClass("com.google.common.collect.HashBiMap")
               .named("create"));

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ArrayAsKeyOfSetOrMapTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ArrayAsKeyOfSetOrMapTest.java
@@ -48,6 +48,7 @@ public final class ArrayAsKeyOfSetOrMapTest {
             "import java.util.Set;",
             "import java.util.Map;",
             "import java.util.LinkedHashMap;",
+            "import java.util.concurrent.ConcurrentHashMap;",
             "import com.google.common.collect.Sets;",
             "import com.google.common.collect.Maps;",
             "import com.google.common.collect.HashMultiset;",
@@ -94,6 +95,9 @@ public final class ArrayAsKeyOfSetOrMapTest {
             "    LinkedHashMap<String[], Integer> testLinkedHashMap"
                 + "= new LinkedHashMap<String[], Integer>();",
             "    // BUG: Diagnostic contains: ArrayAsKeyOfSetOrMap",
+            "    ConcurrentHashMap<String[], Integer> testConcurrentHashMap"
+                + "= new ConcurrentHashMap<String[], Integer>();",
+            "    // BUG: Diagnostic contains: ArrayAsKeyOfSetOrMap",
             "    HashMultiset<String[]> testHashMultiSet = HashMultiset.create();",
             "    // BUG: Diagnostic contains: ArrayAsKeyOfSetOrMap",
             "    LinkedHashMultiset<String[]> testLinkedHashMultiSet"
@@ -112,6 +116,7 @@ public final class ArrayAsKeyOfSetOrMapTest {
             "import java.util.Set;",
             "import java.util.Map;",
             "import java.util.LinkedHashMap;",
+            "import java.util.concurrent.ConcurrentHashMap;",
             "import com.google.common.collect.Sets;",
             "import com.google.common.collect.Maps;",
             "import java.util.HashMap;",
@@ -147,6 +152,8 @@ public final class ArrayAsKeyOfSetOrMapTest {
             "    HashBiMap<String, Integer> testHashBiMap = HashBiMap.create();",
             "    LinkedHashMap<String, Integer> testLinkedHashMap"
                 + "= new LinkedHashMap<String, Integer>();",
+            "    ConcurrentHashMap<String, Integer> testConcurrentHashMap"
+                + "= new ConcurrentHashMap<String, Integer>();",
             "    HashMultiset<String> testHashMultiSet = HashMultiset.create();",
             "    LinkedHashMultiset<String> testLinkedHashMultiSet"
                 + "= LinkedHashMultiset.create();",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ProtosAsKeyOfSetOrMapTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ProtosAsKeyOfSetOrMapTest.java
@@ -46,6 +46,7 @@ public final class ProtosAsKeyOfSetOrMapTest {
             "import java.util.HashMap;",
             "import java.util.HashSet;",
             "import java.util.Collection;",
+            "import java.util.concurrent.ConcurrentHashMap;",
             "import com.google.common.collect.Sets;",
             "import com.google.common.collect.Maps;",
             "import com.google.common.collect.HashMultiset;",
@@ -97,6 +98,9 @@ public final class ProtosAsKeyOfSetOrMapTest {
             "    LinkedHashMap<TestProtoMessage, Integer> testLinkedHashMap"
                 + "= new LinkedHashMap<TestProtoMessage, Integer>();",
             "    // BUG: Diagnostic contains: ProtosAsKeyOfSetOrMap",
+            "    ConcurrentHashMap<TestProtoMessage, Integer>  testConcurrentHashMap"
+                + "= new ConcurrentHashMap<TestProtoMessage, Integer>();",
+            "    // BUG: Diagnostic contains: ProtosAsKeyOfSetOrMap",
             "    LinkedHashMultiset<TestProtoMessage> testLinkedHashMultiSet"
                 + "= LinkedHashMultiset.create();",
             "    // BUG: Diagnostic contains: ProtosAsKeyOfSetOrMap",
@@ -115,6 +119,7 @@ public final class ProtosAsKeyOfSetOrMapTest {
             "import java.util.Set;",
             "import java.util.Map;",
             "import java.util.LinkedHashMap;",
+            "import java.util.concurrent.ConcurrentHashMap;",
             "import com.google.common.collect.Sets;",
             "import com.google.common.collect.Maps;",
             "import java.util.HashMap;",
@@ -150,6 +155,8 @@ public final class ProtosAsKeyOfSetOrMapTest {
             "    HashBiMap<String, Integer> testHashBiMap = HashBiMap.create();",
             "    LinkedHashMap<String, Integer> testLinkedHashMap"
                 + "= new LinkedHashMap<String, Integer>();",
+            "    ConcurrentHashMap<String, Integer> testConcurrentHashMap"
+                + "= new ConcurrentHashMap<String, Integer>();",
             "    HashMultiset<String> testHashMultiSet = HashMultiset.create();",
             "    LinkedHashMultiset<String> testLinkedHashMultiSet"
                 + "= LinkedHashMultiset.create();",


### PR DESCRIPTION
Add support for `ConcurrentHashMap` in `AbstractAsKeyOfSetOrMap`, thus the error patterns `ArrayAsKeyOfSetOrMap` and `ProtosAsKeyOfSetOrMap` are available for `ConcurrentHashMap`. 