### PR TITLE
Moe Sync

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -304,7 +304,7 @@
       <!-- Apache 2.0 -->
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.1.12.Final</version>
+      <version>4.1.42.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Bump netty-all from 4.1.12.Final to 4.1.42.Final in /core

Bumps [netty-all](https://github.com/netty/netty) from 4.1.12.Final to 4.1.42.Final.
- [Release notes](https://github.com/netty/netty/releases)
- [Commits](https://github.com/netty/netty/compare/netty-4.1.12.Final...netty-4.1.42.Final)

Fixes #1373

f1e1c0432e0b4f379a81d7a7643f1f4842f72d75