### PR TITLE
MOE Sync 2019-11-19

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/TheoryButNoTheories.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TheoryButNoTheories.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.AT_LEAST_ONE;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.JUnitMatchers.hasJUnit4TestRunner;
+import static com.google.errorprone.matchers.JUnitMatchers.isJUnit4TestRunnerOfType;
+import static com.google.errorprone.matchers.Matchers.annotations;
+import static com.google.errorprone.matchers.Matchers.hasArgumentWithValue;
+import static com.google.errorprone.util.ASTHelpers.annotationsAmong;
+import static com.google.errorprone.util.ASTHelpers.getAnnotationWithSimpleName;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.MultiMatcher;
+import com.google.errorprone.suppliers.Supplier;
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.util.Name;
+import java.util.stream.Stream;
+
+/** Flags uses of {@code @Theory} (and others) in non-{@code Theories}-run tests. */
+@BugPattern(
+    name = "TheoryButNoTheories",
+    summary =
+        "This test has members annotated with @Theory, @DataPoint, or @DataPoints but is using the"
+            + " default JUnit4 runner.",
+    severity = ERROR)
+public final class TheoryButNoTheories extends BugChecker implements ClassTreeMatcher {
+  private static final String THEORIES = "org.junit.experimental.theories.Theories";
+
+  private static final Supplier<ImmutableSet<Name>> TYPES =
+      VisitorState.memoize(
+          s ->
+              Stream.of(
+                      "org.junit.experimental.theories.Theory",
+                      "org.junit.experimental.theories.DataPoint",
+                      "org.junit.experimental.theories.DataPoints")
+                  .map(s::getName)
+                  .collect(toImmutableSet()));
+
+  private static final MultiMatcher<Tree, AnnotationTree> USING_THEORIES_RUNNER =
+      annotations(
+          AT_LEAST_ONE,
+          hasArgumentWithValue("value", isJUnit4TestRunnerOfType(ImmutableSet.of(THEORIES))));
+
+  @Override
+  public Description matchClass(ClassTree tree, VisitorState state) {
+    if (!hasJUnit4TestRunner.matches(tree, state)) {
+      return NO_MATCH;
+    }
+    if (USING_THEORIES_RUNNER.matches(tree, state)) {
+      return NO_MATCH;
+    }
+    if (tree.getMembers().stream()
+        .allMatch(m -> annotationsAmong(getSymbol(m), TYPES.get(state), state).isEmpty())) {
+      return NO_MATCH;
+    }
+    AnnotationTree annotation =
+        getAnnotationWithSimpleName(tree.getModifiers().getAnnotations(), "RunWith");
+    SuggestedFix.Builder fix = SuggestedFix.builder();
+    fix.replace(
+        annotation,
+        String.format("@RunWith(%s.class)", SuggestedFixes.qualifyType(state, fix, THEORIES)));
+    return describeMatch(tree, fix.build());
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/NamedParameterComment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/NamedParameterComment.java
@@ -41,7 +41,7 @@ import java.util.stream.Stream;
 public final class NamedParameterComment {
 
   public static final Pattern PARAMETER_COMMENT_PATTERN =
-      Pattern.compile("\\s*([\\w\\d_]+)\\s*=\\s*");
+      Pattern.compile("\\s*([\\w\\d_]+)(...)?\\s*=\\s*");
 
   private static final String PARAMETER_COMMENT_MARKER = "=";
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/AlmostJavadoc.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/AlmostJavadoc.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.javadoc;
+
+import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.BugPattern.StandardTags.STYLE;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static java.util.stream.Collectors.joining;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Streams;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.google.errorprone.util.ErrorProneToken;
+import com.google.errorprone.util.ErrorProneTokens;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePathScanner;
+import com.sun.tools.javac.parser.Tokens.Comment;
+import com.sun.tools.javac.tree.JCTree;
+import java.util.regex.Pattern;
+import javax.lang.model.element.ElementKind;
+
+/**
+ * Flags comments which appear to be intended to be Javadoc, but are not started with an extra
+ * {@code *}.
+ */
+@BugPattern(
+    name = "AlmostJavadoc",
+    summary =
+        "This comment contains Javadoc or HTML tags, but isn't started with a double asterisk"
+            + " (/**); is it meant to be Javadoc?",
+    severity = WARNING,
+    tags = STYLE,
+    providesFix = REQUIRES_HUMAN_ATTENTION,
+    documentSuppression = false)
+public final class AlmostJavadoc extends BugChecker implements CompilationUnitTreeMatcher {
+  private static final Pattern HAS_TAG =
+      Pattern.compile(
+          String.format(
+              "<\\w+>|@(%s)",
+              Streams.concat(
+                      JavadocTag.VALID_CLASS_TAGS.stream(),
+                      JavadocTag.VALID_METHOD_TAGS.stream(),
+                      JavadocTag.VALID_VARIABLE_TAGS.stream())
+                  .map(JavadocTag::name)
+                  .map(Pattern::quote)
+                  .distinct()
+                  .collect(joining("|"))));
+
+  @Override
+  public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {
+    ImmutableMap<Integer, Tree> javadocableTrees = getJavadocableTrees(tree, state);
+    for (ErrorProneToken token :
+        ErrorProneTokens.getTokens(state.getSourceCode().toString(), state.context)) {
+      for (Comment comment : token.comments()) {
+        if (!javadocableTrees.containsKey(token.pos())) {
+          continue;
+        }
+        if (!comment.getText().startsWith("/*") || comment.getText().startsWith("/**")) {
+          continue;
+        }
+        if (HAS_TAG.matcher(comment.getText()).find()) {
+          int pos = comment.getSourcePos(1);
+          SuggestedFix fix = SuggestedFix.replace(pos, pos, "*");
+          state.reportMatch(describeMatch(javadocableTrees.get(token.pos()), fix));
+        }
+      }
+    }
+    return NO_MATCH;
+  }
+
+  private ImmutableMap<Integer, Tree> getJavadocableTrees(
+      CompilationUnitTree tree, VisitorState state) {
+    ImmutableMap.Builder<Integer, Tree> javadoccablePositions = ImmutableMap.builder();
+    new TreePathScanner<Void, Void>() {
+      @Override
+      public Void visitClass(ClassTree classTree, Void unused) {
+        if (!shouldMatch()) {
+          return null;
+        }
+        javadoccablePositions.put(startPos(classTree), classTree);
+        return super.visitClass(classTree, null);
+      }
+
+      @Override
+      public Void visitMethod(MethodTree methodTree, Void unused) {
+        if (!shouldMatch()) {
+          return null;
+        }
+        if (!ASTHelpers.isGeneratedConstructor(methodTree)) {
+          javadoccablePositions.put(startPos(methodTree), methodTree);
+        }
+        return super.visitMethod(methodTree, null);
+      }
+
+      @Override
+      public Void visitVariable(VariableTree variableTree, Void unused) {
+        if (!shouldMatch()) {
+          return null;
+        }
+        ElementKind kind = getSymbol(variableTree).getKind();
+        if (kind == ElementKind.FIELD || kind == ElementKind.ENUM_CONSTANT) {
+          javadoccablePositions.put(startPos(variableTree), variableTree);
+        }
+        return super.visitVariable(variableTree, null);
+      }
+
+      private boolean shouldMatch() {
+        if (isSuppressed(getCurrentPath().getLeaf())) {
+          return false;
+        }
+        // Check there isn't already a Javadoc for the element under question, otherwise we might
+        // suggest double Javadoc.
+        return Utils.getDocTreePath(state.withPath(getCurrentPath())) == null;
+      }
+
+      private int startPos(Tree tree) {
+        return ((JCTree) tree).getStartPosition();
+      }
+    }.scan(tree, null);
+    return javadoccablePositions.build();
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -373,6 +373,7 @@ import com.google.errorprone.bugpatterns.inject.guice.InjectOnFinalField;
 import com.google.errorprone.bugpatterns.inject.guice.OverridesGuiceInjectableMethod;
 import com.google.errorprone.bugpatterns.inject.guice.OverridesJavaxInjectableMethod;
 import com.google.errorprone.bugpatterns.inject.guice.ProvidesMethodOutsideOfModule;
+import com.google.errorprone.bugpatterns.javadoc.AlmostJavadoc;
 import com.google.errorprone.bugpatterns.javadoc.EmptyBlockTag;
 import com.google.errorprone.bugpatterns.javadoc.EscapedEntity;
 import com.google.errorprone.bugpatterns.javadoc.InheritDoc;
@@ -786,6 +787,7 @@ public class BuiltInCheckerSuppliers {
   /** A list of all checks that are off by default. */
   public static final ImmutableSet<BugCheckerInfo> DISABLED_CHECKS =
       getSuppliers(
+          AlmostJavadoc.class,
           AndroidJdkLibsChecker.class,
           AnnotationPosition.class,
           AssertFalse.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -267,6 +267,7 @@ import com.google.errorprone.bugpatterns.SwitchDefault;
 import com.google.errorprone.bugpatterns.SystemExitOutsideMain;
 import com.google.errorprone.bugpatterns.TestExceptionChecker;
 import com.google.errorprone.bugpatterns.TestExceptionRefactoring;
+import com.google.errorprone.bugpatterns.TheoryButNoTheories;
 import com.google.errorprone.bugpatterns.ThreadJoinLoop;
 import com.google.errorprone.bugpatterns.ThreadLocalUsage;
 import com.google.errorprone.bugpatterns.ThreeLetterTimeZoneID;
@@ -604,6 +605,7 @@ public class BuiltInCheckerSuppliers {
           SubstringOfZero.class,
           SuppressWarningsDeprecated.class,
           TemporalAccessorGetChronoField.class,
+          TheoryButNoTheories.class,
           ThrowIfUncheckedKnownChecked.class,
           ThrowNull.class,
           TruthSelfEquals.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ParameterNameTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ParameterNameTest.java
@@ -479,4 +479,159 @@ public class ParameterNameTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void positiveVarargs() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void foo(int... args) {}",
+            "",
+            "  void bar() {",
+            "    // BUG: Diagnostic contains: /* args...= */",
+            "    // /* argh */",
+            "    foo(/* argh...= */ 1, 2, 3);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negativeVarargs() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void foo(int... args) {}",
+            "",
+            "  void bar() {",
+            "    foo(/* args...= */ 1, 2);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void varargsCommentAllowedWithArraySyntax() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void foo(int... args) {}",
+            "",
+            "  void bar() {",
+            "    int[] myInts = {1, 2, 3};",
+            "    foo(/* args...= */ myInts);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  // TODO(b/144728869): clean up existing usages with non-"..." syntax
+  @Test
+  public void normalCommentNotAllowedWithVarargsArraySyntax() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void foo(int... args) {}",
+            "",
+            "  void bar() {",
+            "    int[] myInts = {1, 2, 3};",
+            "    // BUG: Diagnostic contains: /* args...= */",
+            "    foo(/* args= */ myInts);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void varargsCommentAllowedOnOnlyFirstArg() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void foo(int... args) {}",
+            "",
+            "  void bar() {",
+            "    // BUG: Diagnostic contains: parameter name comment only allowed on first varargs"
+                + " argument",
+            "    foo(1, /* args...= */ 2);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void varargsWrongFormat() {
+    BugCheckerRefactoringTestHelper.newInstance(new ParameterName(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "class Test {",
+            "  void foo(int... args) {}",
+            "",
+            "  void bar() {",
+            "    foo(/* args= */ 1, 2);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "class Test {",
+            "  void foo(int... args) {}",
+            "",
+            "  void bar() {",
+            "    foo(/* args...= */ 1, 2);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void varargsIgnoreNonParameterNameComments() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void foo(int... args) {}",
+            "",
+            "  void bar() {",
+            "    foo(/* fake */ 1, 2);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void varargsWrongNameAndWrongFormat() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void foo(int... args) {}",
+            "",
+            "  void bar() {",
+            "    // BUG: Diagnostic contains: /* args...= */",
+            "    // /* argh */",
+            "    foo(/* argh= */ 1, 2);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void varargsCommentNotAllowedOnNormalArg() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void foo(int i) {}",
+            "",
+            "  void bar() {",
+            "    // BUG: Diagnostic contains: /* i= */",
+            "    foo(/* i...= */ 1);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TheoryButNoTheoriesTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TheoryButNoTheoriesTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link TheoryButNoTheories}. */
+@RunWith(JUnit4.class)
+public final class TheoryButNoTheoriesTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(TheoryButNoTheories.class, getClass());
+  private final BugCheckerRefactoringTestHelper refactoringHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new TheoryButNoTheories(), getClass());
+
+  @Test
+  public void positive() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import org.junit.experimental.theories.Theory;",
+            "import org.junit.runner.RunWith;",
+            "import org.junit.runners.JUnit4;",
+            "@RunWith(JUnit4.class)",
+            "public class Test {",
+            "  @Theory public void test() {}",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import org.junit.experimental.theories.Theories;",
+            "import org.junit.experimental.theories.Theory;",
+            "import org.junit.runner.RunWith;",
+            "import org.junit.runners.JUnit4;",
+            "@RunWith(Theories.class)",
+            "public class Test {",
+            "  @Theory public void test() {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void alreadyParameterized_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import org.junit.experimental.theories.Theories;",
+            "import org.junit.experimental.theories.Theory;",
+            "import org.junit.runner.RunWith;",
+            "import org.junit.runners.JUnit4;",
+            "@RunWith(Theories.class)",
+            "public class Test {",
+            "  @Theory public void test() {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void noParameters_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import org.junit.runner.RunWith;",
+            "import org.junit.runners.JUnit4;",
+            "@RunWith(JUnit4.class)",
+            "public class Test {",
+            "}")
+        .doTest();
+  }
+}

--- a/docs/bugpattern/ParameterName.md
+++ b/docs/bugpattern/ParameterName.md
@@ -14,6 +14,9 @@ parameter:
 booleanMethod(/* enableFoo= */ true);
 ```
 
+Varargs methods are also supported using `...` syntax: `java varargsMethod(/*
+states...= */ true, true, false);`
+
 If the comment deliberately does not match the formal parameter name, using a
 regular block comment without the `=` is recommended: `/* enableFoo */`.
 

--- a/docs/bugpattern/javadoc/AlmostJavadoc.md
+++ b/docs/bugpattern/javadoc/AlmostJavadoc.md
@@ -1,0 +1,21 @@
+This comment contains Javadoc or HTML tags, and is in the right position for a
+Javadoc, but doesn't start with a double asterisk. Should it be a Javadoc?
+
+```java
+/* Frobnicates the {@link Foo}s. */
+class Frobnicator {
+  Foo frobnicate(Foo foo);
+}
+```
+
+```java
+/** Frobnicates the {@link Foo}s. */
+class Frobnicator {
+  Foo frobnicate(Foo foo);
+}
+```
+
+## Suppression
+
+Suppress by applying `@SuppressWarnings("AlmostJavadoc")` to the element being
+documented (or not documented).


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Rework handling of varargs in ParameterName.

Previously we did not do anything special for varargs, so we matched the first argument in the group of vararg arguments using the standard syntax ("/* params= */").  This CL introduces new syntax for matching the first varargs parameter name: "/* params...= */".

9b7767845a3f1a033e83f561548bd4148502294b

-------

<p> AlmostJavadoc: flag comments which look like they were meant to be Javadoc, but are not.

a484d5f03760493216973db5f034c9bfa50c12cc

-------

<p> Add check for tests including `@Theory`s but not using the `Theories` runner.

d0369179debdd4461c80551f2f9c8da6e478d2e8