### PR TITLE
fix #1428 InterruptedExceptionSwallowed handles CatchTree throw statements

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/InterruptedExceptionSwallowedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/InterruptedExceptionSwallowedTest.java
@@ -93,6 +93,34 @@ public final class InterruptedExceptionSwallowedTest {
   }
 
   @Test
+  public void positiveThrowFromCatch() {
+    compilationHelper
+            .addSourceLines(
+                    "Test.java",
+                    "import java.util.concurrent.ExecutionException;",
+                    "import java.util.concurrent.Future;",
+                    "class Test {",
+                    "  void test(Future<?> future) {",
+                    "    try {",
+                    "      try {",
+                    "        future.get();",
+                    "      } catch (ExecutionException e) {",
+                    "        if (e.getCause() instanceof IllegalStateException) {",
+                    "          throw new InterruptedException();",
+                    "        }",
+                    "      } catch (InterruptedException e) {",
+                    "        Thread.currentThread().interrupt();",
+                    "        throw new IllegalStateException(e);",
+                    "      }",
+                    "    // BUG: Diagnostic contains:",
+                    "    } catch (Exception e) {",
+                    "    }",
+                    "  }",
+                    "}")
+            .doTest();
+  }
+
+  @Test
   public void checkedViaInstanceof_noWarning() {
     compilationHelper
         .addSourceLines(


### PR DESCRIPTION
fix #1428

Previously the check assumed that exceptions could be handled by
subsequent catch blocks, which is incorrect.