### PR TITLE
UnnecessaryCheckNotNull correctly qualifies Preconditions

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/UnnecessaryCheckNotNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/UnnecessaryCheckNotNull.java
@@ -30,6 +30,7 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.Fix;
 import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
@@ -67,9 +68,10 @@ import java.util.Set;
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class UnnecessaryCheckNotNull extends BugChecker implements MethodInvocationTreeMatcher {
 
+  private static final String PRECONDITIONS = "com.google.common.base.Preconditions";
   private static final Matcher<MethodInvocationTree> CHECK_NOT_NULL_MATCHER =
       Matchers.<MethodInvocationTree>anyOf(
-          staticMethod().onClass("com.google.common.base.Preconditions").named("checkNotNull"),
+          staticMethod().onClass(PRECONDITIONS).named("checkNotNull"),
           staticMethod().onClass("com.google.common.base.Verify").named("verifyNotNull"),
           staticMethod().onClass("java.util.Objects").named("requireNonNull"));
 
@@ -186,7 +188,7 @@ public class UnnecessaryCheckNotNull extends BugChecker implements MethodInvocat
     if (methodInvocationTree.getMethodSelect().getKind() == Kind.IDENTIFIER) {
       fix.addStaticImport("com.google.common.base.Preconditions." + replacementMethod);
     } else {
-      replacement.append("Preconditions.");
+      replacement.append(SuggestedFixes.qualifyType(state, fix, PRECONDITIONS)).append('.');
     }
     replacement.append(replacementMethod).append('(');
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/UnnecessaryCheckNotNullTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/UnnecessaryCheckNotNullTest.java
@@ -22,6 +22,7 @@ import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.CompilerBasedAbstractTest;
@@ -131,6 +132,32 @@ public class UnnecessaryCheckNotNullTest extends CompilerBasedAbstractTest {
             "// BUG: Diagnostic contains: UnnecessaryCheckNotNull",
             "Objects.requireNonNull(new int[5][2]);",
             "}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positive_qualifiedImport() {
+    BugCheckerRefactoringTestHelper.newInstance(new UnnecessaryCheckNotNull(), getClass())
+        .addInputLines(
+            "Test.java",
+            "import com.google.common.base.Verify;",
+            "import java.util.Objects;",
+            "class Test {",
+            "void negative() {",
+            "Verify.verifyNotNull(getClass().getName().contains(\"value\"));",
+            "}",
+            "static final class Preconditions {}",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import com.google.common.base.Verify;",
+            "import java.util.Objects;",
+            "class Test {",
+            "void negative() {",
+            "com.google.common.base.Preconditions.checkArgument(getClass().getName().contains(\"value\"));",
+            "}",
+            "static final class Preconditions {}",
             "}")
         .doTest();
   }


### PR DESCRIPTION
Previously other imports or nested classes named Preconditions
caused the suggested fix to fail.