### PR TITLE
Moe Sync

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -343,6 +343,13 @@
       <version>3.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <!-- Apache 2.0 -->
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <version>1.0.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UndefinedEqualsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UndefinedEqualsTest.java
@@ -16,18 +16,20 @@
 
 package com.google.errorprone.bugpatterns;
 
+import com.google.common.base.Joiner;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /**
  * Unit tests for {@link UndefinedEquals}
  *
  * @author eleanorh@google.com (Eleanor Harris)
  */
-@RunWith(JUnit4.class)
+@RunWith(JUnitParamsRunner.class)
 public final class UndefinedEqualsTest {
   private final CompilationTestHelper compilationHelper =
       CompilationTestHelper.newInstance(UndefinedEquals.class, getClass());
@@ -116,6 +118,276 @@ public final class UndefinedEqualsTest {
             "    assertThat(a).isEqualTo(b);",
             "    // BUG: Diagnostic contains: Queue does not have",
             "    assertThat(a).isNotEqualTo(b);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  @Parameters(method = "truthFixParameters")
+  public void truthFixParameterized(String input, String output) {
+    BugCheckerRefactoringTestHelper.newInstance(new UndefinedEquals(), getClass())
+        .addInputLines(
+            "Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "import com.google.common.collect.Multimap;",
+            "import java.lang.Iterable;",
+            "import java.util.Collection;",
+            "import java.util.Queue;",
+            "class Test {",
+            input,
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "import com.google.common.collect.Multimap;",
+            "import java.lang.Iterable;",
+            "import java.util.Collection;",
+            "import java.util.Queue;",
+            "class Test {",
+            output,
+            "}")
+        .doTest();
+  }
+
+  private Object truthFixParameters() {
+    return new Object[] {
+      new String[] {
+        lines(
+            "  void f1(Multimap a, Multimap b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f1(Multimap a, Multimap b) {", //
+            "    assertThat(a).containsExactlyEntriesIn(b);",
+            "  }")
+      },
+      new String[] {
+        lines(
+            "  void f2(Multimap a, Collection b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f2(Multimap a, Collection b) {",
+            "    assertThat(a).isEqualTo(b);", // no fix
+            "  }")
+      },
+      new String[] {
+        lines(
+            "  void f3(Multimap a, Iterable b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f3(Multimap a, Iterable b) {",
+            "    assertThat(a).isEqualTo(b);", // no fix
+            "  }")
+      },
+      new String[] {
+        lines(
+            "  void f4(Multimap a, Queue b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f4(Multimap a, Queue b) {",
+            "    assertThat(a).isEqualTo(b);", // no fix
+            "  }")
+      },
+      new String[] {
+        lines(
+            "  void f5(Collection a, Multimap b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f5(Collection a, Multimap b) {",
+            "    assertThat(a).isEqualTo(b);", // no fix
+            "  }")
+      },
+      new String[] {
+        lines(
+            "  void f6(Collection a, Collection b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f6(Collection a, Collection b) {", //
+            "    assertThat(a).containsExactlyElementsIn(b);",
+            "  }")
+      },
+      new String[] {
+        lines(
+            "  void f7(Collection a, Iterable b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f7(Collection a, Iterable b) {", //
+            "    assertThat(a).containsExactlyElementsIn(b);",
+            "  }")
+      },
+      new String[] {
+        lines(
+            "  void f8(Collection a, Queue b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f8(Collection a, Queue b) {", //
+            "    assertThat(a).containsExactlyElementsIn(b);",
+            "  }")
+      },
+      new String[] {
+        lines(
+            "  void f9(Iterable a, Multimap b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f9(Iterable a, Multimap b) {",
+            "    assertThat(a).isEqualTo(b);", // no fix
+            "  }")
+      },
+      new String[] {
+        lines(
+            "  void f10(Iterable a, Collection b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f10(Iterable a, Collection b) {", //
+            "    assertThat(a).containsExactlyElementsIn(b);",
+            "  }")
+      },
+      new String[] {
+        lines(
+            "  void f11(Iterable a, Iterable b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f11(Iterable a, Iterable b) {", //
+            "    assertThat(a).containsExactlyElementsIn(b);",
+            "  }")
+      },
+      new String[] {
+        lines(
+            "  void f12(Iterable a, Queue b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f12(Iterable a, Queue b) {", //
+            "    assertThat(a).containsExactlyElementsIn(b);",
+            "  }")
+      },
+      new String[] {
+        lines(
+            "  void f13(Queue a, Multimap b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f13(Queue a, Multimap b) {",
+            "    assertThat(a).isEqualTo(b);", // no fix
+            "  }")
+      },
+      new String[] {
+        lines(
+            "  void f14(Queue a, Collection b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f14(Queue a, Collection b) {", //
+            "    assertThat(a).containsExactlyElementsIn(b);",
+            "  }")
+      },
+      new String[] {
+        lines(
+            "  void f15(Queue a, Iterable b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f15(Queue a, Iterable b) {", //
+            "    assertThat(a).containsExactlyElementsIn(b);",
+            "  }")
+      },
+      new String[] {
+        lines(
+            "  void f16(Queue a, Queue b) {", //
+            "    assertThat(a).isEqualTo(b);",
+            "  }"),
+        lines(
+            "  void f16(Queue a, Queue b) {", //
+            "    assertThat(a).containsExactlyElementsIn(b);",
+            "  }")
+      }
+    };
+  }
+
+  private String lines(String... lines) {
+    return Joiner.on('\n').join(lines);
+  }
+
+  @Test
+  public void truthFixAssertWithMessage() {
+    BugCheckerRefactoringTestHelper.newInstance(new UndefinedEquals(), getClass())
+        .addInputLines(
+            "Test.java",
+            "import static com.google.common.truth.Truth.assertWithMessage;",
+            "import java.lang.Iterable;",
+            "class Test {",
+            "  void f(Iterable a, Iterable b) {",
+            "    assertWithMessage(\"message\").that(a).isEqualTo(b);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import static com.google.common.truth.Truth.assertWithMessage;",
+            "import java.lang.Iterable;",
+            "class Test {",
+            "  void f(Iterable a, Iterable b) {",
+            "    assertWithMessage(\"message\").that(a).containsExactlyElementsIn(b);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void truthFixDontRewriteIsNotEqualTo() {
+    BugCheckerRefactoringTestHelper.newInstance(new UndefinedEquals(), getClass())
+        .addInputLines(
+            "Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "import java.lang.Iterable;",
+            "class Test {",
+            "  void f(Iterable a, Iterable b) {",
+            "    assertThat(a).isNotEqualTo(b);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "import java.lang.Iterable;",
+            "class Test {",
+            "  void f(Iterable a, Iterable b) {",
+            "    assertThat(a).isNotEqualTo(b);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void truthFixAcrossMultipleLinesAndPoorlyFormatted() {
+    BugCheckerRefactoringTestHelper.newInstance(new UndefinedEquals(), getClass())
+        .addInputLines(
+            "Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "import java.lang.Iterable;",
+            "class Test {",
+            "  void f(Iterable a, Iterable b) {",
+            "    assertThat(a).", // period should be on following line per style guide
+            "      isEqualTo(b);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "import java.lang.Iterable;",
+            "class Test {",
+            "  void f(Iterable a, Iterable b) {",
+            "    assertThat(a).",
+            "      containsExactlyElementsIn(b);",
             "  }",
             "}")
         .doTest();


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a special-case suggested fix to UndefinedEquals which rewrites calls to Truth `isEqualTo` to `containsExactlyElementsIn`/`containsExactlyEntriesIn`.

7422065a51d6c4d0a6cd8872b79be6e09e85fd27