### PR TITLE
MOE Sync 2019-11-11

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ArrayToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ArrayToString.java
@@ -29,6 +29,8 @@ import com.google.errorprone.predicates.TypePredicates;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Types;
 import java.util.Optional;
 
 /**
@@ -80,14 +82,23 @@ public class ArrayToString extends AbstractToString {
     }
     // e.g. String.valueOf(theArray) -> Arrays.toString(theArray)
     // or:  theArray.toString() -> Arrays.toString(theArray)
+    // or:  theArrayOfArrays.toString() -> Arrays.deepToString(theArrayOfArrays)
     return fix(parent, tree, state);
   }
 
   private Optional<Fix> fix(Tree replace, Tree with, VisitorState state) {
+    String method = isNestedArray(with, state) ? "deepToString" : "toString";
+
     return Optional.of(
         SuggestedFix.builder()
             .addImport("java.util.Arrays")
-            .replace(replace, String.format("Arrays.toString(%s)", state.getSourceForNode(with)))
+            .replace(replace, String.format("Arrays.%s(%s)", method, state.getSourceForNode(with)))
             .build());
+  }
+
+  private static boolean isNestedArray(Tree with, VisitorState state) {
+    Types types = state.getTypes();
+    Type withType = ASTHelpers.getType(with);
+    return withType != null && types.isArray(withType) && types.isArray(types.elemtype(withType));
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TransientMisuse.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TransientMisuse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.LinkType.NONE;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.VariableTree;
+import javax.lang.model.element.Modifier;
+
+/**
+ * Warns against use of both {@code static} and {@code transient} modifiers on field declarations.
+ */
+@BugPattern(
+    name = "TransientMisuse",
+    summary = "Static fields are implicitly transient, so the explicit modifier is unnecessary",
+    linkType = NONE,
+    severity = WARNING,
+    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+public class TransientMisuse extends BugChecker implements VariableTreeMatcher {
+  @Override
+  public Description matchVariable(VariableTree tree, VisitorState state) {
+    if (tree.getModifiers()
+        .getFlags()
+        .containsAll(ImmutableList.of(Modifier.STATIC, Modifier.TRANSIENT))) {
+      return describeMatch(tree, SuggestedFixes.removeModifiers(tree, state, Modifier.TRANSIENT));
+    }
+    return Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -275,6 +275,7 @@ import com.google.errorprone.bugpatterns.ThrowNull;
 import com.google.errorprone.bugpatterns.ThrowSpecificExceptions;
 import com.google.errorprone.bugpatterns.ThrowsUncheckedException;
 import com.google.errorprone.bugpatterns.ToStringReturnsNull;
+import com.google.errorprone.bugpatterns.TransientMisuse;
 import com.google.errorprone.bugpatterns.TreeToString;
 import com.google.errorprone.bugpatterns.TruthAssertExpected;
 import com.google.errorprone.bugpatterns.TruthConstantAsserts;
@@ -879,6 +880,7 @@ public class BuiltInCheckerSuppliers {
           ThrowSpecificExceptions.class,
           ThrowsUncheckedException.class,
           TimeUnitMismatch.class,
+          TransientMisuse.class,
           TryFailRefactoring.class,
           TypeParameterNaming.class,
           UnescapedEntity.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TransientMisuseTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TransientMisuseTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link TransientMisuse}. */
+@RunWith(JUnit4.class)
+public class TransientMisuseTest {
+
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(TransientMisuse.class, getClass());
+
+  @Test
+  public void positive() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  // BUG: Diagnostic contains: static String foo1",
+            "  static transient String foo1;",
+            "  // BUG: Diagnostic contains: static String foo2",
+            "  transient static String foo2;",
+            "  // BUG: Diagnostic contains: static final public String foo3",
+            "  static final public transient String foo3 = \"\";",
+            "  // BUG: Diagnostic contains: protected final static String foo4",
+            "  protected final static transient String foo4 = \"\";",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java", //
+            "class Test {",
+            "  static String foo;",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ArrayToStringPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ArrayToStringPositiveCases.java
@@ -70,4 +70,10 @@ public class ArrayToStringPositiveCases {
     // BUG: Diagnostic contains: Throwables.getStackTraceAsString(e)
     System.out.println(e.getStackTrace().toString());
   }
+
+  public void arrayOfArrays() {
+    int[][] a = {};
+    // BUG: Diagnostic contains: Arrays.deepToString(a)
+    System.out.println(a);
+  }
 }

--- a/docs/bugpattern/FormatStringAnnotation.md
+++ b/docs/bugpattern/FormatStringAnnotation.md
@@ -29,3 +29,8 @@ We will then check that the format string and format arguments match.
 
 For more information on possible format string errors, see the documentation on
 the [FormatString check](FormatString).
+
+## Suppression
+
+Suppress false positives by adding the suppression annotation
+@SuppressWarnings("FormatStringAnnotation") to the enclosing element.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Document @SuppressFormatString suppression.

0a379f0d03ef4bb39544cdcd6ae7746a98df5b5c

-------

<p> Add a check for "static transient."

All static fields are transient, so this may reflect a misunderstanding on the user's part.

bfdeaf9e0e1c7319572297dc9075617e217d961f

-------

<p> ArrayToString: use deepToString for arrays of arrays

4426e87c6799962f7d965a4fea994e830e903af5