### PR TITLE
MOE Sync 2019-12-02

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/Comments.java
+++ b/check_api/src/main/java/com/google/errorprone/util/Comments.java
@@ -97,9 +97,10 @@ public class Comments {
         return comment.getText().replaceAll("^\\s*/\\*\\s*(.*?)\\s*\\*/\\s*", "$1");
       case LINE:
         return comment.getText().replaceAll("^\\s*//\\s*", "");
-      default:
-        return comment.getText();
+      case JAVADOC:
+        return comment.getText().replaceAll("^\\s*/\\*\\*\\s*(.*?)\\s*\\*/\\s*", "$1");
     }
+    throw new AssertionError(comment.getStyle());
   }
 
   private static ImmutableList<Commented<ExpressionTree>> findCommentsForArguments(

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ParameterName.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ParameterName.java
@@ -20,7 +20,6 @@ import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Streams.forEachPair;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
-import static com.sun.tools.javac.parser.Tokens.Comment.CommentStyle.BLOCK;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Strings;
@@ -155,9 +154,6 @@ public class ParameterName extends BugChecker
       VarSymbol formal, ExpressionTree actual, ErrorProneToken token, VisitorState state) {
     List<FixInfo> matches = new ArrayList<>();
     for (Comment comment : token.comments()) {
-      if (comment.getStyle() != BLOCK) {
-        continue;
-      }
       Matcher m =
           NamedParameterComment.PARAMETER_COMMENT_PATTERN.matcher(
               Comments.getTextFromComment(comment));
@@ -235,9 +231,6 @@ public class ParameterName extends BugChecker
   // complains on parameter name comments on varargs past the first one
   private void checkComment(ExpressionTree arg, ErrorProneToken token, VisitorState state) {
     for (Comment comment : token.comments()) {
-      if (comment.getStyle() != BLOCK) {
-        continue;
-      }
       Matcher m =
           NamedParameterComment.PARAMETER_COMMENT_PATTERN.matcher(
               Comments.getTextFromComment(comment));

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ParameterNameTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ParameterNameTest.java
@@ -41,6 +41,7 @@ public class ParameterNameTest {
             "  void f(int foo, int bar) {}",
             "  {",
             "    f(/* bar= */ 1, /* foo= */ 2);",
+            "    f(/** bar= */ 3, /** foo= */ 4);",
             "  }",
             "}")
         .addOutputLines(
@@ -49,6 +50,7 @@ public class ParameterNameTest {
             "  void f(int foo, int bar) {}",
             "  {",
             "    f(/* foo= */ 1, /* bar= */ 2);",
+            "    f(/* foo= */ 3, /* bar= */ 4);",
             "  }",
             "}")
         .doTest(TEXT_MATCH);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Recognize javadoc comments in ParameterNameTest

e.g. `f(/** arg= */ 42)` in addition to `f(/* arg= */ 42)`.

8e6ce5748caadc7d96d9aea280fe82a698e099f4