### PR TITLE
Moe Sync

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -957,7 +957,8 @@ public class ASTHelpers {
 
   /** Return the enclosing {@code ClassSymbol} of the given symbol, or {@code null}. */
   public static ClassSymbol enclosingClass(Symbol sym) {
-    return sym.owner.enclClass();
+    // sym.owner is null in the case of module symbols.
+    return sym.owner == null ? null : sym.owner.enclClass();
   }
 
   /** Return the enclosing {@code PackageSymbol} of the given symbol, or {@code null}. */

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedNestedClassTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedNestedClassTest.java
@@ -16,9 +16,12 @@
 
 package com.google.errorprone.bugpatterns;
 
+import static java.util.Arrays.asList;
+
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.util.RuntimeVersion;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -117,5 +120,20 @@ public class UnusedNestedClassTest {
             "class A {",
             "}")
         .doTest(TestMode.TEXT_MATCH);
+  }
+
+  @Test
+  public void moduleInfo() {
+    if (!RuntimeVersion.isAtLeast9()) {
+      return;
+    }
+    compilationHelper
+        .setArgs(asList("-source", "9", "-target", "9"))
+        .addSourceLines(
+            "module-info.java", //
+            "module foo {",
+            "  requires java.base;",
+            "}")
+        .doTest();
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/XorPowerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/XorPowerTest.java
@@ -34,6 +34,7 @@ public class XorPowerTest {
             "  static final int X = 2 ^ 16;",
             "  static final int Y = 2 ^ 32;",
             "  static final int Z = 2 ^ 31;",
+            "  static final int P = 10 ^ 6;",
             "}")
         .addOutputLines(
             "Test.java",
@@ -41,6 +42,7 @@ public class XorPowerTest {
             "  static final int X = 1 << 16;",
             "  static final int Y = 2 ^ 32;",
             "  static final int Z = 1 << 31;",
+            "  static final int P = 1000000;",
             "}")
         .doTest();
   }

--- a/docs/bugpattern/TruthAssertExpected.md
+++ b/docs/bugpattern/TruthAssertExpected.md
@@ -1,4 +1,4 @@
-Arguments to a fluent [Truth](go/truth) assertion appear to be reversed based on
+Arguments to a fluent [Truth][truth] assertion appear to be reversed based on
 the argument names.
 
 ```java
@@ -22,4 +22,6 @@ follow the opposite order to JUnit assertions. Compare:
   assertEquals(expected, actual);
 ```
 
-See https://google.github.io/truth/faq#order for more details.
+See https://truth.dev/faq#order for more details.
+
+[truth]: https://truth.dev


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update broken link to the Truth project

4a16e80e169ff8f73934d52f701651eabdfa863e

-------

<p> Make enclosingClass return null for module symbols.

This solves a problem with UnusedNestedClass on module-info.java files.

Fixes https://github.com/google/error-prone/issues/1240
Somewhat relevant to https://github.com/google/guava-beta-checker/issues/8

88e535aee8a328372f9de2cc844065ae12c048d9

-------

<p> Also check for `10 ^ ...` in XorPower

d2f796be9b14a9c30e212fd104f1399043796fd2