### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -1847,9 +1847,10 @@ public class ASTHelpers {
    * aren't containing in a package, unlike {@link Symbol#outermostClass} (see b/123431414).
    */
   // TODO(b/123431414): fix javac and use Symbol.outermostClass insteads
+  @Nullable
   public static ClassSymbol outermostClass(Symbol symbol) {
     ClassSymbol curr = symbol.enclClass();
-    while (curr.owner != null) {
+    while (curr != null && curr.owner != null) {
       ClassSymbol encl = curr.owner.enclClass();
       if (encl == null) {
         break;

--- a/core/src/test/java/com/google/errorprone/util/ASTHelpersTest.java
+++ b/core/src/test/java/com/google/errorprone/util/ASTHelpersTest.java
@@ -1240,4 +1240,30 @@ public class ASTHelpersTest extends CompilerBasedAbstractTest {
     tests.add(scanner);
     assertCompiles(scanner);
   }
+
+  @Test
+  public void testOutermostclass_dotClass() {
+    writeFile(
+        "Foo.java",
+        "class Foo {",
+        "  void f() {",
+        "    Object unused = boolean.class;",
+        "  }",
+        "}");
+
+    TestScanner scanner =
+        new TestScanner() {
+          @Override
+          public Void visitMemberSelect(MemberSelectTree tree, VisitorState state) {
+            Symbol targetSymbol = ASTHelpers.getSymbol(tree);
+            // ASTHelpers#outermostClass shouldn't itself NPE
+            assertThat(ASTHelpers.outermostClass(targetSymbol)).isNull();
+            setAssertionsComplete();
+            return super.visitMemberSelect(tree, state);
+          }
+        };
+    tests.add(scanner);
+
+    assertCompiles(scanner);
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Avoid NPEing on symbols which have no enclosing class

See also b/123431414, which is about symbols with no enclosing package.

0f1c1a8b73f7f3e5749a05c7c6a29db281b93543