### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedException.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedException.java
@@ -21,6 +21,7 @@ import static com.google.common.collect.Iterables.getLast;
 import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.BugPattern.StandardTags.STYLE;
+import static com.google.errorprone.util.ASTHelpers.isSameType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -78,6 +79,9 @@ public final class UnusedException extends BugChecker implements CatchTreeMatche
       return Description.NO_MATCH;
     }
     VarSymbol exceptionSymbol = ASTHelpers.getSymbol(tree.getParameter());
+    if (isSameType(exceptionSymbol.asType(), state.getSymtab().interruptedExceptionType, state)) {
+      return Description.NO_MATCH;
+    }
     AtomicBoolean symbolUsed = new AtomicBoolean(false);
     ((JCTree) tree)
         .accept(

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaLocalDateTimeGetNano.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaLocalDateTimeGetNano.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.bugpatterns.time.NearbyCallers.containsCallToSameReceiverNearby;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.not;
+import static com.google.errorprone.matchers.Matchers.packageStartsWith;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.time.LocalDateTime;
+
+/**
+ * This checker warns about calls to {@link LocalDateTime#getNano} without a corresponding "nearby"
+ * call to {@link LocalDateTime#getSecond}.
+ */
+@BugPattern(
+    name = "JavaLocalDateTimeGetNano",
+    summary =
+        "localDateTime.getNano() only accesss the nanos-of-second field."
+            + " It's rare to only use getNano() without a nearby getSecond() call.",
+    severity = WARNING)
+public final class JavaLocalDateTimeGetNano extends BugChecker
+    implements MethodInvocationTreeMatcher {
+
+  private static final Matcher<ExpressionTree> GET_SECOND =
+      instanceMethod().onExactClass("java.time.LocalDateTime").named("getSecond");
+  private static final Matcher<ExpressionTree> GET_NANO =
+      allOf(
+          instanceMethod().onExactClass("java.time.LocalDateTime").named("getNano"),
+          not(packageStartsWith("java.")));
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (GET_NANO.matches(tree, state)) {
+      if (!containsCallToSameReceiverNearby(
+          tree, GET_SECOND, state, /* checkProtoChains= */ false)) {
+        return describeMatch(tree);
+      }
+    }
+    return Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaLocalTimeGetNano.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaLocalTimeGetNano.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.bugpatterns.time.NearbyCallers.containsCallToSameReceiverNearby;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.not;
+import static com.google.errorprone.matchers.Matchers.packageStartsWith;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.time.LocalTime;
+
+/**
+ * This checker warns about calls to {@link LocalTime#getNano} without a corresponding "nearby" call
+ * to {@link LocalTime#getSecond}.
+ */
+@BugPattern(
+    name = "JavaLocalTimeGetNano",
+    summary =
+        "localTime.getNano() only accesses the nanos-of-second field."
+            + " It's rare to only use getNano() without a nearby getSecond() call.",
+    severity = WARNING)
+public final class JavaLocalTimeGetNano extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private static final Matcher<ExpressionTree> GET_SECOND =
+      instanceMethod().onExactClass("java.time.LocalTime").named("getSecond");
+  private static final Matcher<ExpressionTree> GET_NANO =
+      allOf(
+          instanceMethod().onExactClass("java.time.LocalTime").named("getNano"),
+          not(packageStartsWith("java.")));
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (GET_NANO.matches(tree, state)) {
+      if (!containsCallToSameReceiverNearby(
+          tree, GET_SECOND, state, /* checkProtoChains= */ false)) {
+        return describeMatch(tree);
+      }
+    }
+    return Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -406,6 +406,8 @@ import com.google.errorprone.bugpatterns.time.JavaDurationGetSecondsGetNano;
 import com.google.errorprone.bugpatterns.time.JavaDurationWithNanos;
 import com.google.errorprone.bugpatterns.time.JavaDurationWithSeconds;
 import com.google.errorprone.bugpatterns.time.JavaInstantGetSecondsGetNano;
+import com.google.errorprone.bugpatterns.time.JavaLocalDateTimeGetNano;
+import com.google.errorprone.bugpatterns.time.JavaLocalTimeGetNano;
 import com.google.errorprone.bugpatterns.time.JavaPeriodGetDays;
 import com.google.errorprone.bugpatterns.time.JavaTimeDefaultTimeZone;
 import com.google.errorprone.bugpatterns.time.JodaDurationConstructor;
@@ -674,6 +676,8 @@ public class BuiltInCheckerSuppliers {
           JavaDurationWithNanos.class,
           JavaDurationWithSeconds.class,
           JavaInstantGetSecondsGetNano.class,
+          JavaLocalDateTimeGetNano.class,
+          JavaLocalTimeGetNano.class,
           JavaTimeDefaultTimeZone.class,
           JavaLangClash.class,
           JavaPeriodGetDays.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedExceptionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedExceptionTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
-import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -84,7 +83,7 @@ public final class UnusedExceptionTest {
             "    }",
             "  }",
             "}")
-        .doTest(TestMode.AST_MATCH);
+        .doTest();
   }
 
   @Test
@@ -255,6 +254,23 @@ public final class UnusedExceptionTest {
             "  }",
             "}")
         .expectUnchanged()
+        .doTest();
+  }
+
+  @Test
+  public void interruptedException_noFinding() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void test() {",
+            "    try {",
+            "      throw new InterruptedException();",
+            "    } catch (InterruptedException e) {",
+            "      throw new IllegalStateException(\"foo\");",
+            "    }",
+            "  }",
+            "}")
         .doTest();
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/JavaLocalDateTimeGetNanoTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/JavaLocalDateTimeGetNanoTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link JavaLocalDateTimeGetNano}. */
+@RunWith(JUnit4.class)
+public final class JavaLocalDateTimeGetNanoTest {
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(JavaLocalDateTimeGetNano.class, getClass());
+
+  @Test
+  public void getSecondWithGetNano() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package test;",
+            "import java.time.LocalDateTime;",
+            "public class Test {",
+            "  public static void foo(LocalDateTime localDateTime) {",
+            "    long seconds = localDateTime.getSecond();",
+            "    int nanos = localDateTime.getNano();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getNanoWithNoGetSeconds() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.time.LocalDateTime;",
+            "public class Test {",
+            "  public static int foo(LocalDateTime localDateTime) {",
+            "    // BUG: Diagnostic contains:",
+            "    return localDateTime.getNano();",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/JavaLocalTimeGetNanoTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/JavaLocalTimeGetNanoTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link JavaLocalTimeGetNano}. */
+@RunWith(JUnit4.class)
+public final class JavaLocalTimeGetNanoTest {
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(JavaLocalTimeGetNano.class, getClass());
+
+  @Test
+  public void getSecondWithGetNano() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package test;",
+            "import java.time.LocalTime;",
+            "public class Test {",
+            "  public static void foo(LocalTime localTime) {",
+            "    long seconds = localTime.getSecond();",
+            "    int nanos = localTime.getNano();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void getNanoWithNoGetSeconds() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.time.LocalTime;",
+            "public class Test {",
+            "  public static int foo(LocalTime localTime) {",
+            "    // BUG: Diagnostic contains:",
+            "    return localTime.getNano();",
+            "  }",
+            "}")
+        .doTest();
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> UnusedException: don't complain about InterruptedException.

I lack a strong opinion that this is worth special-casing, but a few folks seem to regard it as noise. :)

3d5456c03baf6d24dc3c952b1fb3d0722b9527e1

-------

<p> Add a check to flag calls to Local{,Date}Time#getNano without a nearby getSecond call.

I didn't test as exhaustively as the other similar checks; otherwise we're just duplicating testing containsCallToSameReceiverNearby.

0a82d57c60c10dd4f185b6c052768a963932cdd7