### PR TITLE
MOE Sync 2019-10-31

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
@@ -120,6 +120,8 @@ import javax.lang.model.type.NullType;
 public final class UnusedVariable extends BugChecker implements CompilationUnitTreeMatcher {
   private static final String EXEMPT_PREFIX = "unused";
 
+  private static final ImmutableSet<String> EXEMPT_NAMES = ImmutableSet.of("ignored");
+
 
   /**
    * The set of annotation full names which exempt annotated element from being reported as unused.
@@ -528,7 +530,9 @@ public final class UnusedVariable extends BugChecker implements CompilationUnitT
   }
 
   private static boolean exemptedByName(Name name) {
-    return Ascii.toLowerCase(name.toString()).startsWith(EXEMPT_PREFIX);
+    String nameString = name.toString();
+    return Ascii.toLowerCase(nameString).startsWith(EXEMPT_PREFIX)
+        || EXEMPT_NAMES.contains(nameString);
   }
 
   private class VariableFinder extends TreePathScanner<Void, Void> {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/InvalidJavaTimeConstant.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/InvalidJavaTimeConstant.java
@@ -15,7 +15,7 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.packageStartsWith;
@@ -33,10 +33,11 @@ import static java.time.temporal.ChronoField.NANO_OF_SECOND;
 import static java.time.temporal.ChronoField.SECOND_OF_DAY;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 import static java.time.temporal.ChronoField.YEAR;
-import static java.util.Arrays.asList;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -46,8 +47,10 @@ import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.code.Type;
 import java.time.DateTimeException;
 import java.time.temporal.ChronoField;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -59,50 +62,11 @@ import java.util.List;
 @BugPattern(
     name = "InvalidJavaTimeConstant",
     summary =
-        "This checker errors on calls to java.time methods using literals that are guaranteed to "
+        "This checker errors on calls to java.time methods using values that are guaranteed to "
             + "throw a DateTimeException.",
     severity = ERROR)
 public final class InvalidJavaTimeConstant extends BugChecker
     implements MethodInvocationTreeMatcher {
-
-  private static MatcherWithUnits createStatic(
-      String className,
-      String methodName,
-      List<String> parameterTypes,
-      List<ChronoField> parameterUnits) {
-    checkEqualSizes(parameterTypes, parameterUnits);
-    return new AutoValue_InvalidJavaTimeConstant_MatcherWithUnits(
-        staticMethod()
-            .onClass(className)
-            .named(methodName)
-            .withParameters(parameterTypes.toArray(new String[0])),
-        ImmutableList.copyOf(parameterUnits));
-  }
-
-  private static MatcherWithUnits createInstance(
-      String className,
-      String methodName,
-      List<String> parameterTypes,
-      List<ChronoField> parameterUnits) {
-    checkEqualSizes(parameterTypes, parameterUnits);
-    return new AutoValue_InvalidJavaTimeConstant_MatcherWithUnits(
-        instanceMethod()
-            .onExactClass(className)
-            .named(methodName)
-            .withParameters(parameterTypes.toArray(new String[0])),
-        ImmutableList.copyOf(parameterUnits));
-  }
-
-  private static void checkEqualSizes(
-      List<String> parameterTypes, List<ChronoField> parameterUnits) {
-    checkArgument(
-        parameterTypes.size() == parameterUnits.size(),
-        "There must be an equal number of parameter types (%s) and parameter units (%s):\n%s\n%s",
-        parameterTypes.size(),
-        parameterUnits.size(),
-        parameterTypes,
-        parameterUnits);
-  }
 
   @AutoValue
   abstract static class MatcherWithUnits {
@@ -111,165 +75,224 @@ public final class InvalidJavaTimeConstant extends BugChecker
     abstract ImmutableList<ChronoField> units();
   }
 
-  // Note, we use asList(...) below instead of ImmutableList.of(...) to reduce line wrapping.
+  @AutoValue
+  abstract static class Param {
+    abstract String type();
 
-  private static final ImmutableList<MatcherWithUnits> DAY_OF_WEEK_APIS =
-      ImmutableList.of(
-          createStatic("java.time.DayOfWeek", "of", asList("int"), asList(DAY_OF_WEEK)));
+    abstract ChronoField unit();
+  }
 
-  private static final ImmutableList<MatcherWithUnits> MONTH_APIS =
-      ImmutableList.of(createStatic("java.time.Month", "of", asList("int"), asList(MONTH_OF_YEAR)));
+  private static Param intP(ChronoField unit) {
+    return new AutoValue_InvalidJavaTimeConstant_Param("int", unit);
+  }
 
-  private static final ImmutableList<MatcherWithUnits> YEAR_APIS =
-      ImmutableList.of(
-          createStatic("java.time.Year", "of", asList("int"), asList(YEAR)),
-          createInstance("java.time.Year", "atDay", asList("int"), asList(DAY_OF_YEAR)),
-          createInstance("java.time.Year", "atMonth", asList("int"), asList(MONTH_OF_YEAR)));
+  private static Param longP(ChronoField unit) {
+    return new AutoValue_InvalidJavaTimeConstant_Param("long", unit);
+  }
 
-  private static final String YEAR_MONTH = "java.time.YearMonth";
-  private static final ImmutableList<MatcherWithUnits> YEAR_MONTH_APIS =
-      ImmutableList.of(
-          createStatic(YEAR_MONTH, "of", asList("int", "int"), asList(YEAR, MONTH_OF_YEAR)),
-          createStatic(
-              YEAR_MONTH, "of", asList("int", "java.time.Month"), asList(YEAR, MONTH_OF_YEAR)),
-          createInstance(YEAR_MONTH, "atDay", asList("int"), asList(DAY_OF_MONTH)),
-          createInstance(YEAR_MONTH, "withMonth", asList("int"), asList(MONTH_OF_YEAR)),
-          createInstance(YEAR_MONTH, "withYear", asList("int"), asList(YEAR)));
+  private static Param monthP(ChronoField unit) {
+    return new AutoValue_InvalidJavaTimeConstant_Param("java.time.Month", unit);
+  }
 
-  private static final String MONTH_DAY = "java.time.MonthDay";
-  private static final ImmutableList<MatcherWithUnits> MONTH_DAY_APIS =
-      ImmutableList.of(
-          createStatic(MONTH_DAY, "of", asList("int", "int"), asList(MONTH_OF_YEAR, DAY_OF_MONTH)),
-          createStatic(
-              MONTH_DAY,
-              "of",
-              asList("java.time.Month", "int"),
-              asList(MONTH_OF_YEAR, DAY_OF_MONTH)),
-          createInstance(MONTH_DAY, "atYear", asList("int"), asList(YEAR)),
-          createInstance(MONTH_DAY, "withDayOfMonth", asList("int"), asList(DAY_OF_MONTH)),
-          createInstance(MONTH_DAY, "withMonth", asList("int"), asList(MONTH_OF_YEAR)));
+  @AutoValue
+  abstract static class JavaTimeType {
+    abstract String className();
 
-  private static final String LOCAL_TIME = "java.time.LocalTime";
-  private static final ImmutableList<MatcherWithUnits> LOCAL_TIME_APIS =
-      ImmutableList.of(
-          createStatic(LOCAL_TIME, "of", asList("int", "int"), asList(HOUR_OF_DAY, MINUTE_OF_HOUR)),
-          createStatic(
-              LOCAL_TIME,
-              "of",
-              asList("int", "int", "int"),
-              asList(HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE)),
-          createStatic(
-              LOCAL_TIME,
-              "of",
-              asList("int", "int", "int", "int"),
-              asList(HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE, NANO_OF_SECOND)),
-          createStatic(LOCAL_TIME, "ofNanoOfDay", asList("long"), asList(NANO_OF_DAY)),
-          createStatic(LOCAL_TIME, "ofSecondOfDay", asList("long"), asList(SECOND_OF_DAY)),
-          createInstance(LOCAL_TIME, "withHour", asList("int"), asList(HOUR_OF_DAY)),
-          createInstance(LOCAL_TIME, "withMinute", asList("int"), asList(MINUTE_OF_HOUR)),
-          createInstance(LOCAL_TIME, "withNano", asList("int"), asList(NANO_OF_SECOND)),
-          createInstance(LOCAL_TIME, "withSecond", asList("int"), asList(SECOND_OF_MINUTE)));
+    abstract ImmutableList<MatcherWithUnits> methods();
 
-  private static final String LOCAL_DATE = "java.time.LocalDate";
-  private static final ImmutableList<MatcherWithUnits> LOCAL_DATE_APIS =
-      ImmutableList.of(
-          createStatic(
-              LOCAL_DATE,
-              "of",
-              asList("int", "int", "int"),
-              asList(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH)),
-          createStatic(
-              LOCAL_DATE,
-              "of",
-              asList("int", "java.time.Month", "int"),
-              asList(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH)),
-          createStatic(LOCAL_DATE, "ofEpochDay", asList("long"), asList(EPOCH_DAY)),
-          createStatic(LOCAL_DATE, "ofYearDay", asList("int", "int"), asList(YEAR, DAY_OF_YEAR)),
-          createInstance(LOCAL_DATE, "withDayOfMonth", asList("int"), asList(DAY_OF_MONTH)),
-          createInstance(LOCAL_DATE, "withDayOfYear", asList("int"), asList(DAY_OF_YEAR)),
-          createInstance(LOCAL_DATE, "withMonth", asList("int"), asList(MONTH_OF_YEAR)),
-          createInstance(LOCAL_DATE, "withYear", asList("int"), asList(YEAR)));
+    public static Builder builder() {
+      return new AutoValue_InvalidJavaTimeConstant_JavaTimeType.Builder();
+    }
 
-  private static final String LOCAL_DATE_TIME = "java.time.LocalDateTime";
-  private static final ImmutableList<MatcherWithUnits> LOCAL_DATE_TIME_APIS =
-      ImmutableList.of(
-          createStatic(
-              LOCAL_DATE_TIME,
-              "of",
-              asList("int", "int", "int", "int", "int"),
-              asList(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH, HOUR_OF_DAY, MINUTE_OF_HOUR)),
-          createStatic(
-              LOCAL_DATE_TIME,
-              "of",
-              asList("int", "java.time.Month", "int", "int", "int"),
-              asList(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH, HOUR_OF_DAY, MINUTE_OF_HOUR)),
-          createStatic(
-              LOCAL_DATE_TIME,
-              "of",
-              asList("int", "int", "int", "int", "int", "int"),
-              asList(
-                  YEAR,
-                  MONTH_OF_YEAR,
-                  DAY_OF_MONTH,
-                  HOUR_OF_DAY,
-                  MINUTE_OF_HOUR,
-                  SECOND_OF_MINUTE)),
-          createStatic(
-              LOCAL_DATE_TIME,
-              "of",
-              asList("int", "java.time.Month", "int", "int", "int", "int"),
-              asList(
-                  YEAR,
-                  MONTH_OF_YEAR,
-                  DAY_OF_MONTH,
-                  HOUR_OF_DAY,
-                  MINUTE_OF_HOUR,
-                  SECOND_OF_MINUTE)),
-          createStatic(
-              LOCAL_DATE_TIME,
-              "of",
-              asList("int", "int", "int", "int", "int", "int", "int"),
-              asList(
-                  YEAR,
-                  MONTH_OF_YEAR,
-                  DAY_OF_MONTH,
-                  HOUR_OF_DAY,
-                  MINUTE_OF_HOUR,
-                  SECOND_OF_MINUTE,
-                  NANO_OF_SECOND)),
-          createStatic(
-              LOCAL_DATE_TIME,
-              "of",
-              asList("int", "java.time.Month", "int", "int", "int", "int", "int"),
-              asList(
-                  YEAR,
-                  MONTH_OF_YEAR,
-                  DAY_OF_MONTH,
-                  HOUR_OF_DAY,
-                  MINUTE_OF_HOUR,
-                  SECOND_OF_MINUTE,
-                  NANO_OF_SECOND)),
-          createInstance(LOCAL_DATE_TIME, "withDayOfMonth", asList("int"), asList(DAY_OF_MONTH)),
-          createInstance(LOCAL_DATE_TIME, "withDayOfYear", asList("int"), asList(DAY_OF_YEAR)),
-          createInstance(LOCAL_DATE_TIME, "withHour", asList("int"), asList(HOUR_OF_DAY)),
-          createInstance(LOCAL_DATE_TIME, "withMinute", asList("int"), asList(MINUTE_OF_HOUR)),
-          createInstance(LOCAL_DATE_TIME, "withMonth", asList("int"), asList(MONTH_OF_YEAR)),
-          createInstance(LOCAL_DATE_TIME, "withNano", asList("int"), asList(NANO_OF_SECOND)),
-          createInstance(LOCAL_DATE_TIME, "withSecond", asList("int"), asList(SECOND_OF_MINUTE)),
-          createInstance(LOCAL_DATE_TIME, "withYear", asList("int"), asList(YEAR)));
+    @AutoValue.Builder
+    public abstract static class Builder {
+      public abstract Builder setClassName(String className);
 
-  private static final ImmutableList<MatcherWithUnits> APIS =
-      ImmutableList.<MatcherWithUnits>builder()
-          // add the more popular types at the beginning for a slight speed-up
-          .addAll(LOCAL_TIME_APIS)
-          .addAll(LOCAL_DATE_APIS)
-          .addAll(LOCAL_DATE_TIME_APIS)
-          .addAll(DAY_OF_WEEK_APIS)
-          .addAll(MONTH_APIS)
-          .addAll(MONTH_DAY_APIS)
-          .addAll(YEAR_APIS)
-          .addAll(YEAR_MONTH_APIS)
+      abstract String className();
+
+      abstract ImmutableList.Builder<MatcherWithUnits> methodsBuilder();
+
+      public Builder addStaticMethod(String methodName, Param... params) {
+        methodsBuilder()
+            .add(
+                new AutoValue_InvalidJavaTimeConstant_MatcherWithUnits(
+                    staticMethod()
+                        .onClass(className())
+                        .named(methodName)
+                        .withParameters(getParameterTypes(params)),
+                    getParameterUnits(params)));
+        return this;
+      }
+
+      public Builder addInstanceMethod(String methodName, Param... params) {
+        methodsBuilder()
+            .add(
+                new AutoValue_InvalidJavaTimeConstant_MatcherWithUnits(
+                    instanceMethod()
+                        .onExactClass(className())
+                        .named(methodName)
+                        .withParameters(getParameterTypes(params)),
+                    getParameterUnits(params)));
+        return this;
+      }
+
+      private static ImmutableList<ChronoField> getParameterUnits(Param... params) {
+        return Arrays.stream(params).map(p -> p.unit()).collect(toImmutableList());
+      }
+
+      private static String[] getParameterTypes(Param... params) {
+        return Arrays.stream(params).map(p -> p.type()).toArray(String[]::new);
+      }
+
+      public abstract JavaTimeType build();
+    }
+  }
+
+  private static final JavaTimeType DAY_OF_WEEK_APIS =
+      JavaTimeType.builder()
+          .setClassName("java.time.DayOfWeek")
+          .addStaticMethod("of", intP(DAY_OF_WEEK))
           .build();
+
+  private static final JavaTimeType MONTH_APIS =
+      JavaTimeType.builder()
+          .setClassName("java.time.Month")
+          .addStaticMethod("of", intP(MONTH_OF_YEAR))
+          .build();
+
+  private static final JavaTimeType YEAR_APIS =
+      JavaTimeType.builder()
+          .setClassName("java.time.Year")
+          .addStaticMethod("of", intP(YEAR))
+          .addInstanceMethod("atDay", intP(DAY_OF_YEAR))
+          .addInstanceMethod("atMonth", intP(MONTH_OF_YEAR))
+          .build();
+
+  private static final JavaTimeType YEAR_MONTH_APIS =
+      JavaTimeType.builder()
+          .setClassName("java.time.YearMonth")
+          .addStaticMethod("of", intP(YEAR), intP(MONTH_OF_YEAR))
+          .addStaticMethod("of", intP(YEAR), monthP(MONTH_OF_YEAR))
+          .addInstanceMethod("atDay", intP(DAY_OF_MONTH))
+          .addInstanceMethod("withMonth", intP(MONTH_OF_YEAR))
+          .addInstanceMethod("withYear", intP(YEAR))
+          .build();
+
+  private static final JavaTimeType MONTH_DAY_APIS =
+      JavaTimeType.builder()
+          .setClassName("java.time.MonthDay")
+          .addStaticMethod("of", intP(MONTH_OF_YEAR), intP(DAY_OF_MONTH))
+          .addStaticMethod("of", monthP(MONTH_OF_YEAR), intP(DAY_OF_MONTH))
+          .addInstanceMethod("atYear", intP(YEAR))
+          .addInstanceMethod("withDayOfMonth", intP(DAY_OF_MONTH))
+          .addInstanceMethod("withMonth", intP(MONTH_OF_YEAR))
+          .build();
+
+  private static final JavaTimeType LOCAL_TIME_APIS =
+      JavaTimeType.builder()
+          .setClassName("java.time.LocalTime")
+          .addStaticMethod("of", intP(HOUR_OF_DAY), intP(MINUTE_OF_HOUR))
+          .addStaticMethod("of", intP(HOUR_OF_DAY), intP(MINUTE_OF_HOUR), intP(SECOND_OF_MINUTE))
+          .addStaticMethod(
+              "of",
+              intP(HOUR_OF_DAY),
+              intP(MINUTE_OF_HOUR),
+              intP(SECOND_OF_MINUTE),
+              intP(NANO_OF_SECOND))
+          .addStaticMethod("ofNanoOfDay", longP(NANO_OF_DAY))
+          .addStaticMethod("ofSecondOfDay", longP(SECOND_OF_DAY))
+          .addInstanceMethod("withHour", intP(HOUR_OF_DAY))
+          .addInstanceMethod("withMinute", intP(MINUTE_OF_HOUR))
+          .addInstanceMethod("withNano", intP(NANO_OF_SECOND))
+          .addInstanceMethod("withSecond", intP(SECOND_OF_MINUTE))
+          .build();
+
+  private static final JavaTimeType LOCAL_DATE_APIS =
+      JavaTimeType.builder()
+          .setClassName("java.time.LocalDate")
+          .addStaticMethod("of", intP(YEAR), intP(MONTH_OF_YEAR), intP(DAY_OF_MONTH))
+          .addStaticMethod("of", intP(YEAR), monthP(MONTH_OF_YEAR), intP(DAY_OF_MONTH))
+          .addStaticMethod("ofEpochDay", longP(EPOCH_DAY))
+          .addStaticMethod("ofYearDay", intP(YEAR), intP(DAY_OF_YEAR))
+          .addInstanceMethod("withDayOfMonth", intP(DAY_OF_MONTH))
+          .addInstanceMethod("withDayOfYear", intP(DAY_OF_YEAR))
+          .addInstanceMethod("withMonth", intP(MONTH_OF_YEAR))
+          .addInstanceMethod("withYear", intP(YEAR))
+          .build();
+
+  private static final JavaTimeType LOCAL_DATE_TIME_APIS =
+      JavaTimeType.builder()
+          .setClassName("java.time.LocalDateTime")
+          .addStaticMethod(
+              "of",
+              intP(YEAR),
+              intP(MONTH_OF_YEAR),
+              intP(DAY_OF_MONTH),
+              intP(HOUR_OF_DAY),
+              intP(MINUTE_OF_HOUR))
+          .addStaticMethod(
+              "of",
+              intP(YEAR),
+              monthP(MONTH_OF_YEAR),
+              intP(DAY_OF_MONTH),
+              intP(HOUR_OF_DAY),
+              intP(MINUTE_OF_HOUR))
+          .addStaticMethod(
+              "of",
+              intP(YEAR),
+              intP(MONTH_OF_YEAR),
+              intP(DAY_OF_MONTH),
+              intP(HOUR_OF_DAY),
+              intP(MINUTE_OF_HOUR),
+              intP(SECOND_OF_MINUTE))
+          .addStaticMethod(
+              "of",
+              intP(YEAR),
+              monthP(MONTH_OF_YEAR),
+              intP(DAY_OF_MONTH),
+              intP(HOUR_OF_DAY),
+              intP(MINUTE_OF_HOUR),
+              intP(SECOND_OF_MINUTE))
+          .addStaticMethod(
+              "of",
+              intP(YEAR),
+              intP(MONTH_OF_YEAR),
+              intP(DAY_OF_MONTH),
+              intP(HOUR_OF_DAY),
+              intP(MINUTE_OF_HOUR),
+              intP(SECOND_OF_MINUTE),
+              intP(NANO_OF_SECOND))
+          .addStaticMethod(
+              "of",
+              intP(YEAR),
+              monthP(MONTH_OF_YEAR),
+              intP(DAY_OF_MONTH),
+              intP(HOUR_OF_DAY),
+              intP(MINUTE_OF_HOUR),
+              intP(SECOND_OF_MINUTE),
+              intP(NANO_OF_SECOND))
+          .addInstanceMethod("withDayOfMonth", intP(DAY_OF_MONTH))
+          .addInstanceMethod("withDayOfYear", intP(DAY_OF_YEAR))
+          .addInstanceMethod("withHour", intP(HOUR_OF_DAY))
+          .addInstanceMethod("withMinute", intP(MINUTE_OF_HOUR))
+          .addInstanceMethod("withMonth", intP(MONTH_OF_YEAR))
+          .addInstanceMethod("withNano", intP(NANO_OF_SECOND))
+          .addInstanceMethod("withSecond", intP(SECOND_OF_MINUTE))
+          .addInstanceMethod("withYear", intP(YEAR))
+          .build();
+
+  private static final ImmutableMap<String, JavaTimeType> APIS =
+      Maps.uniqueIndex(
+          ImmutableList.of(
+              LOCAL_TIME_APIS,
+              LOCAL_DATE_APIS,
+              LOCAL_DATE_TIME_APIS,
+              DAY_OF_WEEK_APIS,
+              MONTH_APIS,
+              YEAR_APIS,
+              MONTH_DAY_APIS,
+              YEAR_MONTH_APIS),
+          JavaTimeType::className);
 
   private static final Matcher<ExpressionTree> JAVA_MATCHER =
       anyOf(packageStartsWith("java."), packageStartsWith("tck.java."));
@@ -280,8 +303,19 @@ public final class InvalidJavaTimeConstant extends BugChecker
     if (JAVA_MATCHER.matches(tree, state)) {
       return Description.NO_MATCH;
     }
+    // Get the receiver of the method invocation and make sure it's not null
+    Type receiverType = ASTHelpers.getReceiverType(tree);
+    if (receiverType == null) {
+      return Description.NO_MATCH;
+    }
+    // If the receiver is not one of our java.time types, then return early
+    JavaTimeType type = APIS.get(receiverType.toString());
+    if (type == null) {
+      return Description.NO_MATCH;
+    }
 
-    for (MatcherWithUnits matcherWithUnits : APIS) {
+    // Otherwise, check the method matchers we have for that type
+    for (MatcherWithUnits matcherWithUnits : type.methods()) {
       if (matcherWithUnits.matcher().matches(tree, state)) {
         List<? extends ExpressionTree> arguments = tree.getArguments();
         for (int i = 0; i < arguments.size(); i++) {
@@ -295,8 +329,8 @@ public final class InvalidJavaTimeConstant extends BugChecker
             }
           }
         }
-        // we short-circuit the loop here; only 1 matcher will ever match, so there's no sense in
-        // checking the rest of them
+        // we short-circuit the loop here; only 1 method matcher will ever match, so there's no
+        // sense in checking the rest of them
         return Description.NO_MATCH;
       }
     }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedVariableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedVariableTest.java
@@ -434,6 +434,7 @@ public class UnusedVariableTest {
             "  private int unused;",
             "  private int unusedInt;",
             "  private static final int UNUSED_CONSTANT = 5;",
+            "  private int ignored;",
             "}")
         .doTest();
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/InvalidJavaTimeConstantTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/InvalidJavaTimeConstantTest.java
@@ -158,4 +158,18 @@ public class InvalidJavaTimeConstantTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void dayOfWeek_withBadDay() {
+    compilationHelper
+        .addSourceLines(
+            "test/TestCase.java",
+            "package test;",
+            "import java.time.DayOfWeek;",
+            "public class TestCase {",
+            "  // BUG: Diagnostic contains: DayOfWeek (valid values 1 - 7): 8",
+            "  private static final DayOfWeek DOW = DayOfWeek.of(8);",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Use an AutoValue builder to avoid repeating the type name on every MatcherWithUnits creation.

#goodtime

518c1a0c274fb29754d869dc68550119bdb0891d

-------

<p> UnusedVariable: skip variables named "ignored", too, given IntelliJ suggests this.

5957ac27c43cf79e20ff384eb15f1e04a0ed1394