### PR TITLE
MOE Sync 2019-11-22

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ParametersButNotParameterized.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ParametersButNotParameterized.java
@@ -43,6 +43,7 @@ public final class ParametersButNotParameterized extends BugChecker implements C
   private static final String PARAMETER = "org.junit.runners.Parameterized.Parameter";
   private static final String PARAMETERS = "org.junit.runners.Parameterized.Parameters";
 
+
   @Override
   public Description matchClass(ClassTree tree, VisitorState state) {
     if (!hasJUnit4TestRunner.matches(tree, state)) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/NamedParameterComment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/NamedParameterComment.java
@@ -41,7 +41,8 @@ import java.util.stream.Stream;
 public final class NamedParameterComment {
 
   public static final Pattern PARAMETER_COMMENT_PATTERN =
-      Pattern.compile("\\s*([\\w\\d_]+)(\\.\\.\\.)?\\s*=\\s*");
+      Pattern.compile(
+          "\\s*(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)(\\.\\.\\.)?\\s*=\\s*");
 
   private static final String PARAMETER_COMMENT_MARKER = "=";
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ParameterNameTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ParameterNameTest.java
@@ -151,6 +151,21 @@ public class ParameterNameTest {
         .doTest();
   }
 
+  @Test // not allowed by Google style guide, but other styles may want this
+  public void namedParametersChecker_findsError_withUnusualIdentifier() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "abstract class Test {",
+            "  abstract void target(Object $param$);",
+            "  void test(Object arg) {",
+            "    // BUG: Diagnostic contains: 'target(/* $param$= */arg);'",
+            "    target(/* param= */arg);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
   @Test
   public void namedParametersChecker_suggestsSwap_withSwappedArgs() {
     testHelper
@@ -290,6 +305,20 @@ public class ParameterNameTest {
             "  abstract void target(Object param);",
             "  void test(Object arg) {",
             "    target(/* some_other_comment */arg);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void namedParametersChecker_ignoresComment_wrongVarargs() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "abstract class Test {",
+            "  abstract void target(Object... param);",
+            "  void test(Object arg) {",
+            "    target(/* param.!.= */arg);",
             "  }",
             "}")
         .doTest();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ParametersButNotParameterizedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ParametersButNotParameterizedTest.java
@@ -82,4 +82,5 @@ public final class ParametersButNotParameterizedTest {
             "}")
         .doTest();
   }
+
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> ParameterName: More regex improvements.

1. Adds a test for [] which changed the pattern to match an actual "...", rather than 3 arbitrary characters.

2. Matches any valid Java identifier, rather than only \w+ (note that \w includes \d and '_'). Such identifiers are not allowed by the Google style guide ([] but other styles might use them.

2b393d73de7b348b46b88f7d391c61c3fc26784d

-------

<p> ParametersButNotParameterized: don't match on ParameterizedTestRunner, which does use @Parameters.

d68681848a112b42ad9858708b178b2737ccbdcb