### PR TITLE
Rejuvenate log levels.

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/RefactoringCollection.java
+++ b/check_api/src/main/java/com/google/errorprone/RefactoringCollection.java
@@ -194,7 +194,7 @@ class RefactoringCollection implements DescriptionListener.Factory {
         fileDestination.writeFile(file);
       } catch (IOException e) {
         logger.log(
-            Level.WARNING,
+            Level.SEVERE,
             "Failed to apply diff to file " + listener.base.getRelevantFileName(),
             e);
       }

--- a/check_api/src/main/java/com/google/errorprone/apply/DiffApplier.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/DiffApplier.java
@@ -121,7 +121,7 @@ public class DiffApplier extends AbstractService {
 
         int completed = completedFiles.incrementAndGet();
         if (completed % 100 == 0) {
-          logger.log(Level.INFO, String.format("Completed %d files in %s", completed, stopwatch));
+          logger.log(Level.WARNING, String.format("Completed %d files in %s", completed, stopwatch));
         }
       } catch (IOException | DiffNotApplicableException e) {
         logger.log(Level.WARNING, "Failed to apply diff to file " + diff.getRelevantFileName(), e);

--- a/core/src/main/java/com/google/errorprone/refaster/ExpressionTemplate.java
+++ b/core/src/main/java/com/google/errorprone/refaster/ExpressionTemplate.java
@@ -17,8 +17,8 @@
 package com.google.errorprone.refaster;
 
 import static com.google.common.base.Preconditions.checkState;
-import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Function;
@@ -208,7 +208,7 @@ public abstract class ExpressionTemplate extends Template<ExpressionTemplateMatc
                   return typecheck(
                       unifier, inliner, new Warner(target), expectedTypes, actualTypes);
                 } catch (CouldNotResolveImportException e) {
-                  logger.log(FINE, "Failure to resolve import", e);
+                  logger.log(WARNING, "Failure to resolve import", e);
                   return Optional.absent();
                 }
               }

--- a/core/src/main/java/com/google/errorprone/refaster/Template.java
+++ b/core/src/main/java/com/google/errorprone/refaster/Template.java
@@ -17,6 +17,7 @@
 package com.google.errorprone.refaster;
 
 import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.WARNING;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableClassToInstanceMap;
@@ -217,7 +218,7 @@ public abstract class Template<M extends TemplateMatch> implements Serializable 
       }
       return Optional.of(unifier);
     } catch (CouldNotResolveImportException e) {
-      logger.log(FINE, "Failure to resolve an import", e);
+      logger.log(WARNING, "Failure to resolve an import", e);
       return Optional.absent();
     } catch (InferException e) {
       logger.log(FINE, "No valid instantiation found: " + e.getMessage());


### PR DESCRIPTION
Here's a reissue of https://github.com/google/error-prone/pull/1268 with a new version of our tool. The tool made better transformations. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 4000.
The head at the time of analysis was: 2118ba35b0efe2fdfe4b1af35d1967ed935b6988
