### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaPeriodGetDays.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaPeriodGetDays.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.bugpatterns.time.NearbyCallers.containsCallToSameReceiverNearby;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+
+/**
+ * This checker warns about calls to {@code period.getDays()} without a corresponding "nearby" call
+ * to {@code period.getYears(), period.getMonths(), or period.getTotalMonths()}.
+ *
+ * @author glorioso@google.com (Nick Glorioso)
+ */
+@BugPattern(
+    name = "JavaPeriodGetDays",
+    summary =
+        "period.getDays() only accesses the \"days\" portion of the Period, and doesn't represent"
+            + " the total span of time of the period. Consider using org.threeten.extra.Days to"
+            + " extract the difference between two civil dates if you want the whole time.",
+    severity = WARNING)
+public final class JavaPeriodGetDays extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private static final Matcher<ExpressionTree> PERIOD_LOOK_AT_OTHERS =
+      instanceMethod()
+          .onExactClass("java.time.Period")
+          .namedAnyOf("getMonths", "getYears", "getTotalMonths");
+  private static final Matcher<ExpressionTree> PERIOD_GET_DAYS =
+      allOf(
+          instanceMethod().onExactClass("java.time.Period").named("getDays"),
+          Matchers.not(Matchers.packageStartsWith("java.")));
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (PERIOD_GET_DAYS.matches(tree, state)) {
+      if (!containsCallToSameReceiverNearby(
+          tree, PERIOD_LOOK_AT_OTHERS, state, /*checkProtoChains=*/ false)) {
+        return describeMatch(tree);
+      }
+    }
+    return Description.NO_MATCH;
+  }
+
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -406,6 +406,7 @@ import com.google.errorprone.bugpatterns.time.JavaDurationGetSecondsGetNano;
 import com.google.errorprone.bugpatterns.time.JavaDurationWithNanos;
 import com.google.errorprone.bugpatterns.time.JavaDurationWithSeconds;
 import com.google.errorprone.bugpatterns.time.JavaInstantGetSecondsGetNano;
+import com.google.errorprone.bugpatterns.time.JavaPeriodGetDays;
 import com.google.errorprone.bugpatterns.time.JavaTimeDefaultTimeZone;
 import com.google.errorprone.bugpatterns.time.JodaDurationConstructor;
 import com.google.errorprone.bugpatterns.time.JodaDurationWithMillis;
