### PR TITLE
Moe Sync

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -53,6 +53,16 @@
           <target>1.7</target>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.google.errorprone.annotations</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Set Automatic-Module-Name for annotations package.

This makes it practical to use from code that uses modules.

Compare to Guava:
https://github.com/google/guava/blob/5496c37d4d904869297c2ced1f0d20e6f1507eaa/guava/pom.xml#L60
https://github.com/google/guava/issues/2920

This is a step toward https://github.com/google/error-prone/issues/1116 (though it doesn't address most artifacts, including javac).

Modules users may still see problems because com.google.errorprone.annotations is split between error_prone_annotations and error_prone_type_annotations. I wonder if the best solution to that is going to be to merge the two into error_prone_annotations, turning error_prone_type_annotations into an empty "forwarding" artifact. That would require compiling some files for Java 7 and some for Java 8, but that's doable (if a little clumsy). It might cause problems from some tool somewhere, though. Given that error_prone_type_annotations isn't nearly as commonly used, maybe you can wait it out until it's time to drop Java 7 support?

In any case, I don't think this CL makes things any worse.

RELNOTES=Set Automatic-Module-Name for annotations package.

d6d9078a30cee9df38472178bb7d7f2321bdf84b