### PR TITLE
Fix exception from unused variable bug pattern from Lombok.

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/InvalidTokenException.java
+++ b/check_api/src/main/java/com/google/errorprone/InvalidTokenException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/check_api/src/main/java/com/google/errorprone/VisitorState.java
+++ b/check_api/src/main/java/com/google/errorprone/VisitorState.java
@@ -574,8 +574,12 @@ public class VisitorState {
    * be used if a fix is already going to be emitted.
    */
   public List<ErrorProneToken> getOffsetTokens(int start, int end) {
-    return ErrorProneTokens.getTokens(
-        getSourceCode().subSequence(start, end).toString(), start, context);
+    try {
+      return ErrorProneTokens.getTokens(
+          getSourceCode().subSequence(start, end).toString(), start, context);
+    } catch (IndexOutOfBoundsException e) {
+      throw new InvalidTokenException("Could not find source location.");
+    }
   }
 
   /** Returns the end position of the node, or -1 if it is not available. */

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -350,6 +350,13 @@
       <version>1.0.5</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <!-- MIT -->
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.8</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
@@ -46,6 +46,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimaps;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.ErrorProneFlags;
+import com.google.errorprone.InvalidTokenException;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -379,8 +380,12 @@ public final class UnusedVariable extends BugChecker implements CompilationUnitT
                 String.format(
                     "%s{ %s; }",
                     varSymbol.isStatic() ? "static " : "", state.getSourceForNode(initializer));
-            fix.merge(SuggestedFixes.replaceIncludingComments(usagePath, newContent, state));
-            removeSideEffectsFix.replace(statement, "");
+            try {
+              fix.merge(SuggestedFixes.replaceIncludingComments(usagePath, newContent, state));
+              removeSideEffectsFix.replace(statement, "");
+            } catch (InvalidTokenException e) {
+              return ImmutableList.of();
+            }
           } else {
             fix.replace(statement, String.format("%s;", state.getSourceForNode(initializer)));
             removeSideEffectsFix.replace(statement, "");

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedVariableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedVariableTest.java
@@ -1288,4 +1288,18 @@ public class UnusedVariableTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void unusedVariableCreatedByAnnotation() {
+    helper
+        .addSourceLines(
+            "Unuseds.java",
+            "package unusedvars;",
+            "import lombok.extern.java.Log;",
+            "// BUG: Diagnostic contains: 'log' is never read",
+            "@Log",
+            "public class Unuseds {}")
+        .setArgs(ImmutableList.of("-processor", "lombok.launch.AnnotationProcessorHider$AnnotationProcessor"))
+        .doTest();
+  }
 }


### PR DESCRIPTION
This should fix all such exceptions due to variables added by
annotation processors that are unused.