### PR TITLE
MOE Sync 2019-11-21

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/matchers/method/BaseMethodMatcher.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/method/BaseMethodMatcher.java
@@ -48,6 +48,7 @@ interface BaseMethodMatcher {
         switch (tree.getKind()) {
           case NEW_CLASS:
           case METHOD_INVOCATION:
+          case MEMBER_REFERENCE:
             break;
           default:
             return null;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ParameterName.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ParameterName.java
@@ -108,9 +108,13 @@ public class ParameterName extends BugChecker
         });
 
     // handle any varargs arguments after the first
-    for (ExpressionTree arg : arguments.subList(sym.getParameters().size(), arguments.size())) {
-      if (advanceTokens(tokens, arg, state)) {
-        checkComment(arg, tokens.removeFirst(), state);
+    int numParams = sym.getParameters().size();
+    int numArgs = arguments.size();
+    if (numParams < numArgs) {
+      for (ExpressionTree arg : arguments.subList(numParams, numArgs)) {
+        if (advanceTokens(tokens, arg, state)) {
+          checkComment(arg, tokens.removeFirst(), state);
+        }
       }
     }
   }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/NamedParameterComment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/NamedParameterComment.java
@@ -41,7 +41,7 @@ import java.util.stream.Stream;
 public final class NamedParameterComment {
 
   public static final Pattern PARAMETER_COMMENT_PATTERN =
-      Pattern.compile("\\s*([\\w\\d_]+)(...)?\\s*=\\s*");
+      Pattern.compile("\\s*([\\w\\d_]+)(\\.\\.\\.)?\\s*=\\s*");
 
   private static final String PARAMETER_COMMENT_MARKER = "=";
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ParameterNameTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ParameterNameTest.java
@@ -498,6 +498,23 @@ public class ParameterNameTest {
   }
 
   @Test
+  public void emptyVarargs_shouldNotCrash() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void foo(int first, int... rest) {}",
+            "",
+            "  void bar() {",
+            "    foo(/* first= */ 1);",
+            " // BUG: Diagnostic contains: /* first= */",
+            "    foo(/* second= */ 1);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void negativeVarargs() {
     testHelper
         .addSourceLines(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add tests that method matchers work for method references

And make them actually work for constructor references

4fe8578a87b53ae87731a5e9bd14b6e8c37d25d3

-------

<p> Fix ParameterName comment regex to correctly match varargs comments.

0ce2394024d9b33b342a4ab475b5b0281ed6c776

-------

<p> Fix IllegalArgumentException in ParameterName when varargs are empty.

8e1c71604da7efbdc868484844377a2108152f35