@@ -675,6 +676,7 @@ public class BuiltInCheckerSuppliers {
           JavaInstantGetSecondsGetNano.class,
           JavaTimeDefaultTimeZone.class,
           JavaLangClash.class,
+          JavaPeriodGetDays.class,
           JdkObsolete.class,
           JodaDurationConstructor.class,
           JodaDurationWithMillis.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/JavaPeriodGetDaysTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/JavaPeriodGetDaysTest.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static org.junit.Assume.assumeFalse;
+
+import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.util.RuntimeVersion;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link JavaPeriodGetDays}.
+ *
+ * @author kak@google.com (Kurt Alfred Kluever)
+ */
+@RunWith(JUnit4.class)
+public class JavaPeriodGetDaysTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setUp() {
+    compilationHelper = CompilationTestHelper.newInstance(JavaPeriodGetDays.class, getClass());
+  }
+
+  @Test
+  public void getBoth() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  public static void foo(Period period) {",
+            "    int days = period.getDays();",
+            "    int months = period.getMonths();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getDaysInReturn() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  public static int foo(Period period) {",
+            "    // BUG: Diagnostic contains: JavaPeriodGetDays",
+            "    return period.getDays();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getDaysInReturnWithConsultingMonths() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import com.google.common.collect.ImmutableMap;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  public static ImmutableMap<String, Object> foo(Period period) {",
+            "    return ImmutableMap.of(",
+            "        \"months\", period.getMonths(), \"days\", period.getDays());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getDaysWithMonthsInDifferentScope() {
+    // Ideally we would also catch cases like this, but it requires scanning "too much" of the class
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  public static void foo(Period period) {",
+            "    long months = period.getMonths();",
+            "    if (true) {",
+            "      // BUG: Diagnostic contains: JavaPeriodGetDays",
+            "      int days = period.getDays();",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getDaysAndGetMonthsInDifferentMethods() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  public static void foo(Period period) {",
+            "    long months = period.getMonths();",
+            "  }",
+            "  public static void bar(Period period) {",
+            "    // BUG: Diagnostic contains: JavaPeriodGetDays",
+            "    int days = period.getDays();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getMonths() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  public static void foo(Period period) {",
+            "    long months = period.getMonths();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getDaysOnly() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  public static void foo(Period period) {",
+            "    // BUG: Diagnostic contains: JavaPeriodGetDays",
+            "    int days = period.getDays();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getMonthsInVariableDetachedFromDays() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  private static final Period PERIOD = Period.ZERO;",
+            "  private static final long months = PERIOD.getMonths();",
+            "  public static void foo() {",
+            "    // BUG: Diagnostic contains: JavaPeriodGetDays",
+            "    int days = PERIOD.getDays();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getMonthsInStaticBlock() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  static {",
+            "    long months = Period.ZERO.getMonths();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getDaysInStaticBlock() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  static {",
+            "    // BUG: Diagnostic contains: JavaPeriodGetDays",
+            "    int days = Period.ZERO.getDays();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getDaysAndMonthsInParallelInitializers() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  private final long months = Period.ZERO.getMonths();",
+            "  private final int days = Period.ZERO.getDays();",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getDaysInFieldInitializer() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  // BUG: Diagnostic contains: JavaPeriodGetDays",
+            "  private final int days = Period.ZERO.getDays();",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getDaysInInnerClass() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  private static final Period PERIOD = Period.ZERO;",
+            "  public static void foo() {",
+            "    long months = PERIOD.getMonths();",
+            "    Object obj = new Object() {",
+            "      @Override public String toString() {",
+            "        // BUG: Diagnostic contains: JavaPeriodGetDays",
+            "        return String.valueOf(PERIOD.getDays()); ",
+            "      }",
+            "    };",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getDaysInInnerClassField() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  Period PERIOD = Period.ZERO;",
+            "  long months = PERIOD.getMonths();",
+            "  Object obj = new Object() {",
+            "    // BUG: Diagnostic contains: JavaPeriodGetDays",
+            "    long days = PERIOD.getDays();",
+            "  };",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getDaysWithMonthInLambdaContext() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  private static final Period PERIOD = Period.ZERO;",
+            "  public static void foo() {",
+            "    Runnable r = () -> PERIOD.getMonths();",
+            "    // BUG: Diagnostic contains: JavaPeriodGetDays",
+            "    int days = PERIOD.getDays();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getDaysWithMonthInMethodArgumentLambda() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "import java.util.function.Supplier;",
+            "public class TestCase {",
+            "  private static final Period PERIOD = Period.ZERO;",
+            "  public void foo() {",
+            "    doSomething(() -> PERIOD.getMonths());",
+            "    // BUG: Diagnostic contains: JavaPeriodGetDays",
+            "    int days = PERIOD.getDays();",
+            "  }",
+            "  public void doSomething(Supplier<Integer> supplier) {",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getDaysInLambdaWithMonthOutside() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.Period;",
+            "public class TestCase {",
+            "  private static final Period PERIOD = Period.ZERO;",
+            "  public static void foo() {",
+            "    // BUG: Diagnostic contains: JavaPeriodGetDays",
+            "    Runnable r = () -> PERIOD.getDays();",
+            "    long months = PERIOD.getMonths();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testByJavaTime() {
+    assumeFalse(RuntimeVersion.isAtLeast9());
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package java.time;",
+            "public class TestCase {",
+            "  private static final Period PERIOD = Period.ZERO;",
+            "  public static void foo() {",
+            "    int nanos = PERIOD.getDays();",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/docs/bugpattern/time/JavaPeriodGetDays.md
+++ b/docs/bugpattern/time/JavaPeriodGetDays.md
@@ -1,0 +1,29 @@
+A `java.time.Period` represents a distance of civil time in years, months, and
+days. For example, a period could represent "1 month, 2 days", or another period
+could represent "32 days".
+
+The method `Period.getDays()` only extracts the "days" portion of the Period, so
+a period representing "1 month, 2 days" would return 2 from its `getDays()`.
+
+In many circumstances, developers use `period.getDays()` when they think it
+represents "the total days" in the period, especially when the Period is
+computed using `LocalDate.until(LocalDate)`.
+
+In this instance, a developer has used `period.getDays()` without consulting
+either the `months` or `years` portion of the Period. In all likelihood, the
+developer would be better suited by using
+`org.threeten.extra.Days.between(LocalDate, LocalDate)` to compute the number of
+days between two dates.
+
+For example:
+
+```java
+LocalDate day1, day2; ...
+if (day1.until(day2).getDays() > 31) { // No more than 31 days between them
+  // Oops, this is always false, even if day1 is 4 "months" behind
+}
+
+if (Days.between(day1, day2).compareTo(Days.of(31)) > 0) {
+  // Can actually be executed!
+}
+```


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a new check for using Period.getDays() without checking for months or years.

RELNOTES: New check - JavaPeriodGetDays detects calls to Period.getDays() without consulting getMonths() or getYears()

facd2fcdf69748d1cf6598546cb3b12b9b02a669