### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -601,8 +601,6 @@ public class SuggestedFixes {
    * closest suppressible node, or add {@code warningToSuppress} to that node if there's already a
    * {@code SuppressWarnings} annotation there.
    *
-   * @param fixBuilder The fixBuilder to add the fix to
-   * @param state VisitorState (used for resolving types, etc.)
    * @param warningToSuppress the warning to be suppressed, without the surrounding annotation. For
    *     example, to produce {@code @SuppressWarnings("Foo")}, pass {@code Foo}.
    * @param lineComment if non-null, the {@code @SuppressWarnings} will be prefixed by a line
@@ -622,8 +620,6 @@ public class SuggestedFixes {
    * closest suppressible node, or add {@code warningToSuppress} to that node if there's already a
    * {@code SuppressWarnings} annotation there.
    *
-   * @param fixBuilder The fixBuilder to add the fix to
-   * @param state VisitorState (used for resolving types, etc.)
    * @param warningToSuppress the warning to be suppressed, without the surrounding annotation. For
    *     example, to produce {@code @SuppressWarnings("Foo")}, pass {@code Foo}.
    * @param lineComment if non-null, the {@code @SuppressWarnings} will have this comment associated


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add another overload to addSuppressWarnings to allow users to specify
whether or not to make the line comment appear on the same line as the
new suppression comment.

RELNOTES: n/a

32b352be83e48bc10b92879830295927b2cde522

-------

<p> Small cleanup of unneeded documentation.

RELNOTES: n/a

4c37001ff950a098f67a688c6b47dcebad77b66b