### PR TITLE
MOE Sync 2019-11-08

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ArrayToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ArrayToString.java
@@ -60,7 +60,7 @@ public class ArrayToString extends AbstractToString {
 
   @Override
   protected boolean allowableToStringKind(ToStringKind toStringKind) {
-    return toStringKind == ToStringKind.FLOGGER;
+    return toStringKind == ToStringKind.FLOGGER || toStringKind == ToStringKind.FORMAT_METHOD;
   }
 
   @Override

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ArrayToStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ArrayToStringTest.java
@@ -113,6 +113,10 @@ public class ArrayToStringTest {
         .doTest();
   }
 
+  /**
+   * Don't complain about {@code @FormatMethod}s; there's a chance they're handling arrays
+   * correctly.
+   */
   @Test
   public void customFormatMethod() {
     compilationHelper
@@ -121,29 +125,10 @@ public class ArrayToStringTest {
             "import com.google.errorprone.annotations.FormatMethod;",
             "class Test {",
             "  private void test(Object[] arr) {",
-            "    // BUG: Diagnostic contains:",
             "    format(\"%s %s\", arr, 2);",
             "  }",
             "  @FormatMethod",
             "  String format(String format, Object... args) {",
-            "    return String.format(format, args);",
-            "  }",
-            "}")
-        .doTest();
-  }
-
-  @Test
-  public void customFormatMethod_varargsPassedThrough() {
-    compilationHelper
-        .addSourceLines(
-            "Test.java",
-            "import com.google.errorprone.annotations.FormatMethod;",
-            "class Test {",
-            "  private void test(String format, Object... args) {",
-            "    format(null, format, args);",
-            "  }",
-            "  @FormatMethod",
-            "  String format(Object tag, String format, Object... args) {",
             "    return String.format(format, args);",
             "  }",
             "}")


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> ArrayToString: don't complain about @FormatMethods. They may be doing something special to handle arrays correctly.

This was changed to start checking @FormatMethods. Unfortunately(?), it's quite possible to annotate a @FormatMethod which is more clever than the average, which leads to false positives. I'm backing away from that change just to get this re-enabled as an error.

d4ae118509684aa3de1d27ccffd8c3998cd2f845