### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/CompareToZero.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CompareToZero.java
@@ -148,6 +148,7 @@ public final class CompareToZero extends BugChecker implements MethodInvocationT
         SuggestedFix fix = generateFix(binaryTree, state, comparatorSide, ">");
         state.reportMatch(
             buildDescription(binaryTree).setMessage(SUGGEST_IMPROVEMENT).addFix(fix).build());
+        return null;
       }
       if (COMPARISONS.contains(binaryTree.getKind())) {
         state.reportMatch(describeMatch(binaryTree));

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringValidation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringValidation.java
@@ -98,7 +98,7 @@ public class FormatStringValidation {
       final VisitorState state) {
     Preconditions.checkArgument(
         !arguments.isEmpty(),
-        "A format method should have one or more arguments, but Method(%s) has zero arguments.",
+        "A format method should have one or more arguments, but method (%s) has zero arguments.",
         formatMethodSymbol);
 
     Deque<ExpressionTree> args = new ArrayDeque<>(arguments);

--- a/core/src/test/java/com/google/errorprone/bugpatterns/CompareToZeroTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/CompareToZeroTest.java
@@ -59,6 +59,22 @@ public final class CompareToZeroTest {
   }
 
   @Test
+  public void positive_gte1_has_1_finding() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  boolean test(Integer i) {",
+            "    // BUG: Diagnostic matches: KEY",
+            "    return i.compareTo(2) >= 1;",
+            "  }",
+            "}")
+        .expectErrorMessage(
+            "KEY", msg -> msg.contains("consistency") && !msg.contains("implementation"))
+        .doTest();
+  }
+
+  @Test
   public void positiveAddition() {
     compilationHelper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/CompareToZeroTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/CompareToZeroTest.java
@@ -89,6 +89,19 @@ public final class CompareToZeroTest {
   }
 
   @Test
+  public void testStringConcat_ignored() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  String test(Integer i) {",
+            "    return \"\" + i.compareTo(3);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void refactoring() {
     refactoringHelper
         .addInputLines(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix issue with CompareToZero for '>=1' (the previous version of the code would emit two findings).

RELNOTES: n/a

0dd0ec89964adc68d5bc207ed91d4a8d39668d40

-------

<p> Attempt to clarify message.

https://github.com/google/error-prone/pull/1324#discussion_r309244462

4e780ae06b8f7d3f2af8ede2af556151fe8b8e7b

-------

<p> Update CompareToZero to be tolerant of string concatenation.

ex: "Comparison Result: " + x.compareTo(y)

RELNOTES: n/a

a2884233e8d2675a891a604f72a922a8aa63c50b