### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/UndefinedEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UndefinedEquals.java
@@ -187,6 +187,7 @@ public final class UndefinedEquals extends BugChecker implements MethodInvocatio
     CHAR_SEQUENCE("CharSequence", "java.lang.CharSequence"),
     ITERABLE("Iterable", "java.lang.Iterable", "com.google.common.collect.FluentIterable"),
     COLLECTION("Collection", "java.util.Collection"),
+    IMMUTABLE_COLLECTION("ImmutableCollection", "com.google.common.collect.ImmutableCollection"),
     QUEUE("Queue", "java.util.Queue");
 
     private final String shortName;

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UndefinedEqualsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UndefinedEqualsTest.java
@@ -66,6 +66,22 @@ public final class UndefinedEqualsTest {
   }
 
   @Test
+  public void immutableCollection() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableCollection;",
+            "import java.util.Objects;",
+            "class Test {",
+            "  void f(ImmutableCollection a, ImmutableCollection b) {",
+            "     // BUG: Diagnostic contains: ImmutableCollection does not have",
+            "    Objects.equals(a,b);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void positiveAssertEquals() {
     compilationHelper
         .addSourceLines(
@@ -130,6 +146,7 @@ public final class UndefinedEqualsTest {
         .addInputLines(
             "Test.java",
             "import static com.google.common.truth.Truth.assertThat;",
+            "import com.google.common.collect.ImmutableCollection;",
             "import com.google.common.collect.Multimap;",
             "import java.lang.Iterable;",
             "import java.util.Collection;",
@@ -140,6 +157,7 @@ public final class UndefinedEqualsTest {
         .addOutputLines(
             "Test.java",
             "import static com.google.common.truth.Truth.assertThat;",
+            "import com.google.common.collect.ImmutableCollection;",
             "import com.google.common.collect.Multimap;",
             "import java.lang.Iterable;",
             "import java.util.Collection;",


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> SuggestedFixes: add parameter to compilesWithFix to allow you to specify that only errors in the current compilation unit should be considered.

The motivating case here is UnnecessaryJavacSuppressWarnings: the compilation check is currently under-reporting because it fails when un-suppressed violations are present in other files within the same compilation task.

beb99d7928e7c155b97e989f26a1ebf9156c5a9b

-------

<p> Add ImmutableCollection to UndefinedEquals

fbac69edbe4bac95dfe6764c3a2cd690f9a89d2d