### PR TITLE
MOE Sync 2019-12-09

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/TruthIncompatibleType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/TruthIncompatibleType.java
@@ -33,6 +33,7 @@ import com.google.errorprone.matchers.method.MethodMatchers;
 import com.google.errorprone.util.ASTHelpers;
 import com.google.errorprone.util.Signatures;
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.ParenthesizedTree;
 import com.sun.source.tree.Tree;
@@ -78,8 +79,20 @@ public class TruthIncompatibleType extends BugChecker implements MethodInvocatio
 
         @Nullable
         @Override
+        Type extractSourceType(MemberReferenceTree tree, VisitorState state) {
+          throw new UnsupportedOperationException();
+        }
+
+        @Nullable
+        @Override
         ExpressionTree extractSourceTree(MethodInvocationTree tree, VisitorState state) {
           return getOnlyElement(tree.getArguments());
+        }
+
+        @Nullable
+        @Override
+        ExpressionTree extractSourceTree(MemberReferenceTree tree, VisitorState state) {
+          throw new UnsupportedOperationException();
         }
 
         @Nullable
@@ -112,6 +125,12 @@ public class TruthIncompatibleType extends BugChecker implements MethodInvocatio
             }
           }
           return null;
+        }
+
+        @Nullable
+        @Override
+        Type extractTargetType(MemberReferenceTree tree, VisitorState state) {
+          throw new UnsupportedOperationException();
         }
       };
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
@@ -111,7 +111,8 @@ public final class PreferJavaTimeOverload extends BugChecker
 
   private static final Matcher<ExpressionTree> IGNORED_APIS =
       anyOf(
-          staticMethod().onClass("org.assertj.core.api.Assertions").named("assertThat"));
+          // For AssertJ
+          staticMethod().anyClass().namedAnyOf("assertThat", "assumeThat"));
 
   private static final Matcher<ExpressionTree> JAVA_DURATION_DECOMPOSITION_MATCHER =
       anyOf(

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
@@ -111,8 +111,10 @@ public final class PreferJavaTimeOverload extends BugChecker
 
   private static final Matcher<ExpressionTree> IGNORED_APIS =
       anyOf(
-          // For AssertJ
-          staticMethod().anyClass().namedAnyOf("assertThat", "assumeThat"));
+          // any static method under org.assertj.*
+          staticMethod()
+              .onClass((type, state) -> type.toString().startsWith("org.assertj."))
+              .withAnyName());
 
   private static final Matcher<ExpressionTree> JAVA_DURATION_DECOMPOSITION_MATCHER =
       anyOf(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverloadTest.java
@@ -412,4 +412,24 @@ public class PreferJavaTimeOverloadTest {
             "}")
         .doTest();
   }
+
+  // TODO(kak): After upgrading to AssertJ 3.15, double-check that removing the AssertJ matcher from
+  // PreferJavaTimeOverload.IGNORED_APIS causes these tests to start failing.
+  @Test
+  public void assertJ() {
+    // https://github.com/google/error-prone/issues/1377
+    // https://github.com/google/error-prone/issues/1437
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "public class TestClass {",
+            "  public void testAssertThat() {",
+            "    org.assertj.core.api.Assertions.assertThat(1).isEqualTo(1);",
+            "  }",
+            "  public void testAssumeThat() {",
+            "    org.assertj.core.api.Assumptions.assumeThat(1).isEqualTo(1);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't fire PreferJavaTimeOverload on any static methods named assertThat or assumeThat.

Fixes https://github.com/google/error-prone/issues/1437 and https://github.com/google/error-prone/issues/1435

fb25fb8ce9a37e5cf59b5d3ac5f8c410fa252d49

-------

<p> CollectionIncompatibleType: check method references too.

bdc5309f6ea67cb0214d3cb123647fae50fa9bf5

-------

<p> Disable PreferJavaTimeOverload for all static methods in AssertJ.

See https://github.com/google/error-prone/pull/1436

2dee020a0248f54cf888251f09319609d8d6f930