### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ImmutableCollections.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ImmutableCollections.java
@@ -82,6 +82,9 @@ public final class ImmutableCollections {
           .put(
               java.util.HashSet.class.getName(),
               com.google.common.collect.ImmutableSet.class.getName())
+          .put(
+              java.util.EnumMap.class.getName(),
+              com.google.common.collect.ImmutableMap.class.getName())
           .build();
 
   public static boolean isImmutableType(Type type) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterNaming.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterNaming.java
@@ -68,6 +68,7 @@ import javax.lang.model.element.Name;
 public class TypeParameterNaming extends BugChecker implements TypeParameterTreeMatcher {
 
   private static final Pattern TRAILING_DIGIT_EXTRACTOR = Pattern.compile("^(.*?)(\\d+)$");
+  private static final Pattern SINGLE_PLUS_MAYBE_DIGITS = Pattern.compile("[A-Z]\\d*");
 
   private static String upperCamelToken(String s) {
     return "" + Ascii.toUpperCase(s.charAt(0)) + (s.length() == 1 ? "" : s.substring(1));
@@ -99,7 +100,6 @@ public class TypeParameterNaming extends BugChecker implements TypeParameterTree
     /** Anything else. */
     UNCLASSIFIED(false);
 
-    private static final Pattern SINGLE_PLUS_MAYBE_DIGIT = Pattern.compile("[A-Z]\\d?");
     private final boolean isValidName;
 
     TypeParameterNamingClassification(boolean isValidName) {
@@ -107,7 +107,7 @@ public class TypeParameterNaming extends BugChecker implements TypeParameterTree
     }
 
     public static TypeParameterNamingClassification classify(String name) {
-      if (SINGLE_PLUS_MAYBE_DIGIT.matcher(name).matches()) {
+      if (SINGLE_PLUS_MAYBE_DIGITS.matcher(name).matches()) {
         return LETTER_WITH_MAYBE_NUMERAL;
       }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterNamingTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterNamingTest.java
@@ -281,6 +281,20 @@ public class TypeParameterNamingTest {
   }
 
   @Test
+  public void negativeCases_manyNumberedTypes() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.ArrayList;",
+            "class Test<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> {",
+            "  public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> void method(Exception e) {",
+            "    T10 t = null;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void classifyTypeName_singleLetter() {
     assertKindOfName("T").isEqualTo(LETTER_WITH_MAYBE_NUMERAL);
     assertKindOfName("D").isEqualTo(LETTER_WITH_MAYBE_NUMERAL);

--- a/docs/bugpattern/InterruptedExceptionSwallowed.md
+++ b/docs/bugpattern/InterruptedExceptionSwallowed.md
@@ -1,0 +1,10 @@
+This check warns when an `InterruptedException` could be thrown but isn't being
+individually handled.
+
+It is important for correctness and performance that thread interruption is
+handled properly, however `try` blocks that catch `Exception` or `Throwable` (or
+methods that `throws` either type) make it difficult to recognize that
+interruption may occur.
+
+See go/java-practices/interruptedexception for advice on how to handle
+`InterruptedException`.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> ConstantCaseForConstants: Suggest Maps.immutableEnumMap for immutable enum map types.

Probably not worth building a more general substitution method unless we find more similar cases.

f2598aeb5ea19176959210ed5afe7ffc53ca817b

-------

<p> Seed docs for the InterruptedExceptionSwallowed check.

876bea57d684e5bab29d17534c6d96657b928ded

-------

<p> Fix regex that limits number-suffixed types to single-digits.

b52b145a4f1a37940be2d5cd796bb4c388d9c24e