### PR TITLE
Remove unused dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -79,12 +79,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <!-- Apache 2.0 -->
-      <groupId>com.github.stephenc.jcip</groupId>
-      <artifactId>jcip-annotations</artifactId>
-      <version>1.0-1</version>
-    </dependency>
-    <dependency>
       <!-- MIT -->
       <groupId>org.pcollections</groupId>
       <artifactId>pcollections</artifactId>


### PR DESCRIPTION
Hello, I noticed that dependency `jcip-annotations` is declared in the `pom` of the core module. However,  this dependency is not used. Therefore, it makes sense to remove it in order to make the core of the library slimmer, and the Maven dependency tree less complex and easier to maintain.  