### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ReturnValueIgnored.java
@@ -91,7 +91,7 @@ public class ReturnValueIgnored extends AbstractReturnValueIgnored {
           staticMethod().onClass("java.time.ZoneId").named("ofOffset"),
           instanceMethod()
               .onExactClass("java.time.format.DateTimeFormatterBuilder")
-              .withNameMatching(Pattern.compile("^append.*")),
+              .withNameMatching(Pattern.compile("^(append|parse|pad|optional).*")),
           instanceMethod()
               .onExactClass("java.time.temporal.ChronoField")
               .named("checkValidIntValue"),

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ReturnValueIgnoredTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ReturnValueIgnoredTest.java
@@ -146,6 +146,26 @@ public class ReturnValueIgnoredTest {
   }
 
   @Test
+  public void issue1363_dateTimeFormatterBuilder() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.time.format.DateTimeFormatterBuilder;",
+            "class Test {",
+            "  void f() {",
+            "    DateTimeFormatterBuilder formatter = new DateTimeFormatterBuilder();",
+            "    formatter.appendZoneId();",
+            "    formatter.optionalEnd();",
+            "    formatter.padNext(5);",
+            "    formatter.parseCaseSensitive();",
+            "    // BUG: Diagnostic contains: ReturnValueIgnored",
+            "    formatter.toFormatter();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void issue876() {
     compilationHelper
         .addSourceLines(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Allow the return value to be ignored for the following methods on DateTimeFormatterBuilder:
  parse*()
  pad*()
  optional*()

(In addition to append*() which was already allowed.)

Fixes https://github.com/google/error-prone/issues/1363

6ba35488dee97693cb1a4934625f629d2afa937d