### PR TITLE
Bundle caffeine in the with-dependencies JAR

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -389,6 +389,7 @@
                   <include>org.pcollections:pcollections</include>
                   <include>com.google.guava:guava</include>
                   <include>com.google.guava:failureaccess</include>
+                  <include>com.github.ben-manes.caffeine:caffeine</include>
                   <include>com.google.auto:auto-common</include>
                   <include>com.google.code.findbugs:jsr305</include>
                   <include>com.google.protobuf:protobuf-java</include>


### PR DESCRIPTION
Add caffeine in with-dependencies JAR, broken after https://github.com/google/error-prone/commit/bfb1789f5597a30abef367b88113bd61e023d86b
Similar to https://github.com/google/error-prone/pull/1259 and https://github.com/google/error-prone/issues/1238