### PR TITLE
Fix for Java12+ compatibility

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/Finally.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Finally.java
@@ -168,7 +168,7 @@ public class Finally extends BugChecker
     }
 
     public FinallyJumpMatcher(JCBreak jcBreak) {
-      this.label = jcBreak.label;
+      this.label = jcBreak.getLabel();
       this.jumpType = JumpType.BREAK;
     }
 


### PR DESCRIPTION
This commit fixes issues #1342, #1335, #1301, #1257, and #1249

Prior to this change, static analysis of code containing a `break` statement would fail when running on Java version 12+, with an error similar to the following:

```
BugPattern: Finally
Stack Trace:
java.lang.NoSuchFieldError: com/sun/tools/javac/tree/JCTree$JCBreak.label
```

This was due to a change in the class `com.sun.tools.javac.tree.JCTree$JCBreak`. In Java 12+, `label` is no longer a field, and is instead a calculated value. This change simply changes `com.google.errorprone.bugpatterns.Finally` to call `JCBreak.getLabel()` instead of `JCBreak.label`.

This change maintains compatibility with prior versions of Java.

 Changes to be committed:
	modified:   core/src/main/java/com/google/errorprone/bugpatterns/Finally.java