### PR TITLE
MOE Sync 2019-11-07

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/CompileTimeConstantChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CompileTimeConstantChecker.java
@@ -271,6 +271,9 @@ public class CompileTimeConstantChecker extends BugChecker
     ExpressionTree variable = node.getVariable();
     ExpressionTree expression = node.getExpression();
     Symbol assignedSymbol = ASTHelpers.getSymbol(variable);
+    if (assignedSymbol == null || assignedSymbol.owner == null) {
+      return Description.NO_MATCH;
+    }
     if (assignedSymbol.owner.getKind() != ElementKind.CLASS) {
       return Description.NO_MATCH;
     }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix NPE in CompileTimeConstantChecker, unblock JavaBuilder release

e8d0ed81c4a99ba289804808875194fb07156659