### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -816,7 +816,7 @@ public class SuggestedFixes {
    */
   public static boolean compilesWithFix(
       Fix fix, VisitorState state, ImmutableList<String> extraOptions) {
-    if (fix.isEmpty()) {
+    if (fix.isEmpty() && extraOptions.isEmpty()) {
       return true;
     }
     JCCompilationUnit compilationUnit = (JCCompilationUnit) state.getPath().getCompilationUnit();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DoNotCallChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DoNotCallChecker.java
@@ -68,14 +68,11 @@ public class DoNotCallChecker extends BugChecker
       if (symbol.getModifiers().contains(Modifier.ABSTRACT)) {
         return NO_MATCH;
       }
-      if (symbol.getModifiers().contains(Modifier.FINAL)) {
-        return NO_MATCH;
-      }
-      if (symbol.owner.enclClass().getModifiers().contains(Modifier.FINAL)) {
+      if (!ASTHelpers.methodCanBeOverridden(symbol)) {
         return NO_MATCH;
       }
       return buildDescription(tree)
-          .setMessage("Methods annotated with @DoNotCall should be final.")
+          .setMessage("Methods annotated with @DoNotCall should be final or static.")
           .addFix(SuggestedFixes.addModifiers(tree, state, Modifier.FINAL))
           .build();
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ExtendsAutoValue.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ExtendsAutoValue.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ClassTree;
+
+/** Makes sure that you are not extending a class that has @AutoValue as an annotation. */
+@BugPattern(
+    name = "ExtendsAutoValue",
+    summary = "Do not extend an @AutoValue class in non-generated code.",
+    severity = SeverityLevel.WARNING)
+public final class ExtendsAutoValue extends BugChecker implements ClassTreeMatcher {
+
+  @Override
+  public Description matchClass(ClassTree tree, VisitorState state) {
+
+    if (!ASTHelpers.getGeneratedBy(ASTHelpers.getSymbol(tree), state).isEmpty()) {
+      // Skip generated code. Yes, I know we can do this via a flag but we should always ignore
+      // generated code, so to be sure, manually check it.
+      return Description.NO_MATCH;
+    }
+
+    if (tree.getExtendsClause() == null) {
+      // Doesn't extend anything, can't possibly be a violation.
+      return Description.NO_MATCH;
+    }
+    if (ASTHelpers.hasAnnotation(
+        ASTHelpers.getSymbol(tree.getExtendsClause()), "com.google.auto.value.AutoValue", state)) {
+      // Violation: one of its superclasses extends AutoValue.
+      return buildDescription(tree).build();
+    }
+
+    return Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThrowSpecificExceptions.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThrowSpecificExceptions.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.NewClassTree;
+
+/** Bugpattern to discourage throwing base exception classes.. */
+@BugPattern(
+    name = "ThrowSpecificExceptions",
+    summary =
+        "Consider throwing more specific exceptions rather than (e.g.) RuntimeException. Throwing"
+            + " generic exceptions forces any users of the API that wish to handle the failure"
+            + " mode to catch very non-specific exceptions that convey little information.",
+    providesFix = REQUIRES_HUMAN_ATTENTION,
+    severity = WARNING)
+public final class ThrowSpecificExceptions extends BugChecker implements NewClassTreeMatcher {
+  private static final ImmutableList<AbstractLikeException> ABSTRACT_LIKE_EXCEPTIONS =
+      ImmutableList.of(
+          AbstractLikeException.of(RuntimeException.class, IllegalStateException.class),
+          AbstractLikeException.of(Throwable.class, AssertionError.class),
+          AbstractLikeException.of(Error.class, AssertionError.class));
+
+  @Override
+  public Description matchNewClass(NewClassTree tree, VisitorState state) {
+    if (tree.getClassBody() != null) {
+      return Description.NO_MATCH;
+    }
+    for (AbstractLikeException abstractLikeException : ABSTRACT_LIKE_EXCEPTIONS) {
+      if (abstractLikeException.matcher().matches(tree, state)) {
+        SuggestedFix.Builder fix = SuggestedFix.builder();
+        String className =
+            SuggestedFixes.qualifyType(state, fix, abstractLikeException.replacement());
+        return describeMatch(tree, SuggestedFix.replace(tree.getIdentifier(), className));
+      }
+    }
+    return Description.NO_MATCH;
+  }
+
+  @AutoValue
+  abstract static class AbstractLikeException {
+    abstract Matcher<ExpressionTree> matcher();
+
+    abstract String replacement();
+
+    static AbstractLikeException of(Class<?> abstractLikeException, Class<?> replacement) {
+      return new AutoValue_ThrowSpecificExceptions_AbstractLikeException(
+          Matchers.constructor().forClass(abstractLikeException.getName()), replacement.getName());
+    }
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedNestedClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedNestedClass.java
@@ -53,7 +53,7 @@ public final class UnusedNestedClass extends BugChecker implements CompilationUn
 
   @Override
   public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {
-    PrivateNestedClassScanner privateNestedClassScanner = new PrivateNestedClassScanner();
+    PrivateNestedClassScanner privateNestedClassScanner = new PrivateNestedClassScanner(state);
     privateNestedClassScanner.scan(state.getPath(), null);
 
     Map<ClassSymbol, TreePath> privateNestedClasses = privateNestedClassScanner.classes;
@@ -70,10 +70,15 @@ public final class UnusedNestedClass extends BugChecker implements CompilationUn
 
   private final class PrivateNestedClassScanner extends TreePathScanner<Void, Void> {
     private final Map<ClassSymbol, TreePath> classes = new HashMap<>();
+    private final VisitorState state;
+
+    private PrivateNestedClassScanner(VisitorState state) {
+      this.state = state;
+    }
 
     @Override
     public Void visitClass(ClassTree classTree, Void unused) {
-      if (isSuppressed(classTree)) {
+      if (ignoreUnusedClass(classTree)) {
         return null;
       }
       ClassSymbol symbol = getSymbol(classTree);
@@ -81,6 +86,13 @@ public final class UnusedNestedClass extends BugChecker implements CompilationUn
         classes.put(symbol, getCurrentPath());
       }
       return super.visitClass(classTree, null);
+    }
+
+    private boolean ignoreUnusedClass(ClassTree classTree) {
+      if (isSuppressed(classTree)) {
+        return true;
+      }
+      return false;
     }
   }
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/XorPower.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/XorPower.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.BinaryTree;
+import com.sun.source.tree.Tree;
+import java.util.Objects;
+
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
+@BugPattern(
+    name = "XorPower",
+    summary = "The `^` operator is binary XOR, not a power operator.",
+    severity = ERROR,
+    providesFix = REQUIRES_HUMAN_ATTENTION)
+public class XorPower extends BugChecker implements BinaryTreeMatcher {
+  @Override
+  public Description matchBinary(BinaryTree tree, VisitorState state) {
+    if (!tree.getKind().equals(Tree.Kind.XOR)) {
+      return NO_MATCH;
+    }
+    Integer lhs = ASTHelpers.constValue(tree.getLeftOperand(), Integer.class);
+    if (!Objects.equals(lhs, 2)) {
+      return NO_MATCH;
+    }
+    Integer rhs = ASTHelpers.constValue(tree.getRightOperand(), Integer.class);
+    if (rhs == null) {
+      return NO_MATCH;
+    }
+    if (state.getSourceForNode(tree.getRightOperand()).startsWith("0")) {
+      // hex and octal literals
+      return NO_MATCH;
+    }
+    Description.Builder description =
+        buildDescription(tree)
+            .setMessage(
+                String.format(
+                    "The ^ operator is binary XOR, not a power operator, so '%s' will always"
+                        + " evaluate to %d.",
+                    state.getSourceForNode(tree), lhs ^ rhs));
+    if (rhs <= 31) {
+      description.addFix(SuggestedFix.replace(tree, String.format("1 << %d", rhs)));
+    }
+    return description.build();
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaDurationGetSecondsGetNano.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaDurationGetSecondsGetNano.java
@@ -16,10 +16,10 @@
 package com.google.errorprone.bugpatterns.time;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.bugpatterns.time.NearbyCallers.containsCallToSameReceiverNearby;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 
-import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -27,22 +27,8 @@ import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
-import com.google.errorprone.util.ASTHelpers;
-import com.google.protobuf.GeneratedMessage;
-import com.google.protobuf.GeneratedMessageLite;
-import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
-import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
-import com.sun.source.tree.Tree;
-import com.sun.source.tree.VariableTree;
-import com.sun.source.util.TreeScanner;
-import com.sun.tools.javac.code.Symbol;
-import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
-import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * This checker warns about calls to {@code duration.getNano()} without a corresponding "nearby"
@@ -70,142 +56,15 @@ public final class JavaDurationGetSecondsGetNano extends BugChecker
           instanceMethod().onExactClass("java.time.Duration").named("getNano"),
           Matchers.not(Matchers.packageStartsWith("java.")));
 
-  // lifted from com.google.devtools.javatools.refactory.refaster.cleanups.proto.ProtoMatchers
-  private static final Matcher<ExpressionTree> IS_IMMUTABLE_PROTO_GETTER =
-      instanceMethod()
-          .onDescendantOfAny(GeneratedMessage.class.getName(), GeneratedMessageLite.class.getName())
-          .withNameMatching(Pattern.compile("get(?!CachedSize$|SerializedSize$).+"))
-          .withParameters();
-
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (GET_NANO.matches(tree, state)) {
-      if (!containsGetSecondsCallInNearbyCode(
-          tree, state, GET_SECONDS, /*checkProtoChains=*/ false)) {
+      if (!containsCallToSameReceiverNearby(
+          tree, GET_SECONDS, state, /*checkProtoChains=*/ false)) {
         return describeMatch(tree);
       }
     }
     return Description.NO_MATCH;
   }
 
-  /**
-   * Returns whether or not there is a "nearby" {@code getSeconds()} method call.
-   *
-   * @param nanoTree the tree that contains the {@code getNanos()} method call
-   * @param state the visitor state of this matcher
-   * @param secondsMatcher the matcher that matches the appropriate {@code getSeconds()} call
-   * @param checkProtoChains whether or not to check a chain of protobuf getter methods for equality
-   *     (e.g., {@code a.getB().getC().getSeconds()} and {@code a.getB().getC().getNanos()}
-   */
-  static boolean containsGetSecondsCallInNearbyCode(
-      MethodInvocationTree nanoTree,
-      VisitorState state,
-      Matcher<ExpressionTree> secondsMatcher,
-      boolean checkProtoChains) {
-    ExpressionTree getNanoReceiver = ASTHelpers.getReceiver(nanoTree);
-    TreeScanner<Boolean, Void> scanner =
-        new TreeScanner<Boolean, Void>() {
-          @Override
-          public Boolean reduce(Boolean r1, Boolean r2) {
-            return (r1 == null ? false : r1) || (r2 == null ? false : r2);
-          }
-
-          @Override
-          public Boolean visitLambdaExpression(LambdaExpressionTree node, Void unused) {
-            return false;
-          }
-
-          @Override
-          public Boolean visitMethodInvocation(MethodInvocationTree tree, Void unused) {
-            if (super.visitMethodInvocation(tree, unused)) {
-              return true;
-            }
-            if (tree != null && secondsMatcher.matches(tree, state)) {
-              ExpressionTree getSecondsReceiver = ASTHelpers.getReceiver(tree);
-              if (getSecondsReceiver != null) {
-                // if the methods are being invoked directly on the same variable...
-                if (getNanoReceiver != null
-                    && getSecondsReceiver != null
-                    && ASTHelpers.sameVariable(getNanoReceiver, getSecondsReceiver)) {
-                  return true;
-                }
-                if (!checkProtoChains) {
-                  return false;
-                }
-                // now check if the root variables of the invocations are the same...
-                ExpressionTree treeRootAssignable = ASTHelpers.getRootAssignable(tree);
-                ExpressionTree nanoTreeRootAssignable = ASTHelpers.getRootAssignable(nanoTree);
-                if (treeRootAssignable != null
-                    && nanoTreeRootAssignable != null
-                    && ASTHelpers.sameVariable(treeRootAssignable, nanoTreeRootAssignable)) {
-
-                  // build up a list of method invocations for both invocations
-
-                  List<Symbol> secondsChain = new ArrayList<>();
-                  boolean allProtoGettersForSeconds = buildChain(tree, state, secondsChain);
-
-                  List<Symbol> nanosChain = new ArrayList<>();
-                  boolean allProtoGettersForNanos = buildChain(nanoTree, state, nanosChain);
-
-                  // if we saw a non protobuf getter in the chain, we have to return false
-                  if (!allProtoGettersForSeconds || !allProtoGettersForNanos) {
-                    return false;
-                  }
-
-                  if (secondsChain.equals(nanosChain)) {
-                    return true;
-                  }
-                }
-              }
-            }
-            return false;
-          }
-        };
-    ImmutableList<Tree> treesToScan = getNearbyTreesToScan(state);
-    return treesToScan.isEmpty() ? false : scanner.scan(treesToScan, null);
-  }
-
-  // passing in output variables? what is this C++?
-  private static boolean buildChain(ExpressionTree expr, VisitorState state, List<Symbol> chain) {
-    while (expr instanceof JCMethodInvocation) {
-      expr = ((JCMethodInvocation) expr).getMethodSelect();
-      // if the method isn't an immutable protobuf getter, return false
-      if (!IS_IMMUTABLE_PROTO_GETTER.matches(expr, state)) {
-        return false;
-      }
-      if (expr instanceof JCFieldAccess) {
-        expr = ((JCFieldAccess) expr).getExpression();
-      }
-      chain.add(ASTHelpers.getSymbol(expr));
-    }
-    return true;
-  }
-
-  private static ImmutableList<Tree> getNearbyTreesToScan(VisitorState state) {
-    for (Tree parent : state.getPath()) {
-      // if we get all the way up to the class tree, then _only_ scan the other class-level fields
-      if (parent.getKind() == Tree.Kind.CLASS) {
-        ImmutableList.Builder<Tree> treesToScan = ImmutableList.builder();
-        for (Tree member : ((ClassTree) parent).getMembers()) {
-          if (member instanceof VariableTree) {
-            ExpressionTree expressionTree = ((VariableTree) member).getInitializer();
-            if (expressionTree != null) {
-              treesToScan.add(expressionTree);
-            }
-          }
-        }
-        return treesToScan.build();
-      }
-      // if we reach a block tree, then _only_ scan that block
-      if (parent.getKind() == Tree.Kind.BLOCK) {
-        return ImmutableList.of(parent);
-      }
-      // if we reach a lambda tree, then don't scan anything since we don't know where/when that
-      // lambda will actually be executed
-      if (parent.getKind() == Tree.Kind.LAMBDA_EXPRESSION) {
-        return ImmutableList.of();
-      }
-    }
-    return ImmutableList.of();
-  }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaInstantGetSecondsGetNano.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaInstantGetSecondsGetNano.java
@@ -16,7 +16,7 @@
 package com.google.errorprone.bugpatterns.time;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
-import static com.google.errorprone.bugpatterns.time.JavaDurationGetSecondsGetNano.containsGetSecondsCallInNearbyCode;
+import static com.google.errorprone.bugpatterns.time.NearbyCallers.containsCallToSameReceiverNearby;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 
@@ -59,8 +59,8 @@ public final class JavaInstantGetSecondsGetNano extends BugChecker
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (GET_NANO.matches(tree, state)) {
-      if (!containsGetSecondsCallInNearbyCode(
-          tree, state, GET_EPOCH_SECOND, /*checkProtoChains=*/ false)) {
+      if (!containsCallToSameReceiverNearby(
+          tree, GET_EPOCH_SECOND, state, /*checkProtoChains=*/ false)) {
         return describeMatch(tree);
       }
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/NearbyCallers.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/NearbyCallers.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.google.protobuf.GeneratedMessage;
+import com.google.protobuf.GeneratedMessageLite;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
+import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * Utility class to find calls "nearby" other calls.
+ *
+ * <p>TODO(glorioso): Coalesce this with ByteBufferBackingArray since they have similar aims?
+ */
+public class NearbyCallers {
+  private NearbyCallers() {}
+
+  // lifted from com.google.devtools.javatools.refactory.refaster.cleanups.proto.ProtoMatchers
+  private static final Matcher<ExpressionTree> IS_IMMUTABLE_PROTO_GETTER =
+      instanceMethod()
+          .onDescendantOfAny(GeneratedMessage.class.getName(), GeneratedMessageLite.class.getName())
+          .withNameMatching(Pattern.compile("get(?!CachedSize$|SerializedSize$).+"))
+          .withParameters();
+
+  /**
+   * Returns whether or not there is a call matching {@code secondaryMethodMatcher} with the same
+   * receiver as the method call represented by {@code primaryMethod} in "nearby" code.
+   *
+   * <p>This is generally used to ensure that developers calling {@code primaryMethod} should likely
+   * also be checking {@code secondaryMethodMatcher} (as a signal that they understand the
+   * edge-cases of {@code primaryMethod}).
+   *
+   * @param primaryMethod the tree that contains the primary method call (e.g.: what might have
+   *     weird edge-cases).
+   * @param secondaryMethodMatcher A matcher to identify the secondary method call (e.g.: that shows
+   *     a demonstration of the knowledge of the edge-cases in {@code primaryMethod})
+   * @param state the visitor state of this matcher
+   * @param checkProtoChains whether or not to check a chain of protobuf getter methods to see if
+   *     it's the 'same receiver' (e.g., {@code a.getB().getC().getSeconds()} and {@code
+   *     a.getB().getC().getNanos()}
+   */
+  static boolean containsCallToSameReceiverNearby(
+      MethodInvocationTree primaryMethod,
+      Matcher<ExpressionTree> secondaryMethodMatcher,
+      VisitorState state,
+      boolean checkProtoChains) {
+    ExpressionTree primaryMethodReceiver = ASTHelpers.getReceiver(primaryMethod);
+    TreeScanner<Boolean, Void> scanner =
+        new TreeScanner<Boolean, Void>() {
+          @Override
+          public Boolean reduce(Boolean r1, Boolean r2) {
+            return firstNonNull(r1, Boolean.FALSE) || firstNonNull(r2, Boolean.FALSE);
+          }
+
+          @Override
+          public Boolean visitLambdaExpression(LambdaExpressionTree node, Void unused) {
+            return false;
+          }
+
+          @Override
+          public Boolean visitMethodInvocation(MethodInvocationTree secondaryMethod, Void unused) {
+            if (super.visitMethodInvocation(secondaryMethod, unused)) {
+              return true;
+            }
+            if (secondaryMethod == null
+                || !secondaryMethodMatcher.matches(secondaryMethod, state)) {
+              return false;
+            }
+
+            ExpressionTree secondaryMethodReceiver = ASTHelpers.getReceiver(secondaryMethod);
+            if (secondaryMethodReceiver == null) {
+              return false;
+            }
+
+            // if the methods are being invoked directly on the same variable...
+            if (primaryMethodReceiver != null
+                && ASTHelpers.sameVariable(primaryMethodReceiver, secondaryMethodReceiver)) {
+              return true;
+            }
+
+            // If we're checking proto chains, look for the root variables and see if they're the
+            // same.
+            return checkProtoChains && protoChainsMatch(primaryMethod, secondaryMethod);
+          }
+
+          private boolean protoChainsMatch(
+              MethodInvocationTree primaryMethod, MethodInvocationTree secondaryMethod) {
+            ExpressionTree primaryRootAssignable = ASTHelpers.getRootAssignable(primaryMethod);
+            ExpressionTree secondaryRootAssignable = ASTHelpers.getRootAssignable(secondaryMethod);
+            if (primaryRootAssignable == null
+                || secondaryRootAssignable == null
+                || !ASTHelpers.sameVariable(primaryRootAssignable, secondaryRootAssignable)) {
+              return false;
+            }
+
+            // build up a list of method invocations for both invocations
+            return buildProtoGetterChain(primaryMethod, state)
+                .flatMap(
+                    primaryChain ->
+                        buildProtoGetterChain(secondaryMethod, state).map(primaryChain::equals))
+                .orElse(false);
+          }
+        };
+    ImmutableList<Tree> treesToScan = getNearbyTreesToScan(state);
+    return !treesToScan.isEmpty() && scanner.scan(treesToScan, null);
+  }
+
+  // Return the chain of receivers from expr (intended to be a MethodInvocation) so long
+  // as it's entirely composed of proto getters, followed by a terminal identifier, e.g.:
+  //
+  // FooProto x = ...;
+  // String value = x.getA().getB().getC().expr()
+  //
+  // the chain would be [getC(), getB(), getA(), x]
+  private static Optional<ImmutableList<Symbol>> buildProtoGetterChain(
+      ExpressionTree expr, VisitorState state) {
+    ImmutableList.Builder<Symbol> symbolChain = ImmutableList.builder();
+    while (expr instanceof JCMethodInvocation) {
+      expr = ((JCMethodInvocation) expr).getMethodSelect();
+      // if the method isn't an immutable protobuf getter, return false
+      if (!IS_IMMUTABLE_PROTO_GETTER.matches(expr, state)) {
+        return Optional.empty();
+      }
+      if (expr instanceof JCFieldAccess) {
+        expr = ((JCFieldAccess) expr).getExpression();
+      }
+      symbolChain.add(ASTHelpers.getSymbol(expr));
+    }
+    return Optional.of(symbolChain.build());
+  }
+
+  private static ImmutableList<Tree> getNearbyTreesToScan(VisitorState state) {
+    for (Tree parent : state.getPath()) {
+      switch (parent.getKind()) {
+        case BLOCK:
+          // if we reach a block tree, then _only_ scan that block
+          return ImmutableList.of(parent);
+
+        case LAMBDA_EXPRESSION:
+          // if we reach a lambda tree, then don't scan anything since we don't know where/when that
+          // lambda will actually be executed.
+          // TODO(glorioso): for simple expression lambdas, consider looking for use sites and scan
+          // *those* sites, but binding the lambda variable to its use site might be rough :(
+
+          // e.g.:
+          //   Function<Duration, Long> NANOS = d -> d.getNano();
+          //   Function<Duration, Long> SECONDS = d -> d.getSeconds();
+          //   ...
+          //   long nanos = NANOS.apply(myDuration) + SECONDS.apply(myDuration) * 1_000_000L;
+          //
+          // how do we track myDuration through both layers?
+          return ImmutableList.of();
+
+        case CLASS:
+          // if we get all the way up to the class tree, then _only_ scan the other class-level
+          // fields
+          ImmutableList.Builder<Tree> treesToScan = ImmutableList.builder();
+          for (Tree member : ((ClassTree) parent).getMembers()) {
+            if (member instanceof VariableTree) {
+              ExpressionTree expressionTree = ((VariableTree) member).getInitializer();
+              if (expressionTree != null) {
+                treesToScan.add(expressionTree);
+              }
+            }
+          }
+          return treesToScan.build();
+
+        default:
+          // fall out, continue searching up the tree
+      }
+    }
+    return ImmutableList.of();
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
@@ -337,6 +337,9 @@ public final class PreferJavaTimeOverload extends BugChecker
                 // Make sure we're not currently *inside* that overload, to avoid
                 // creating an infinite loop.
                 && !input.equals(enclosingMethod)
+                && !enclosingMethod.overrides(
+                    input, (TypeSymbol) input.owner, state.getTypes(), true)
+
                 // TODO(kak): Do we want to check return types too?
                 && input.isStatic() == calledMethod.isStatic()
                 && input.getParameters().size() == 1

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/ProtoDurationGetSecondsGetNano.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/ProtoDurationGetSecondsGetNano.java
@@ -16,7 +16,7 @@
 package com.google.errorprone.bugpatterns.time;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
-import static com.google.errorprone.bugpatterns.time.JavaDurationGetSecondsGetNano.containsGetSecondsCallInNearbyCode;
+import static com.google.errorprone.bugpatterns.time.NearbyCallers.containsCallToSameReceiverNearby;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 
 import com.google.errorprone.BugPattern;
@@ -53,8 +53,7 @@ public final class ProtoDurationGetSecondsGetNano extends BugChecker
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (GET_NANOS.matches(tree, state)) {
-      if (!containsGetSecondsCallInNearbyCode(
-          tree, state, GET_SECONDS, /*checkProtoChains=*/ true)) {
+      if (!containsCallToSameReceiverNearby(tree, GET_SECONDS, state, /*checkProtoChains=*/ true)) {
         return describeMatch(tree);
       }
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/ProtoTimestampGetSecondsGetNano.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/ProtoTimestampGetSecondsGetNano.java
@@ -16,7 +16,7 @@
 package com.google.errorprone.bugpatterns.time;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
-import static com.google.errorprone.bugpatterns.time.JavaDurationGetSecondsGetNano.containsGetSecondsCallInNearbyCode;
+import static com.google.errorprone.bugpatterns.time.NearbyCallers.containsCallToSameReceiverNearby;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 
 import com.google.errorprone.BugPattern;
@@ -53,8 +53,7 @@ public final class ProtoTimestampGetSecondsGetNano extends BugChecker
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (GET_NANOS.matches(tree, state)) {
-      if (!containsGetSecondsCallInNearbyCode(
-          tree, state, GET_SECONDS, /*checkProtoChains=*/ true)) {
+      if (!containsCallToSameReceiverNearby(tree, GET_SECONDS, state, /*checkProtoChains=*/ true)) {
         return describeMatch(tree);
       }
     }

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -314,6 +314,7 @@ import com.google.errorprone.bugpatterns.WaitNotInLoop;
 import com.google.errorprone.bugpatterns.WildcardImport;
 import com.google.errorprone.bugpatterns.WithSignatureDiscouraged;
 import com.google.errorprone.bugpatterns.WrongParameterPackage;
+import com.google.errorprone.bugpatterns.XorPower;
 import com.google.errorprone.bugpatterns.android.BinderIdentityRestoredDangerously;
 import com.google.errorprone.bugpatterns.android.BundleDeserializationCast;
 import com.google.errorprone.bugpatterns.android.FragmentInjection;
@@ -601,7 +602,8 @@ public class BuiltInCheckerSuppliers {
           UnnecessaryTypeArgument.class,
           UnusedAnonymousClass.class,
           UnusedCollectionModifiedInPlace.class,
-          VarTypeName.class);
+          VarTypeName.class,
+          XorPower.class);
 
   /** A list of all checks with severity WARNING that are on by default. */
   public static final ImmutableSet<BugCheckerInfo> ENABLED_WARNINGS =

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -269,6 +269,7 @@ import com.google.errorprone.bugpatterns.ThreadLocalUsage;
 import com.google.errorprone.bugpatterns.ThreeLetterTimeZoneID;
 import com.google.errorprone.bugpatterns.ThrowIfUncheckedKnownChecked;
 import com.google.errorprone.bugpatterns.ThrowNull;
+import com.google.errorprone.bugpatterns.ThrowSpecificExceptions;
 import com.google.errorprone.bugpatterns.ThrowsUncheckedException;
 import com.google.errorprone.bugpatterns.ToStringReturnsNull;
 import com.google.errorprone.bugpatterns.TreeToString;
@@ -804,20 +805,18 @@ public class BuiltInCheckerSuppliers {
           ImmutableRefactoring.class,
           ImplementAssertionWithChaining.class,
           InconsistentOverloads.class,
+          InheritDoc.class,
           InjectedConstructorAnnotations.class,
           InsecureCipherMode.class,
           InterfaceWithOnlyStatics.class,
-          InvalidTargetingOnScopingAnnotation.class,
-          IterablePathParameter.class,
-          JMockTestWithoutRunWithOrRuleAnnotation.class,
-          Java7ApiChecker.class,
-          InheritDoc.class,
           InvalidBlockTag.class,
           InvalidInlineTag.class,
           InvalidParam.class,
-          RedundantOverride.class,
-          ReturnFromVoid.class,
+          InvalidTargetingOnScopingAnnotation.class,
           InvalidThrows.class,
+          IterablePathParameter.class,
+          JMockTestWithoutRunWithOrRuleAnnotation.class,
+          Java7ApiChecker.class,
           JavaxInjectOnFinalField.class,
           LambdaFunctionalInterface.class,
           LockMethodChecker.class,
@@ -845,8 +844,10 @@ public class BuiltInCheckerSuppliers {
           ProtosAsKeyOfSetOrMap.class,
           ProvidesFixChecker.class,
           QualifierWithTypeUse.class,
+          RedundantOverride.class,
           RedundantThrows.class,
           RemoveUnusedImports.class,
+          ReturnFromVoid.class,
           ReturnMissingNullable.class,
           ScopeAnnotationOnInterfaceOrAbstractClass.class,
           ScopeOnModule.class,
@@ -858,6 +859,7 @@ public class BuiltInCheckerSuppliers {
           SystemExitOutsideMain.class,
           TestExceptionChecker.class,
           TestExceptionRefactoring.class,
+          ThrowSpecificExceptions.class,
           ThrowsUncheckedException.class,
           TimeUnitMismatch.class,
           TryFailRefactoring.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -103,6 +103,7 @@ import com.google.errorprone.bugpatterns.EqualsWrongThing;
 import com.google.errorprone.bugpatterns.ExpectedExceptionChecker;
 import com.google.errorprone.bugpatterns.ExpectedExceptionRefactoring;
 import com.google.errorprone.bugpatterns.ExtendingJUnitAssert;
+import com.google.errorprone.bugpatterns.ExtendsAutoValue;
 import com.google.errorprone.bugpatterns.FallThrough;
 import com.google.errorprone.bugpatterns.FieldCanBeFinal;
 import com.google.errorprone.bugpatterns.FieldCanBeLocal;
@@ -645,6 +646,7 @@ public class BuiltInCheckerSuppliers {
           EqualsUnsafeCast.class,
           EqualsUsingHashCode.class,
           ExtendingJUnitAssert.class,
+          ExtendsAutoValue.class,
           FallThrough.class,
           Finally.class,
           FloatCast.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ExtendsAutoValueTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ExtendsAutoValueTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.util.RuntimeVersion;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ExtendsAutoValue}. */
+@RunWith(JUnit4.class)
+public class ExtendsAutoValueTest {
+
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(ExtendsAutoValue.class, getClass());
+
+  @Test
+  public void extendsAutoValue_GoodNoSuperclass() throws Exception {
+    helper.addSourceLines("TestClass.java", "public class TestClass {}").doTest();
+  }
+
+  @Test
+  public void extendsAutoValue_GoodSuperclass() throws Exception {
+    helper
+        .addSourceLines(
+            "TestClass.java", "class SuperClass {}", "public class TestClass extends SuperClass {}")
+        .doTest();
+  }
+
+  @Test
+  public void extendsAutoValue_GoodAutoValueExtendsSuperclass() throws Exception {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import com.google.auto.value.AutoValue;",
+            "public class TestClass {}",
+            "@AutoValue class AutoClass extends TestClass {}")
+        .doTest();
+  }
+
+  @Test
+  public void extendsAutoValue_GoodGeneratedIgnored() throws Exception {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import com.google.auto.value.AutoValue;",
+            (RuntimeVersion.isAtLeast9()
+                ? "import javax.annotation.processing.Generated;"
+                : "import javax.annotation.Generated;"),
+            "@AutoValue class AutoClass {}",
+            "@Generated(value=\"hi\") public class TestClass extends AutoClass {}")
+        .doTest();
+  }
+
+  @Test
+  public void extendsAutoValue_Bad() throws Exception {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import com.google.auto.value.AutoValue;",
+            "@AutoValue class AutoClass {}",
+            "// BUG: Diagnostic contains: ExtendsAutoValue",
+            "public class TestClass extends AutoClass {}")
+        .doTest();
+  }
+
+  @Test
+  public void extendsAutoValue_BadNoImport() throws Exception {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "@com.google.auto.value.AutoValue class AutoClass {}",
+            "// BUG: Diagnostic contains: ExtendsAutoValue",
+            "public class TestClass extends AutoClass {}")
+        .doTest();
+  }
+
+  @Test
+  public void extendsAutoValue_BadInnerClass() throws Exception {
+    helper
+        .addSourceLines(
+            "OuterClass.java",
+            "import com.google.auto.value.AutoValue;",
+            "public class OuterClass { ",
+            "  @AutoValue class AutoClass {}",
+            "  // BUG: Diagnostic contains: ExtendsAutoValue",
+            "  class TestClass extends AutoClass {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void extendsAutoValue_BadInnerStaticClass() throws Exception {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import com.google.auto.value.AutoValue;",
+            "class OuterClass { ",
+            "  @AutoValue static class AutoClass {}",
+            "}",
+            "// BUG: Diagnostic contains: ExtendsAutoValue",
+            "public class TestClass extends OuterClass.AutoClass {}")
+        .doTest();
+  }
+
+  @Test
+  public void extendsAutoValue_BadButSuppressed() throws Exception {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import com.google.auto.value.AutoValue;",
+            "@AutoValue class AutoClass {}",
+            "@SuppressWarnings(\"ExtendsAutoValue\")",
+            "public class TestClass extends AutoClass {}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ThrowSpecificExceptionsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ThrowSpecificExceptionsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ThrowSpecificExceptions}. */
+@RunWith(JUnit4.class)
+public final class ThrowSpecificExceptionsTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(ThrowSpecificExceptions.class, getClass());
+
+  @Test
+  public void positive() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "public class Test {",
+            "  void test() {",
+            "    // BUG: Diagnostic contains: new IllegalStateException",
+            "    throw new RuntimeException();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void anonymousClass() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "public class Test {",
+            "  void test() {",
+            "    throw new RuntimeException() {};",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "public class Test {",
+            "  void test() {",
+            "    throw new IllegalStateException();",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedNestedClassTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedNestedClassTest.java
@@ -56,7 +56,7 @@ public class UnusedNestedClassTest {
   public void usedWithinSelf_warning() {
     compilationHelper
         .addSourceLines(
-            "Test.java", //
+            "Test.java",
             "class A {",
             "  // BUG: Diagnostic contains:",
             "  private static class B {",
@@ -70,7 +70,7 @@ public class UnusedNestedClassTest {
   public void usedOutsideSelf_noWarning() {
     compilationHelper
         .addSourceLines(
-            "Test.java", //
+            "Test.java",
             "class A {",
             "  private static final B b = new B();",
             "  private static class B {}",
@@ -82,7 +82,7 @@ public class UnusedNestedClassTest {
   public void usedOutsideSelf_oddQualification_noWarning() {
     compilationHelper
         .addSourceLines(
-            "Test.java", //
+            "Test.java",
             "class A {",
             "  public static final Object b = new A.B();",
             "  private static class B {}",
@@ -94,13 +94,14 @@ public class UnusedNestedClassTest {
   public void suppression() {
     compilationHelper
         .addSourceLines(
-            "Test.java", //
+            "Test.java",
             "class A {",
             "  @SuppressWarnings(\"unused\")",
             "  private class B {}",
             "}")
         .doTest();
   }
+
 
   @Test
   public void refactoring() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/XorPowerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/XorPowerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** {@link XorPower}Test */
+@RunWith(JUnit4.class)
+public class XorPowerTest {
+  @Test
+  public void positive() {
+    BugCheckerRefactoringTestHelper.newInstance(new XorPower(), getClass())
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  static final int X = 2 ^ 16;",
+            "  static final int Y = 2 ^ 32;",
+            "  static final int Z = 2 ^ 31;",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "class Test {",
+            "  static final int X = 1 << 16;",
+            "  static final int Y = 2 ^ 32;",
+            "  static final int Z = 1 << 31;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative() {
+    CompilationTestHelper.newInstance(XorPower.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  static final int X = 2 ^ 0x16;",
+            "  // BUG: Diagnostic contains:",
+            "  static final int Y = 2 ^ 32;",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverloadTest.java
@@ -278,6 +278,24 @@ public class PreferJavaTimeOverloadTest {
   }
 
   @Test
+  public void callingJodaDurationMethodWithSupertypeJavaDurationOverload() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "public class TestClass extends SuperClass {",
+            "  @Override",
+            "  public void bar(java.time.Duration d) {",
+            "    bar(org.joda.time.Duration.standardSeconds(d.getSeconds()));",
+            "  }",
+            "  public void bar(org.joda.time.Duration jodaDuration) {}",
+            "}",
+            "class SuperClass {",
+            "  public void bar(java.time.Duration d) {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void callingJodaReadableDurationMethodWithDurationOverload_privateMethod() {
     helper
         .addSourceLines(

--- a/docs/bugpattern/XorPower.md
+++ b/docs/bugpattern/XorPower.md
@@ -1,0 +1,4 @@
+The `^` binary XOR operator is sometimes mistaken for a power operator, but e.g.
+`2 ^ 10` evaluates to `0`, not `4`.
+
+Consider expressing powers of `2` using a bit shift instead.

--- a/docs/bugpattern/XorPower.md
+++ b/docs/bugpattern/XorPower.md
@@ -1,4 +1,4 @@
 The `^` binary XOR operator is sometimes mistaken for a power operator, but e.g.
-`2 ^ 10` evaluates to `0`, not `4`.
+`2 ^ 2` evaluates to `0`, not `4`.
 
 Consider expressing powers of `2` using a bit shift instead.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add bugpattern (to JavaCodeClarity) to encourage treating RuntimeException et al as abstract.

b21ed7d5c754160a8865d149f0ee4b3d6f0b018e

-------

<p> SuggestedFixes.compilesWithFix: check that extraOptions is empty before fast-returning, because the extra options may affect compilation.

a4f28dda5c214b6cb2ff3862b818f7876a87120b

-------

<p> ExtendsAutoValue: Makes it illegal to extend an @AutoValue class.

RELNOTES=ExtendsAutoValue: Makes it illegal to extend an @AutoValue class.

8987fa34d8cc9c39b888c8b3339ac8a42668adac

-------

<p> Refactor out "nearby code" method in anticipation of using it for more checks
relating to Period.

RELNOTES: n/a

00381a4590501256d4794233cb1aee66f9a3347a

-------

<p> UnusedNestedClass: obey @UsedReflectively

7738ee25b9b6cd93858751db7081742b8f7f9e26

-------

<p> PreferJavaTimeOverload - avoid suggesting an infinite recursion when the method call is inside an override of a method that accepts the java.time object.

RELNOTES: n/a

73e9456b3771c3e63dafeac01d813796b04cfb7a

-------

<p> Add a check for accidental use of ^

i.e. 2 ^ 16 is not 65536

46a2c8acc1785124423e2926be7be9bfb6148c19

-------

<p> Fix a typo

66b9d831ab0db93f5b45a9d1676de4ad533981f7

-------

<p> DoNotCall: allow static non-final methods to have the annotation.

2b8ab0a9da27c6d2f46490bece4edb6da400a66e

-------

<p> PrivateConstructorForUtilityClass: rephrase description a bit to include main classes.

Drive-by modernise the Java a bit.

b2c39075b445b5fbc303065605e64c62352fb9f3