### PR TITLE
Moe Sync

### DIFF
--- a/annotation/src/main/java/com/google/errorprone/BugPattern.java
+++ b/annotation/src/main/java/com/google/errorprone/BugPattern.java
@@ -127,12 +127,13 @@ public @interface BugPattern {
   String[] tags() default {};
 
   /** Whether and what type of fix this check provides. */
-  ProvidesFix providesFix() default ProvidesFix.NO_FIX;
+  ProvidesFix providesFix() default ProvidesFix.UNSPECIFIED;
 
   /** Types of fixes BugCheckers can provide. */
   public enum ProvidesFix {
     NO_FIX("No"),
-    REQUIRES_HUMAN_ATTENTION("Yes, requires human attention");
+    REQUIRES_HUMAN_ATTENTION("Yes, requires human attention"),
+    UNSPECIFIED("");
 
     private final String displayInfo;
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
@@ -63,6 +63,7 @@ import com.sun.tools.javac.util.Name;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 /** This check suggests the use of {@code java.time}-based APIs, when available. */
 @BugPattern(
@@ -327,7 +328,7 @@ public final class PreferJavaTimeOverload extends BugChecker
     }
 
     MethodTree t = state.findEnclosing(MethodTree.class);
-    MethodSymbol enclosingMethod = t == null ? null : ASTHelpers.getSymbol(t);
+    @Nullable MethodSymbol enclosingMethod = t == null ? null : ASTHelpers.getSymbol(t);
 
     Type type = state.getTypeFromString(typeName);
     return hasMatchingMethods(
@@ -337,8 +338,9 @@ public final class PreferJavaTimeOverload extends BugChecker
                 // Make sure we're not currently *inside* that overload, to avoid
                 // creating an infinite loop.
                 && !input.equals(enclosingMethod)
-                && !enclosingMethod.overrides(
-                    input, (TypeSymbol) input.owner, state.getTypes(), true)
+                && (enclosingMethod == null
+                    || !enclosingMethod.overrides(
+                        input, (TypeSymbol) input.owner, state.getTypes(), true))
 
                 // TODO(kak): Do we want to check return types too?
                 && input.isStatic() == calledMethod.isStatic()

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverloadTest.java
@@ -330,6 +330,24 @@ public class PreferJavaTimeOverloadTest {
   }
 
   @Test
+  public void callingPrimitiveOverloadFromFieldInitializer() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "public class TestClass {",
+            "  static {",
+            "    // BUG: Diagnostic contains: call bar(Duration) instead",
+            "    bar(42);",
+            "  }",
+            "  private static void bar(java.time.Duration d) {",
+            "  }",
+            "  private static void bar(long d) {",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void callingNumericPrimitiveMethodWithDurationOverload() {
     helper
         .addSourceLines(

--- a/docgen/src/main/java/com/google/errorprone/BugPatternFileGenerator.java
+++ b/docgen/src/main/java/com/google/errorprone/BugPatternFileGenerator.java
@@ -175,7 +175,6 @@ class BugPatternFileGenerator implements LineProcessor<List<BugPatternInstance>>
           ImmutableMap.<String, Object>builder()
               .put("tags", Joiner.on(", ").join(pattern.tags))
               .put("severity", pattern.severity)
-              .put("providesFix", pattern.providesFix.displayInfo())
               .put("name", pattern.name)
               .put("className", pattern.className)
               .put("summary", pattern.summary.trim())
@@ -194,7 +193,6 @@ class BugPatternFileGenerator implements LineProcessor<List<BugPatternInstance>>
                 .put("layout", "bugpattern")
                 .put("tags", Joiner.on(", ").join(pattern.tags))
                 .put("severity", pattern.severity.toString())
-                .put("providesFix", pattern.providesFix.toString())
                 .build();
         DumperOptions options = new DumperOptions();
         options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);

--- a/docgen/src/main/java/com/google/errorprone/resources/bugpattern.mustache
+++ b/docgen/src/main/java/com/google/errorprone/resources/bugpattern.mustache
@@ -21,9 +21,6 @@ __{{summary}}__
 {{#tags}}
 <tr><td>Tags</td><td>{{tags}}</td></tr>
 {{/tags}}
-{{#providesFix}}
-<tr><td>Provides Fix?</td><td>{{providesFix}}</td></tr>
-{{/providesFix}}
 <div class=".more-info" data-qualified-name={{className}}></div>
 </table></div>
 

--- a/docgen/src/test/java/com/google/errorprone/BugPatternFileGeneratorTest.java
+++ b/docgen/src/test/java/com/google/errorprone/BugPatternFileGeneratorTest.java
@@ -20,7 +20,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.io.CharStreams;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.gson.Gson;
 import java.io.InputStreamReader;
@@ -68,7 +67,6 @@ public class BugPatternFileGeneratorTest {
     instance.tags = new String[] {"LikelyError"};
     instance.severity = SeverityLevel.ERROR;
     instance.suppressionAnnotations = new String[] {"java.lang.SuppressWarnings.class"};
-    instance.providesFix = ProvidesFix.NO_FIX;
     return instance;
   }
 
@@ -166,7 +164,6 @@ public class BugPatternFileGeneratorTest {
     instance.tags = new String[] {"LikelyError"};
     instance.severity = SeverityLevel.ERROR;
     instance.suppressionAnnotations = new String[] {"java.lang.SuppressWarnings.class"};
-    instance.providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 
     // Write markdown file
     BugPatternFileGenerator generator =

--- a/docgen/src/test/java/com/google/errorprone/testdata/DeadException_frontmatter_pygments.md
+++ b/docgen/src/test/java/com/google/errorprone/testdata/DeadException_frontmatter_pygments.md
@@ -4,7 +4,6 @@ summary: Exception created but not thrown
 layout: bugpattern
 tags: LikelyError
 severity: ERROR
-providesFix: NO_FIX
 ---
 
 <!--

--- a/docgen/src/test/java/com/google/errorprone/testdata/DeadException_nofrontmatter_gfm.md
+++ b/docgen/src/test/java/com/google/errorprone/testdata/DeadException_nofrontmatter_gfm.md
@@ -10,7 +10,6 @@ __Exception created but not thrown__
 <div style="float:right;"><table id="metadata">
 <tr><td>Severity</td><td>ERROR</td></tr>
 <tr><td>Tags</td><td>LikelyError</td></tr>
-<tr><td>Provides Fix?</td><td>No</td></tr>
 <div class=".more-info" data-qualified-name=com.google.errorprone.bugpatterns.DeadException></div>
 </table></div>
 

--- a/docgen/src/test/java/com/google/errorprone/testdata/DontDoThis_nofrontmatter_gfm.md
+++ b/docgen/src/test/java/com/google/errorprone/testdata/DontDoThis_nofrontmatter_gfm.md
@@ -10,7 +10,6 @@ __Don&#39;t do this; do List&lt;Foo&gt; instead__
 <div style="float:right;"><table id="metadata">
 <tr><td>Severity</td><td>ERROR</td></tr>
 <tr><td>Tags</td><td>LikelyError</td></tr>
-<tr><td>Provides Fix?</td><td>Yes, requires human attention</td></tr>
 <div class=".more-info" data-qualified-name=com.google.errorprone.bugpatterns.DontDoThis></div>
 </table></div>
 

--- a/docgen_processor/src/main/java/com/google/errorprone/BugPatternInstance.java
+++ b/docgen_processor/src/main/java/com/google/errorprone/BugPatternInstance.java
@@ -17,7 +17,6 @@
 package com.google.errorprone;
 
 import com.google.common.base.Preconditions;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -41,7 +40,6 @@ public final class BugPatternInstance {
   public String[] suppressionAnnotations;
   public boolean documentSuppression = true;
   public boolean generateExamplesFromTestCases = true;
-  public ProvidesFix providesFix;
 
   public static BugPatternInstance fromElement(Element element) {
     BugPatternInstance instance = new BugPatternInstance();
@@ -55,7 +53,6 @@ public final class BugPatternInstance {
     instance.summary = annotation.summary();
     instance.explanation = annotation.explanation();
     instance.documentSuppression = annotation.documentSuppression();
-    instance.providesFix = annotation.providesFix();
 
     Map<String, Object> keyValues = getAnnotation(element, BugPattern.class.getName());
     Object suppression = keyValues.get("suppressionAnnotations");

--- a/docs/bugpattern/ProvidesFix.md
+++ b/docs/bugpattern/ProvidesFix.md
@@ -1,14 +1,17 @@
-We use the [`providesFix`][annotation] field of `@BugPattern` to keep track of
-whether Error Prone bug checkers suggest a fix to the bug, or just point out the
-presence of an antipattern. There are two different possible values: the default
-being `NO_FIX` for if we do not supply a refactoring, and
-`REQUIRES_HUMAN_ATTENTION`[^1] for when we do.
+**ProvidesFix is now disabled by default, but you may choose to re-enable it for
+your own BugCheckers with `-Xep:ProvidesFix:{WARN,ERROR}`.**
 
-The ProvidesFixChecker helps keep these values updated. It verifies that bug
+The [`providesFix`][annotation] field of `@BugPattern` was intended to keep
+track of whether Error Prone bug checkers suggest a fix to the bug, or just
+point out the presence of an antipattern. The default value is `UNSPECIFIED`,
+and there are two meaningful values: `NO_FIX` for when we do not supply a
+refactoring, and `REQUIRES_HUMAN_ATTENTION`[^1] for when we do.
+
+ProvidesFixChecker helps keep these values updated. It verifies that bug
 checkers do not return a description that includes a fix without setting
 `providesFix = REQUIRES_HUMAN_ATTENTION`.
 
-Note: this checker will have false negatives -- we cannot detect the **absence**
+Note: this checker will have false negatives -- we cannot detect the *absence*
 of a fix. So please keep this field updated to the best of your knowledge :)
 
 [annotation]: https://github.com/google/error-prone/blob/4d7b19f3cb7b46a931856b0c3ca8b1f37c57508f/annotation/src/main/java/com/google/errorprone/BugPattern.java#L129-L135


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Disable ProvidesFixChecker
- Change default providesFix value to UNSPECIFIED
- Delete documentation of providesFix from doc generation
- Update ProvidesFix.md to mention its deprecation

To follow: consider deprecating the providesFix field

This will require a JavaBuilder release and a docgen mpm push to take full effect.

d6855a0263e4e271993c6e2cfcf9712d4e4b5612

-------

<p> Fix bug in PreferJavaTimeOverload when the invocation is performed in a field initializer or static block.

b554cd24ac57f9e48f93bca79f6f9d87e925591f