### PR TITLE
MOE Sync 2019-10-30

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/InvalidJavaTimeConstant.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/InvalidJavaTimeConstant.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.packageStartsWith;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.DAY_OF_WEEK;
+import static java.time.temporal.ChronoField.DAY_OF_YEAR;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.NANO_OF_DAY;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_DAY;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static java.time.temporal.ChronoField.YEAR;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.time.DateTimeException;
+import java.time.temporal.ChronoField;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This checker errors on calls to {@code java.time} methods using values that are guaranteed to
+ * throw a {@link DateTimeException}.
+ *
+ * @author kak@google.com (Kurt Alfred Kluever)
+ */
+@BugPattern(
+    name = "InvalidJavaTimeConstant",
+    summary =
+        "This checker errors on calls to java.time methods using literals that are guaranteed to "
+            + "throw a DateTimeException.",
+    severity = ERROR)
+public final class InvalidJavaTimeConstant extends BugChecker
+    implements MethodInvocationTreeMatcher {
+
+  private static final String LOCAL_TIME = "java.time.LocalTime";
+  private static final String LOCAL_DATE = "java.time.LocalDate";
+  private static final String LOCAL_DATE_TIME = "java.time.LocalDateTime";
+
+  // TODO(kak): We could consider making a helper method for creating the mappings; e.g.,
+  // private static Entry<Matcher<ExpressionTree>, ImmutableList<ChronoField>> makeEntry(
+  //     boolean isStatic, String className, String methodName,
+  //     Map<String, ChronoField> paramsAndUnits) { ... }
+  // TODO(kak): Consider making this an ImmutableListMultimap instead
+  private static final ImmutableMap<Matcher<ExpressionTree>, ImmutableList<ChronoField>> APIS =
+      ImmutableMap.<Matcher<ExpressionTree>, ImmutableList<ChronoField>>builder()
+          // java.time.DayOfWeek
+          .put(
+              staticMethod().onClass("java.time.DayOfWeek").named("of").withParameters("int"),
+              ImmutableList.of(DAY_OF_WEEK))
+          // java.time.Month
+          .put(
+              staticMethod().onClass("java.time.Month").named("of").withParameters("int"),
+              ImmutableList.of(MONTH_OF_YEAR))
+          // java.time.MonthDay
+          .put(
+              staticMethod().onClass("java.time.MonthDay").named("of").withParameters("int", "int"),
+              ImmutableList.of(MONTH_OF_YEAR, DAY_OF_MONTH))
+          .put(
+              staticMethod()
+                  .onClass("java.time.MonthDay")
+                  .named("of")
+                  .withParameters("java.time.Month", "int"),
+              ImmutableList.of(MONTH_OF_YEAR, DAY_OF_MONTH))
+          // java.time.Year
+          .put(
+              staticMethod().onClass("java.time.Year").named("of").withParameters("int"),
+              ImmutableList.of(YEAR))
+          // java.time.YearMonth
+          .put(
+              staticMethod()
+                  .onClass("java.time.YearMonth")
+                  .named("of")
+                  .withParameters("int", "int"),
+              ImmutableList.of(YEAR, MONTH_OF_YEAR))
+          .put(
+              staticMethod()
+                  .onClass("java.time.YearMonth")
+                  .named("of")
+                  .withParameters("int", "java.time.Month"),
+              ImmutableList.of(YEAR, MONTH_OF_YEAR))
+          // java.time.LocalTime
+          .put(
+              staticMethod().onClass(LOCAL_TIME).named("of").withParameters("int", "int"),
+              ImmutableList.of(HOUR_OF_DAY, MINUTE_OF_HOUR))
+          .put(
+              staticMethod().onClass(LOCAL_TIME).named("of").withParameters("int", "int", "int"),
+              ImmutableList.of(HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE))
+          .put(
+              staticMethod()
+                  .onClass(LOCAL_TIME)
+                  .named("of")
+                  .withParameters("int", "int", "int", "int"),
+              ImmutableList.of(HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE, NANO_OF_SECOND))
+          .put(
+              staticMethod().onClass(LOCAL_TIME).named("ofNanoOfDay").withParameters("long"),
+              ImmutableList.of(NANO_OF_DAY))
+          .put(
+              staticMethod().onClass(LOCAL_TIME).named("ofSecondOfDay").withParameters("long"),
+              ImmutableList.of(SECOND_OF_DAY))
+          // java.time.LocalDate
+          .put(
+              staticMethod().onClass(LOCAL_DATE).named("of").withParameters("int", "int", "int"),
+              ImmutableList.of(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH))
+          .put(
+              staticMethod()
+                  .onClass(LOCAL_DATE)
+                  .named("of")
+                  .withParameters("int", "java.time.Month", "int"),
+              ImmutableList.of(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH))
+          // NOTE: do not try to add LocalDate.ofEpochDay(long), EPOCH_DAY; it's incorrect
+          .put(
+              staticMethod().onClass(LOCAL_DATE).named("ofYearDay").withParameters("int", "int"),
+              ImmutableList.of(YEAR, DAY_OF_YEAR))
+          // java.time.LocalDateTime
+          .put(
+              staticMethod()
+                  .onClass(LOCAL_DATE_TIME)
+                  .named("of")
+                  .withParameters("int", "int", "int", "int", "int"),
+              ImmutableList.of(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH, HOUR_OF_DAY, MINUTE_OF_HOUR))
+          .put(
+              staticMethod()
+                  .onClass(LOCAL_DATE_TIME)
+                  .named("of")
+                  .withParameters("int", "java.time.Month", "int", "int", "int"),
+              ImmutableList.of(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH, HOUR_OF_DAY, MINUTE_OF_HOUR))
+          .put(
+              staticMethod()
+                  .onClass(LOCAL_DATE_TIME)
+                  .named("of")
+                  .withParameters("int", "int", "int", "int", "int", "int"),
+              ImmutableList.of(
+                  YEAR, MONTH_OF_YEAR, DAY_OF_MONTH, HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE))
+          .put(
+              staticMethod()
+                  .onClass(LOCAL_DATE_TIME)
+                  .named("of")
+                  .withParameters("int", "java.time.Month", "int", "int", "int", "int"),
+              ImmutableList.of(
+                  YEAR, MONTH_OF_YEAR, DAY_OF_MONTH, HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE))
+          .put(
+              staticMethod()
+                  .onClass(LOCAL_DATE_TIME)
+                  .named("of")
+                  .withParameters("int", "int", "int", "int", "int", "int", "int"),
+              ImmutableList.of(
+                  YEAR,
+                  MONTH_OF_YEAR,
+                  DAY_OF_MONTH,
+                  HOUR_OF_DAY,
+                  MINUTE_OF_HOUR,
+                  SECOND_OF_MINUTE,
+                  NANO_OF_SECOND))
+          .put(
+              staticMethod()
+                  .onClass(LOCAL_DATE_TIME)
+                  .named("of")
+                  .withParameters("int", "java.time.Month", "int", "int", "int", "int", "int"),
+              ImmutableList.of(
+                  YEAR,
+                  MONTH_OF_YEAR,
+                  DAY_OF_MONTH,
+                  HOUR_OF_DAY,
+                  MINUTE_OF_HOUR,
+                  SECOND_OF_MINUTE,
+                  NANO_OF_SECOND))
+          // TODO(kak): Add instance methods to this as well
+          .build();
+
+  private static final Matcher<ExpressionTree> JAVA_MATCHER =
+      anyOf(packageStartsWith("java."), packageStartsWith("tck.java."));
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    // Allow the JDK to do whatever it wants (unit tests, etc.)
+    if (JAVA_MATCHER.matches(tree, state)) {
+      return Description.NO_MATCH;
+    }
+    for (Map.Entry<Matcher<ExpressionTree>, ImmutableList<ChronoField>> entry : APIS.entrySet()) {
+      if (entry.getKey().matches(tree, state)) {
+        List<? extends ExpressionTree> arguments = tree.getArguments();
+        ImmutableList<ChronoField> units = entry.getValue();
+
+        // if units.size() != arguments.size() then we screwed something up in the static map of
+        // matchers above (there should always be an equal number of arguments and units)
+        if (units.size() == arguments.size()) {
+          for (int i = 0; i < arguments.size(); i++) {
+            ExpressionTree argument = arguments.get(i);
+            Number constant = ASTHelpers.constValue(argument, Number.class);
+            if (constant != null) {
+              try {
+                units.get(i).checkValidValue(constant.longValue());
+              } catch (DateTimeException invalid) {
+                return buildDescription(argument).setMessage(invalid.getMessage()).build();
+              }
+            }
+          }
+        }
+      }
+    }
+    return Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/InvalidJavaTimeConstant.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/InvalidJavaTimeConstant.java
@@ -15,13 +15,16 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.packageStartsWith;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.DAY_OF_WEEK;
 import static java.time.temporal.ChronoField.DAY_OF_YEAR;
+import static java.time.temporal.ChronoField.EPOCH_DAY;
 import static java.time.temporal.ChronoField.HOUR_OF_DAY;
 import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
 import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
@@ -30,9 +33,11 @@ import static java.time.temporal.ChronoField.NANO_OF_SECOND;
 import static java.time.temporal.ChronoField.SECOND_OF_DAY;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 import static java.time.temporal.ChronoField.YEAR;
+import static java.util.Arrays.asList;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -62,139 +67,210 @@ import java.util.Map;
 public final class InvalidJavaTimeConstant extends BugChecker
     implements MethodInvocationTreeMatcher {
 
-  private static final String LOCAL_TIME = "java.time.LocalTime";
-  private static final String LOCAL_DATE = "java.time.LocalDate";
-  private static final String LOCAL_DATE_TIME = "java.time.LocalDateTime";
+  private static Map.Entry<Matcher<ExpressionTree>, ImmutableList<ChronoField>> staticEntry(
+      String className,
+      String methodName,
+      List<String> parameterTypes,
+      List<ChronoField> parameterUnits) {
+    return makeEntry(true, className, methodName, parameterTypes, parameterUnits);
+  }
 
-  // TODO(kak): We could consider making a helper method for creating the mappings; e.g.,
-  // private static Entry<Matcher<ExpressionTree>, ImmutableList<ChronoField>> makeEntry(
-  //     boolean isStatic, String className, String methodName,
-  //     Map<String, ChronoField> paramsAndUnits) { ... }
-  // TODO(kak): Consider making this an ImmutableListMultimap instead
+  private static Map.Entry<Matcher<ExpressionTree>, ImmutableList<ChronoField>> instanceEntry(
+      String className,
+      String methodName,
+      List<String> parameterTypes,
+      List<ChronoField> parameterUnits) {
+    return makeEntry(false, className, methodName, parameterTypes, parameterUnits);
+  }
+
+  private static Map.Entry<Matcher<ExpressionTree>, ImmutableList<ChronoField>> makeEntry(
+      boolean isStatic,
+      String className,
+      String methodName,
+      List<String> parameterTypes,
+      List<ChronoField> parameterUnits) {
+    checkArgument(
+        parameterTypes.size() == parameterUnits.size(),
+        "There must be an equal number of parameter types (%s) and parameter units (%s):\n%s\n%s",
+        parameterTypes.size(),
+        parameterUnits.size(),
+        parameterTypes,
+        parameterUnits);
+    String[] parameters = parameterTypes.toArray(new String[0]);
+    Matcher<ExpressionTree> matcher =
+        isStatic
+            ? staticMethod().onClass(className).named(methodName).withParameters(parameters)
+            : instanceMethod().onExactClass(className).named(methodName).withParameters(parameters);
+    return Maps.immutableEntry(matcher, ImmutableList.copyOf(parameterUnits));
+  }
+
+  private static final ImmutableList<Map.Entry<Matcher<ExpressionTree>, ImmutableList<ChronoField>>>
+      DAY_OF_WEEK_APIS =
+          ImmutableList.of(
+              staticEntry("java.time.DayOfWeek", "of", asList("int"), asList(DAY_OF_WEEK)));
+
+  private static final ImmutableList<Map.Entry<Matcher<ExpressionTree>, ImmutableList<ChronoField>>>
+      MONTH_APIS =
+          ImmutableList.of(
+              staticEntry("java.time.Month", "of", asList("int"), asList(MONTH_OF_YEAR)));
+
+  private static final ImmutableList<Map.Entry<Matcher<ExpressionTree>, ImmutableList<ChronoField>>>
+      YEAR_APIS =
+          ImmutableList.of(
+              staticEntry("java.time.Year", "of", asList("int"), asList(YEAR)),
+              instanceEntry("java.time.Year", "atDay", asList("int"), asList(DAY_OF_YEAR)),
+              instanceEntry("java.time.Year", "atMonth", asList("int"), asList(MONTH_OF_YEAR)));
+
+  private static final String YEAR_MONTH = "java.time.YearMonth";
+  private static final ImmutableList<Map.Entry<Matcher<ExpressionTree>, ImmutableList<ChronoField>>>
+      YEAR_MONTH_APIS =
+          ImmutableList.of(
+              staticEntry(YEAR_MONTH, "of", asList("int", "int"), asList(YEAR, MONTH_OF_YEAR)),
+              staticEntry(
+                  YEAR_MONTH, "of", asList("int", "java.time.Month"), asList(YEAR, MONTH_OF_YEAR)),
+              instanceEntry(YEAR_MONTH, "atDay", asList("int"), asList(DAY_OF_MONTH)),
+              instanceEntry(YEAR_MONTH, "withMonth", asList("int"), asList(MONTH_OF_YEAR)),
+              instanceEntry(YEAR_MONTH, "withYear", asList("int"), asList(YEAR)));
+
+  private static final String MONTH_DAY = "java.time.MonthDay";
+  private static final ImmutableList<Map.Entry<Matcher<ExpressionTree>, ImmutableList<ChronoField>>>
+      MONTH_DAY_APIS =
+          ImmutableList.of(
+              staticEntry(
+                  MONTH_DAY, "of", asList("int", "int"), asList(MONTH_OF_YEAR, DAY_OF_MONTH)),
+              staticEntry(
+                  MONTH_DAY,
+                  "of",
+                  asList("java.time.Month", "int"),
+                  asList(MONTH_OF_YEAR, DAY_OF_MONTH)),
+              instanceEntry(MONTH_DAY, "atYear", asList("int"), asList(YEAR)),
+              instanceEntry(MONTH_DAY, "withDayOfMonth", asList("int"), asList(DAY_OF_MONTH)),
+              instanceEntry(MONTH_DAY, "withMonth", asList("int"), asList(MONTH_OF_YEAR)));
+
+  private static final String LOCAL_TIME = "java.time.LocalTime";
+  private static final ImmutableList<Map.Entry<Matcher<ExpressionTree>, ImmutableList<ChronoField>>>
+      LOCAL_TIME_APIS =
+          ImmutableList.of(
+              staticEntry(
+                  LOCAL_TIME, "of", asList("int", "int"), asList(HOUR_OF_DAY, MINUTE_OF_HOUR)),
+              staticEntry(
+                  LOCAL_TIME,
+                  "of",
+                  asList("int", "int", "int"),
+                  asList(HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE)),
+              staticEntry(
+                  LOCAL_TIME,
+                  "of",
+                  asList("int", "int", "int", "int"),
+                  asList(HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE, NANO_OF_SECOND)),
+              staticEntry(LOCAL_TIME, "ofNanoOfDay", asList("long"), asList(NANO_OF_DAY)),
+              staticEntry(LOCAL_TIME, "ofSecondOfDay", asList("long"), asList(SECOND_OF_DAY)),
+              instanceEntry(LOCAL_TIME, "withHour", asList("int"), asList(HOUR_OF_DAY)),
+              instanceEntry(LOCAL_TIME, "withMinute", asList("int"), asList(MINUTE_OF_HOUR)),
+              instanceEntry(LOCAL_TIME, "withNano", asList("int"), asList(NANO_OF_SECOND)),
+              instanceEntry(LOCAL_TIME, "withSecond", asList("int"), asList(SECOND_OF_MINUTE)));
+
+  private static final String LOCAL_DATE = "java.time.LocalDate";
+  private static final ImmutableList<Map.Entry<Matcher<ExpressionTree>, ImmutableList<ChronoField>>>
+      LOCAL_DATE_APIS =
+          ImmutableList.of(
+              staticEntry(
+                  LOCAL_DATE,
+                  "of",
+                  asList("int", "int", "int"),
+                  asList(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH)),
+              staticEntry(
+                  LOCAL_DATE,
+                  "of",
+                  asList("int", "java.time.Month", "int"),
+                  asList(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH)),
+              staticEntry(LOCAL_DATE, "ofEpochDay", asList("long"), asList(EPOCH_DAY)),
+              staticEntry(LOCAL_DATE, "ofYearDay", asList("int", "int"), asList(YEAR, DAY_OF_YEAR)),
+              instanceEntry(LOCAL_DATE, "withDayOfMonth", asList("int"), asList(DAY_OF_MONTH)),
+              instanceEntry(LOCAL_DATE, "withDayOfYear", asList("int"), asList(DAY_OF_YEAR)),
+              instanceEntry(LOCAL_DATE, "withMonth", asList("int"), asList(MONTH_OF_YEAR)),
+              instanceEntry(LOCAL_DATE, "withYear", asList("int"), asList(YEAR)));
+
+  private static final String LOCAL_DATE_TIME = "java.time.LocalDateTime";
+  private static final ImmutableList<Map.Entry<Matcher<ExpressionTree>, ImmutableList<ChronoField>>>
+      LOCAL_DATE_TIME_APIS =
+          ImmutableList.of(
+              staticEntry(
+                  LOCAL_DATE_TIME,
+                  "of",
+                  asList("int", "int", "int", "int", "int"),
+                  asList(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH, HOUR_OF_DAY, MINUTE_OF_HOUR)),
+              staticEntry(
+                  LOCAL_DATE_TIME,
+                  "of",
+                  asList("int", "java.time.Month", "int", "int", "int"),
+                  asList(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH, HOUR_OF_DAY, MINUTE_OF_HOUR)),
+              staticEntry(
+                  LOCAL_DATE_TIME,
+                  "of",
+                  asList("int", "int", "int", "int", "int", "int"),
+                  asList(
+                      YEAR,
+                      MONTH_OF_YEAR,
+                      DAY_OF_MONTH,
+                      HOUR_OF_DAY,
+                      MINUTE_OF_HOUR,
+                      SECOND_OF_MINUTE)),
+              staticEntry(
+                  LOCAL_DATE_TIME,
+                  "of",
+                  asList("int", "java.time.Month", "int", "int", "int", "int"),
+                  asList(
+                      YEAR,
+                      MONTH_OF_YEAR,
+                      DAY_OF_MONTH,
+                      HOUR_OF_DAY,
+                      MINUTE_OF_HOUR,
+                      SECOND_OF_MINUTE)),
+              staticEntry(
+                  LOCAL_DATE_TIME,
+                  "of",
+                  asList("int", "int", "int", "int", "int", "int", "int"),
+                  asList(
+                      YEAR,
+                      MONTH_OF_YEAR,
+                      DAY_OF_MONTH,
+                      HOUR_OF_DAY,
+                      MINUTE_OF_HOUR,
+                      SECOND_OF_MINUTE,
+                      NANO_OF_SECOND)),
+              staticEntry(
+                  LOCAL_DATE_TIME,
+                  "of",
+                  asList("int", "java.time.Month", "int", "int", "int", "int", "int"),
+                  asList(
+                      YEAR,
+                      MONTH_OF_YEAR,
+                      DAY_OF_MONTH,
+                      HOUR_OF_DAY,
+                      MINUTE_OF_HOUR,
+                      SECOND_OF_MINUTE,
+                      NANO_OF_SECOND)),
+              instanceEntry(LOCAL_DATE_TIME, "withDayOfMonth", asList("int"), asList(DAY_OF_MONTH)),
+              instanceEntry(LOCAL_DATE_TIME, "withDayOfYear", asList("int"), asList(DAY_OF_YEAR)),
+              instanceEntry(LOCAL_DATE_TIME, "withHour", asList("int"), asList(HOUR_OF_DAY)),
+              instanceEntry(LOCAL_DATE_TIME, "withMinute", asList("int"), asList(MINUTE_OF_HOUR)),
+              instanceEntry(LOCAL_DATE_TIME, "withMonth", asList("int"), asList(MONTH_OF_YEAR)),
+              instanceEntry(LOCAL_DATE_TIME, "withNano", asList("int"), asList(NANO_OF_SECOND)),
+              instanceEntry(LOCAL_DATE_TIME, "withSecond", asList("int"), asList(SECOND_OF_MINUTE)),
+              instanceEntry(LOCAL_DATE_TIME, "withYear", asList("int"), asList(YEAR)));
+
   private static final ImmutableMap<Matcher<ExpressionTree>, ImmutableList<ChronoField>> APIS =
       ImmutableMap.<Matcher<ExpressionTree>, ImmutableList<ChronoField>>builder()
-          // java.time.DayOfWeek
-          .put(
-              staticMethod().onClass("java.time.DayOfWeek").named("of").withParameters("int"),
-              ImmutableList.of(DAY_OF_WEEK))
-          // java.time.Month
-          .put(
-              staticMethod().onClass("java.time.Month").named("of").withParameters("int"),
-              ImmutableList.of(MONTH_OF_YEAR))
-          // java.time.MonthDay
-          .put(
-              staticMethod().onClass("java.time.MonthDay").named("of").withParameters("int", "int"),
-              ImmutableList.of(MONTH_OF_YEAR, DAY_OF_MONTH))
-          .put(
-              staticMethod()
-                  .onClass("java.time.MonthDay")
-                  .named("of")
-                  .withParameters("java.time.Month", "int"),
-              ImmutableList.of(MONTH_OF_YEAR, DAY_OF_MONTH))
-          // java.time.Year
-          .put(
-              staticMethod().onClass("java.time.Year").named("of").withParameters("int"),
-              ImmutableList.of(YEAR))
-          // java.time.YearMonth
-          .put(
-              staticMethod()
-                  .onClass("java.time.YearMonth")
-                  .named("of")
-                  .withParameters("int", "int"),
-              ImmutableList.of(YEAR, MONTH_OF_YEAR))
-          .put(
-              staticMethod()
-                  .onClass("java.time.YearMonth")
-                  .named("of")
-                  .withParameters("int", "java.time.Month"),
-              ImmutableList.of(YEAR, MONTH_OF_YEAR))
-          // java.time.LocalTime
-          .put(
-              staticMethod().onClass(LOCAL_TIME).named("of").withParameters("int", "int"),
-              ImmutableList.of(HOUR_OF_DAY, MINUTE_OF_HOUR))
-          .put(
-              staticMethod().onClass(LOCAL_TIME).named("of").withParameters("int", "int", "int"),
-              ImmutableList.of(HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE))
-          .put(
-              staticMethod()
-                  .onClass(LOCAL_TIME)
-                  .named("of")
-                  .withParameters("int", "int", "int", "int"),
-              ImmutableList.of(HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE, NANO_OF_SECOND))
-          .put(
-              staticMethod().onClass(LOCAL_TIME).named("ofNanoOfDay").withParameters("long"),
-              ImmutableList.of(NANO_OF_DAY))
-          .put(
-              staticMethod().onClass(LOCAL_TIME).named("ofSecondOfDay").withParameters("long"),
-              ImmutableList.of(SECOND_OF_DAY))
-          // java.time.LocalDate
-          .put(
-              staticMethod().onClass(LOCAL_DATE).named("of").withParameters("int", "int", "int"),
-              ImmutableList.of(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH))
-          .put(
-              staticMethod()
-                  .onClass(LOCAL_DATE)
-                  .named("of")
-                  .withParameters("int", "java.time.Month", "int"),
-              ImmutableList.of(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH))
-          // NOTE: do not try to add LocalDate.ofEpochDay(long), EPOCH_DAY; it's incorrect
-          .put(
-              staticMethod().onClass(LOCAL_DATE).named("ofYearDay").withParameters("int", "int"),
-              ImmutableList.of(YEAR, DAY_OF_YEAR))
-          // java.time.LocalDateTime
-          .put(
-              staticMethod()
-                  .onClass(LOCAL_DATE_TIME)
-                  .named("of")
-                  .withParameters("int", "int", "int", "int", "int"),
-              ImmutableList.of(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH, HOUR_OF_DAY, MINUTE_OF_HOUR))
-          .put(
-              staticMethod()
-                  .onClass(LOCAL_DATE_TIME)
-                  .named("of")
-                  .withParameters("int", "java.time.Month", "int", "int", "int"),
-              ImmutableList.of(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH, HOUR_OF_DAY, MINUTE_OF_HOUR))
-          .put(
-              staticMethod()
-                  .onClass(LOCAL_DATE_TIME)
-                  .named("of")
-                  .withParameters("int", "int", "int", "int", "int", "int"),
-              ImmutableList.of(
-                  YEAR, MONTH_OF_YEAR, DAY_OF_MONTH, HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE))
-          .put(
-              staticMethod()
-                  .onClass(LOCAL_DATE_TIME)
-                  .named("of")
-                  .withParameters("int", "java.time.Month", "int", "int", "int", "int"),
-              ImmutableList.of(
-                  YEAR, MONTH_OF_YEAR, DAY_OF_MONTH, HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE))
-          .put(
-              staticMethod()
-                  .onClass(LOCAL_DATE_TIME)
-                  .named("of")
-                  .withParameters("int", "int", "int", "int", "int", "int", "int"),
-              ImmutableList.of(
-                  YEAR,
-                  MONTH_OF_YEAR,
-                  DAY_OF_MONTH,
-                  HOUR_OF_DAY,
-                  MINUTE_OF_HOUR,
-                  SECOND_OF_MINUTE,
-                  NANO_OF_SECOND))
-          .put(
-              staticMethod()
-                  .onClass(LOCAL_DATE_TIME)
-                  .named("of")
-                  .withParameters("int", "java.time.Month", "int", "int", "int", "int", "int"),
-              ImmutableList.of(
-                  YEAR,
-                  MONTH_OF_YEAR,
-                  DAY_OF_MONTH,
-                  HOUR_OF_DAY,
-                  MINUTE_OF_HOUR,
-                  SECOND_OF_MINUTE,
-                  NANO_OF_SECOND))
-          // TODO(kak): Add instance methods to this as well
+          // put the more popular types at the beginning for a slight speed-up
+          .putAll(LOCAL_TIME_APIS)
+          .putAll(LOCAL_DATE_APIS)
+          .putAll(LOCAL_DATE_TIME_APIS)
+          .putAll(DAY_OF_WEEK_APIS)
+          .putAll(MONTH_APIS)
+          .putAll(MONTH_DAY_APIS)
+          .putAll(YEAR_APIS)
+          .putAll(YEAR_MONTH_APIS)
           .build();
 
   private static final Matcher<ExpressionTree> JAVA_MATCHER =
@@ -206,26 +282,24 @@ public final class InvalidJavaTimeConstant extends BugChecker
     if (JAVA_MATCHER.matches(tree, state)) {
       return Description.NO_MATCH;
     }
+
     for (Map.Entry<Matcher<ExpressionTree>, ImmutableList<ChronoField>> entry : APIS.entrySet()) {
       if (entry.getKey().matches(tree, state)) {
         List<? extends ExpressionTree> arguments = tree.getArguments();
-        ImmutableList<ChronoField> units = entry.getValue();
-
-        // if units.size() != arguments.size() then we screwed something up in the static map of
-        // matchers above (there should always be an equal number of arguments and units)
-        if (units.size() == arguments.size()) {
-          for (int i = 0; i < arguments.size(); i++) {
-            ExpressionTree argument = arguments.get(i);
-            Number constant = ASTHelpers.constValue(argument, Number.class);
-            if (constant != null) {
-              try {
-                units.get(i).checkValidValue(constant.longValue());
-              } catch (DateTimeException invalid) {
-                return buildDescription(argument).setMessage(invalid.getMessage()).build();
-              }
+        for (int i = 0; i < arguments.size(); i++) {
+          ExpressionTree argument = arguments.get(i);
+          Number constant = ASTHelpers.constValue(argument, Number.class);
+          if (constant != null) {
+            try {
+              entry.getValue().get(i).checkValidValue(constant.longValue());
+            } catch (DateTimeException invalid) {
+              return buildDescription(argument).setMessage(invalid.getMessage()).build();
             }
           }
         }
+        // we short-circuit the loop here; only 1 matcher will ever match, so there's no sense in
+        // checking the rest of them
+        return Description.NO_MATCH;
       }
     }
     return Description.NO_MATCH;

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -404,6 +404,7 @@ import com.google.errorprone.bugpatterns.time.DurationGetTemporalUnit;
 import com.google.errorprone.bugpatterns.time.DurationTemporalUnit;
 import com.google.errorprone.bugpatterns.time.DurationToLongTimeUnit;
 import com.google.errorprone.bugpatterns.time.InstantTemporalUnit;
+import com.google.errorprone.bugpatterns.time.InvalidJavaTimeConstant;
 import com.google.errorprone.bugpatterns.time.JavaDurationGetSecondsGetNano;
 import com.google.errorprone.bugpatterns.time.JavaDurationWithNanos;
 import com.google.errorprone.bugpatterns.time.JavaDurationWithSeconds;
@@ -534,6 +535,7 @@ public class BuiltInCheckerSuppliers {
           InjectOnFinalField.class,
           InjectOnMemberAndConstructor.class,
           InstantTemporalUnit.class,
+          InvalidJavaTimeConstant.class,
           InvalidPatternSyntax.class,
           InvalidTimeZoneID.class,
           InvalidZoneId.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/InvalidJavaTimeConstantTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/InvalidJavaTimeConstantTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link InvalidJavaTimeConstant}.
+ *
+ * @author kak@google.com (Kurt Alfred Kluever)
+ */
+@RunWith(JUnit4.class)
+public class InvalidJavaTimeConstantTest {
+
+  private CompilationTestHelper compilationHelper;
+
+  @Before
+  public void setUp() {
+    compilationHelper =
+        CompilationTestHelper.newInstance(InvalidJavaTimeConstant.class, getClass());
+  }
+
+  @Test
+  public void cornerCases() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.LocalDateTime;",
+            "import java.time.LocalTime;",
+            "public class TestCase {",
+            "  // BUG: Diagnostic contains: 0",
+            "  private static final LocalDateTime LDT0 = LocalDateTime.of(0, 0, 0, 0, 0);",
+            "  private static final LocalDateTime LDT1 = LocalDateTime.of(0, 1, 1, 0, 0);",
+            "  private static final LocalTime LT = LocalTime.ofNanoOfDay(12345678);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void localDate_areOk() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.LocalDate;",
+            "import java.time.Month;",
+            "public class TestCase {",
+            "  private static final LocalDate LD0 = LocalDate.of(1985, 5, 31);",
+            "  private static final LocalDate LD1 = LocalDate.of(1985, Month.MAY, 31);",
+            // we can't catch this since it's not a literal
+            "  private static final LocalDate LD2 = LocalDate.of(1985, getBadMonth(), 31);",
+            "  private static int getBadMonth() { return 13; }",
+            "  private static final LocalDate EPOCH_DAY_ZERO = LocalDate.ofEpochDay(0);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void localDate_withBadDays() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.LocalDate;",
+            "import java.time.Month;",
+            "public class TestCase {",
+            "  // BUG: Diagnostic contains: 32",
+            "  private static final LocalDate LD0 = LocalDate.of(1985, 5, 32);",
+            "  // BUG: Diagnostic contains: 32",
+            "  private static final LocalDate LD1 = LocalDate.of(1985, Month.MAY, 32);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void localDate_withBadMonths() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.LocalDate;",
+            "public class TestCase {",
+            "  // BUG: Diagnostic contains: -1",
+            "  private static final LocalDate LD0 = LocalDate.of(1985, -1, 31);",
+            "  // BUG: Diagnostic contains: 0",
+            "  private static final LocalDate LD1 = LocalDate.of(1985, 0, 31);",
+            "  // BUG: Diagnostic contains: 13",
+            "  private static final LocalDate LD2 = LocalDate.of(1985, 13, 31);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void localDate_withBadYears() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.LocalDate;",
+            "import java.time.Year;",
+            "public class TestCase {",
+            "  // BUG: Diagnostic contains: -1000000000",
+            "  private static final LocalDate LD0 = LocalDate.of(Year.MIN_VALUE - 1, 5, 31);",
+            "  // BUG: Diagnostic contains: 1000000000",
+            "  private static final LocalDate LD1 = LocalDate.of(Year.MAX_VALUE + 1, 5, 31);",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/InvalidJavaTimeConstantTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/InvalidJavaTimeConstantTest.java
@@ -46,7 +46,7 @@ public class InvalidJavaTimeConstantTest {
             "import java.time.LocalDateTime;",
             "import java.time.LocalTime;",
             "public class TestCase {",
-            "  // BUG: Diagnostic contains: 0",
+            "  // BUG: Diagnostic contains: MonthOfYear (valid values 1 - 12): 0",
             "  private static final LocalDateTime LDT0 = LocalDateTime.of(0, 0, 0, 0, 0);",
             "  private static final LocalDateTime LDT1 = LocalDateTime.of(0, 1, 1, 0, 0);",
             "  private static final LocalTime LT = LocalTime.ofNanoOfDay(12345678);",
@@ -69,6 +69,7 @@ public class InvalidJavaTimeConstantTest {
             "  private static final LocalDate LD2 = LocalDate.of(1985, getBadMonth(), 31);",
             "  private static int getBadMonth() { return 13; }",
             "  private static final LocalDate EPOCH_DAY_ZERO = LocalDate.ofEpochDay(0);",
+            "  private static final LocalDate EPOCH_DAY_LARGE = LocalDate.ofEpochDay(123467);",
             "}")
         .doTest();
   }
@@ -82,9 +83,9 @@ public class InvalidJavaTimeConstantTest {
             "import java.time.LocalDate;",
             "import java.time.Month;",
             "public class TestCase {",
-            "  // BUG: Diagnostic contains: 32",
+            "  // BUG: Diagnostic contains: DayOfMonth (valid values 1 - 28/31): 32",
             "  private static final LocalDate LD0 = LocalDate.of(1985, 5, 32);",
-            "  // BUG: Diagnostic contains: 32",
+            "  // BUG: Diagnostic contains: DayOfMonth (valid values 1 - 28/31): 32",
             "  private static final LocalDate LD1 = LocalDate.of(1985, Month.MAY, 32);",
             "}")
         .doTest();
@@ -98,11 +99,11 @@ public class InvalidJavaTimeConstantTest {
             "package test;",
             "import java.time.LocalDate;",
             "public class TestCase {",
-            "  // BUG: Diagnostic contains: -1",
+            "  // BUG: Diagnostic contains: MonthOfYear (valid values 1 - 12): -1",
             "  private static final LocalDate LD0 = LocalDate.of(1985, -1, 31);",
-            "  // BUG: Diagnostic contains: 0",
+            "  // BUG: Diagnostic contains: MonthOfYear (valid values 1 - 12): 0",
             "  private static final LocalDate LD1 = LocalDate.of(1985, 0, 31);",
-            "  // BUG: Diagnostic contains: 13",
+            "  // BUG: Diagnostic contains: MonthOfYear (valid values 1 - 12): 13",
             "  private static final LocalDate LD2 = LocalDate.of(1985, 13, 31);",
             "}")
         .doTest();
@@ -117,10 +118,43 @@ public class InvalidJavaTimeConstantTest {
             "import java.time.LocalDate;",
             "import java.time.Year;",
             "public class TestCase {",
-            "  // BUG: Diagnostic contains: -1000000000",
+            "  // BUG: Diagnostic contains: Year (valid values -999999999 - 999999999):"
+                + " -1000000000",
             "  private static final LocalDate LD0 = LocalDate.of(Year.MIN_VALUE - 1, 5, 31);",
-            "  // BUG: Diagnostic contains: 1000000000",
+            "  // BUG: Diagnostic contains: Year (valid values -999999999 - 999999999): 1000000000",
             "  private static final LocalDate LD1 = LocalDate.of(Year.MAX_VALUE + 1, 5, 31);",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void localDate_withBadDayOfMonth() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.LocalDate;",
+            "public class TestCase {",
+            "  private static LocalDate foo(LocalDate localDate) {",
+            "    // BUG: Diagnostic contains: DayOfMonth (valid values 1 - 28/31): 0",
+            "    return localDate.withDayOfMonth(0);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void localTime_withBadHour() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.LocalTime;",
+            "public class TestCase {",
+            "  private static LocalTime foo(LocalTime localTime) {",
+            "    // BUG: Diagnostic contains: HourOfDay (valid values 0 - 23): 25",
+            "    return localTime.withHour(25);",
+            "  }",
             "}")
         .doTest();
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Throw an error when an invalid literal is passed to a java.time.LocalFoo static factory method.

#goodtime

159be18c7b89cdb694873bf9b6591060e254c0f3

-------

<p> Create a helper method for constructing the matchers which validates the # of parameters.
Add instance methods as well to the checker.

#goodtime

cd9184126a818b321eb0eb333f1f64217f25256e

-------

<p> Use an @AutoValue to simplify the data structures in InvalidJavaTimeConstant.

#goodtime

3267e14f1a6af8368d03d66079bad655dbcb7632