### PR TITLE
Fix for compatibility with Java version 12+

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/Finally.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Finally.java
@@ -168,7 +168,7 @@ public class Finally extends BugChecker
     }
 
     public FinallyJumpMatcher(JCBreak jcBreak) {
-      this.label = jcBreak.label;
+      this.label = jcBreak.getLabel();
       this.jumpType = JumpType.BREAK;
     }
 


### PR DESCRIPTION
This commit fixes issues #1342, #1335, #1301, #1257, and #1249

Prior to this change, static analysis of code containing a `break` statement would fail when running on Java version 12+, with the following error:

```
BugPattern: Finally
Stack Trace:
java.lang.NoSuchFieldError: com/sun/tools/javac/tree/JCTree$JCBreak.label
...
```

This was due to a change in the class `com.sun.tools.javac.tree.JCTree$JCBreak`. In Java 12+, `label` is no longer a field, and is instead a calculated value. This change modifies `com.google.errorprone.bugpatterns.Finally` to call `JCBreak.getLabel()` instead of `JCBreak.label`.

This change maintains compatibility with prior versions of Java.

 On branch 1342-compatibility-java-12
 Changes to be committed:
	modified:   core/src/main/java/com/google/errorprone/bugpatterns/Finally.java