### PR TITLE
MOE Sync 2019-11-01

### DIFF
--- a/check_api/pom.xml
+++ b/check_api/pom.xml
@@ -26,7 +26,7 @@
     <repository>
       <id>alt-repo1</id>
       <name>repo1.maven.org</name>
-      <url>http://repo1.maven.org</url>
+      <url>https://repo1.maven.org</url>
     </repository>
   </repositories>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,7 @@
     <repository>
       <id>alt-repo1</id>
       <name>repo1.maven.org</name>
-      <url>http://repo1.maven.org</url>
+      <url>https://repo1.maven.org</url>
     </repository>
   </repositories>
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LiteProtoToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LiteProtoToString.java
@@ -68,9 +68,11 @@ public final class LiteProtoToString extends AbstractToString {
           not(isDescendantOf("com.google.protobuf.ProtocolMessageEnum")),
           not(isDescendantOf("com.google.protobuf.AbstractMessageLite.InternalOneOfEnum")));
 
-  private static final ImmutableSet<String> VERBOSE_LOGGING =
-      ImmutableSet.of(
-          "atVerbose", "atFine", "atFiner", "atFinest", "atDebug", "atConfig", "v", "d");
+  private static final ImmutableSet<String> METHODS_STRIPPED_BY_OPTIMIZER =
+      ImmutableSet.<String>builder()
+          .add("atVerbose", "atFine", "atFiner", "atFinest", "atDebug", "atConfig", "atInfo")
+          .add("v", "d", "i")
+          .build();
 
   @Override
   protected TypePredicate typePredicate() {
@@ -81,19 +83,19 @@ public final class LiteProtoToString extends AbstractToString {
     if (state.errorProneOptions().isTestOnlyTarget()) {
       return false;
     }
-    if (isVerboseLogMessage(state)) {
+    if (isStrippedLogMessage(state)) {
       return false;
     }
     return IS_LITE_PROTO.apply(type, state) || IS_LITE_ENUM.apply(type, state);
   }
 
-  private static boolean isVerboseLogMessage(VisitorState state) {
-    return Streams.stream(state.getPath()).anyMatch(LiteProtoToString::isVerboseLogMessage);
+  private static boolean isStrippedLogMessage(VisitorState state) {
+    return Streams.stream(state.getPath()).anyMatch(LiteProtoToString::isStrippedLogMessage);
   }
 
-  private static boolean isVerboseLogMessage(Tree tree) {
+  private static boolean isStrippedLogMessage(Tree tree) {
     for (; tree instanceof MethodInvocationTree; tree = getReceiver((MethodInvocationTree) tree)) {
-      if (VERBOSE_LOGGING.contains(getSymbol(tree).getSimpleName().toString())) {
+      if (METHODS_STRIPPED_BY_OPTIMIZER.contains(getSymbol(tree).getSimpleName().toString())) {
         return true;
       }
     }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/LiteProtoToStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/LiteProtoToStringTest.java
@@ -120,6 +120,45 @@ public final class LiteProtoToStringTest {
 
 
   @Test
+  public void androidLogAtInfoOrFiner_noWarning() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.protobuf.GeneratedMessageLite;",
+            "class Test {",
+            "  static class Log {",
+            "    static void i(String s) {}",
+            "    static void d(String s) {}",
+            "    static void v(String s) {}",
+            "  }",
+            "  private void test(GeneratedMessageLite message) {",
+            "    Log.i(message.toString());",
+            "    Log.d(message.toString());",
+            "    Log.v(message.toString());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void androidLogAtWarning_error() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.protobuf.GeneratedMessageLite;",
+            "class Test {",
+            "  static class Log {",
+            "    static void w(String s) {}",
+            "  }",
+            "  private void test(GeneratedMessageLite message) {",
+            "    // BUG: Diagnostic contains:",
+            "    Log.w(message.toString());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void customFormatMethod() {
     compilationHelper
         .addSourceLines(

--- a/test_helpers/pom.xml
+++ b/test_helpers/pom.xml
@@ -24,7 +24,7 @@
     <repository>
       <id>alt-repo1</id>
       <name>repo1.maven.org</name>
-      <url>http://repo1.maven.org</url>
+      <url>https://repo1.maven.org</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> maven:  use 'https' instead of 'http'

Fixes #1391

b40559db1bf1d00cf8a4294a9c0a61ec81a48693

-------

<p> Do not report toString calls on lite protos for info logging

46df469afb987d53fae0e60557e962ac02a9ce9e

-------

<p> InterruptedExceptionSwallowed: flag methods which declare they throw Exception, but actually throw an InterruptedException.

ea8406f1fc0e3e640b5303b888aa1198285d79bc