### PR TITLE
MOE Sync 2019-11-27

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/ExtendsAutoValueTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ExtendsAutoValueTest.java
@@ -30,20 +30,26 @@ public class ExtendsAutoValueTest {
       CompilationTestHelper.newInstance(ExtendsAutoValue.class, getClass());
 
   @Test
-  public void extendsAutoValue_GoodNoSuperclass() throws Exception {
-    helper.addSourceLines("TestClass.java", "public class TestClass {}").doTest();
-  }
-
-  @Test
-  public void extendsAutoValue_GoodSuperclass() throws Exception {
+  public void extendsAutoValue_goodNoSuperclass() {
     helper
         .addSourceLines(
-            "TestClass.java", "class SuperClass {}", "public class TestClass extends SuperClass {}")
+            "TestClass.java", //
+            "public class TestClass {}")
         .doTest();
   }
 
   @Test
-  public void extendsAutoValue_GoodAutoValueExtendsSuperclass() throws Exception {
+  public void extendsAutoValue_goodSuperclass() {
+    helper
+        .addSourceLines(
+            "TestClass.java", //
+            "class SuperClass {}",
+            "public class TestClass extends SuperClass {}")
+        .doTest();
+  }
+
+  @Test
+  public void extendsAutoValue_goodAutoValueExtendsSuperclass() {
     helper
         .addSourceLines(
             "TestClass.java",
@@ -54,7 +60,7 @@ public class ExtendsAutoValueTest {
   }
 
   @Test
-  public void extendsAutoValue_GoodGeneratedIgnored() throws Exception {
+  public void extendsAutoValue_goodGeneratedIgnored() {
     helper
         .addSourceLines(
             "TestClass.java",
@@ -68,7 +74,7 @@ public class ExtendsAutoValueTest {
   }
 
   @Test
-  public void extendsAutoValue_Bad() throws Exception {
+  public void extendsAutoValue_bad() {
     helper
         .addSourceLines(
             "TestClass.java",
@@ -80,7 +86,22 @@ public class ExtendsAutoValueTest {
   }
 
   @Test
-  public void extendsAutoValue_BadNoImport() throws Exception {
+  public void extendsAutoOneOf_bad() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import com.google.auto.value.AutoOneOf;",
+            "@AutoOneOf(AutoClass.Kind.class) class AutoClass {",
+            "  enum Kind {}",
+            "}",
+            "// BUG: Diagnostic contains: ExtendsAutoValue",
+            "public class TestClass extends AutoClass {",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void extendsAutoValue_badNoImport() {
     helper
         .addSourceLines(
             "TestClass.java",
@@ -91,7 +112,7 @@ public class ExtendsAutoValueTest {
   }
 
   @Test
-  public void extendsAutoValue_BadInnerClass() throws Exception {
+  public void extendsAutoValue_badInnerClass() {
     helper
         .addSourceLines(
             "OuterClass.java",
@@ -105,7 +126,7 @@ public class ExtendsAutoValueTest {
   }
 
   @Test
-  public void extendsAutoValue_BadInnerStaticClass() throws Exception {
+  public void extendsAutoValue_badInnerStaticClass() {
     helper
         .addSourceLines(
             "TestClass.java",
@@ -119,7 +140,7 @@ public class ExtendsAutoValueTest {
   }
 
   @Test
-  public void extendsAutoValue_BadButSuppressed() throws Exception {
+  public void extendsAutoValue_badButSuppressed() {
     helper
         .addSourceLines(
             "TestClass.java",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryAnonymousClassTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryAnonymousClassTest.java
@@ -16,6 +16,8 @@
 
 package com.google.errorprone.bugpatterns;
 
+import static com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH;
+
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,7 +59,8 @@ public class UnnecessaryAnonymousClassTest {
             "    System.err.println(camelCase(\"world\"));",
             "  }",
             "}")
-        .doTest();
+        // Make sure the method body is still reformatted correctly.
+        .doTest(TEXT_MATCH);
   }
 
   @Test
@@ -114,6 +117,38 @@ public class UnnecessaryAnonymousClassTest {
             "  }",
             "}")
         .expectUnchanged()
+        .doTest();
+  }
+
+  @Test
+  public void recursive() {
+    testHelper
+        .addInputLines(
+            "Test.java",
+            "import java.util.function.Function;",
+            "class Test {",
+            "  private static final Function<Object, Object> STRINGIFY =",
+            "      new Function<Object, Object>() {",
+            "        @Override",
+            "        public Object apply(Object input) {",
+            "          return transform(STRINGIFY);",
+            "        }",
+            "      };",
+            "  public static Object transform(Function<Object, Object> f) {",
+            "    return f.apply(\"a\");",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.util.function.Function;",
+            "class Test {",
+            "  private static Object stringify(Object input) {",
+            "    return transform(Test::stringify);",
+            "  }",
+            "  public static Object transform(Function<Object, Object> f) {",
+            "    return f.apply(\"a\");",
+            "  }",
+            "}")
         .doTest();
   }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix overlapping replacement errors in UnnecessaryAnonymousClass when suggesting fixes for method reference variables that reference themselves.

25a52f74379bb732fe6011757e8d8aa9e7e85cac

-------

<p> ExtendsAutoValue: include AutoOneOf too.

08aaeb3afb301ffee3c71a620a40aa86a88ba79c