### PR TITLE
MOE Sync 2019-12-16

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -1278,7 +1278,7 @@ public class ASTHelpers {
    * Returns the values of the given symbol's {@code javax.annotation.Generated} or {@code
    * javax.annotation.processing.Generated} annotation, if present.
    */
-  public static ImmutableSet<String> getGeneratedBy(Symbol symbol, VisitorState state) {
+  public static ImmutableSet<String> getGeneratedBy(ClassSymbol symbol, VisitorState state) {
     checkNotNull(symbol);
     Optional<Compound> c =
         Stream.of("javax.annotation.Generated", "javax.annotation.processing.Generated")

--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -1278,7 +1278,7 @@ public class ASTHelpers {
    * Returns the values of the given symbol's {@code javax.annotation.Generated} or {@code
    * javax.annotation.processing.Generated} annotation, if present.
    */
-  public static ImmutableSet<String> getGeneratedBy(ClassSymbol symbol, VisitorState state) {
+  public static ImmutableSet<String> getGeneratedBy(Symbol symbol, VisitorState state) {
     checkNotNull(symbol);
     Optional<Compound> c =
         Stream.of("javax.annotation.Generated", "javax.annotation.processing.Generated")

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AmbiguousMethodReference.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AmbiguousMethodReference.java
@@ -41,7 +41,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "AmbiguousMethodReference",
     summary = "Method reference is ambiguous",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AssertThrowsMultipleStatements.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AssertThrowsMultipleStatements.java
@@ -38,7 +38,7 @@ import com.sun.source.tree.Tree;
 import com.sun.tools.javac.tree.JCTree;
 import java.util.List;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "AssertThrowsMultipleStatements",
     summary = "The lambda passed to assertThrows should contain exactly one statement",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AssertionFailureIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AssertionFailureIgnored.java
@@ -56,7 +56,7 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "AssertionFailureIgnored",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
@@ -68,13 +68,14 @@ public class BadImport extends BugChecker implements ImportTreeMatcher {
           "Class");
   private static final ImmutableSet<String> BAD_STATIC_IDENTIFIERS =
       ImmutableSet.of(
-          "copyOf",
-          "of",
-          "from",
-          "INSTANCE",
           "builder",
-          "newBuilder",
+          "create",
+          "copyOf",
+          "from",
           "getDefaultInstance",
+          "INSTANCE",
+          "newBuilder",
+          "of",
           "valueOf");
 
   private static final MultiMatcher<Tree, AnnotationTree> HAS_TYPE_USE_ANNOTATION =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BooleanParameter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BooleanParameter.java
@@ -49,7 +49,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "BooleanParameter",
     summary = "Use parameter comments to document ambiguous literals",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BoxedPrimitiveConstructor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BoxedPrimitiveConstructor.java
@@ -47,7 +47,7 @@ import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
 import com.sun.tools.javac.util.Context;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "BoxedPrimitiveConstructor",
     summary = "valueOf or autoboxing provides better time and space performance",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BoxedPrimitiveEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BoxedPrimitiveEquality.java
@@ -26,7 +26,7 @@ import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "BoxedPrimitiveEquality",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CacheLoaderNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CacheLoaderNull.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.suppliers.Supplier;
+import com.google.errorprone.suppliers.Suppliers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.ReturnTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import com.sun.tools.javac.code.Type;
+
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
+@BugPattern(
+    name = "CacheLoaderNull",
+    summary = "The result of CacheLoader#load must be non-null.",
+    severity = WARNING)
+public class CacheLoaderNull extends BugChecker implements MethodTreeMatcher {
+
+  private static final Supplier<Type> CACHE_LOADER_TYPE =
+      Suppliers.typeFromString("com.google.common.cache.CacheLoader");
+
+  @Override
+  public Description matchMethod(MethodTree tree, VisitorState state) {
+    if (!tree.getName().contentEquals("load")) {
+      return NO_MATCH;
+    }
+    MethodSymbol sym = ASTHelpers.getSymbol(tree);
+    if (sym == null) {
+      return NO_MATCH;
+    }
+    if (!ASTHelpers.isSubtype(sym.owner.asType(), CACHE_LOADER_TYPE.get(state), state)) {
+      return NO_MATCH;
+    }
+    new TreeScanner<Void, Void>() {
+      @Override
+      public Void visitLambdaExpression(LambdaExpressionTree tree, Void unused) {
+        return null;
+      }
+
+      @Override
+      public Void visitClass(ClassTree tree, Void unused) {
+        return null;
+      }
+
+      @Override
+      public Void visitReturn(ReturnTree tree, Void unused) {
+        ExpressionTree expression = tree.getExpression();
+        if (expression != null && expression.getKind() == Tree.Kind.NULL_LITERAL) {
+          state.reportMatch(describeMatch(tree));
+        }
+        return super.visitReturn(tree, null);
+      }
+    }.scan(tree.getBody(), null);
+    return NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CanonicalDuration.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CanonicalDuration.java
@@ -53,7 +53,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "CanonicalDuration",
     summary = "Duration can be expressed more clearly with different units",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CatchAndPrintStackTrace.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CatchAndPrintStackTrace.java
@@ -31,7 +31,7 @@ import com.sun.source.tree.CatchTree;
 import com.sun.source.tree.StatementTree;
 import java.util.List;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "CatchAndPrintStackTrace",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CatchFail.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CatchFail.java
@@ -62,7 +62,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "CatchFail",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassName.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassName.java
@@ -33,7 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.lang.model.element.Modifier;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ClassName",
     summary = "The source file name should match the name of the top-level class it contains",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassNewInstance.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassNewInstance.java
@@ -55,7 +55,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ClassNewInstance",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ConstantField.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ConstantField.java
@@ -37,7 +37,7 @@ import com.sun.tools.javac.code.Type;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ConstantField",
     summary = "Field name is CONSTANT_CASE, but field is not static and final",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ConstantOverflow.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ConstantOverflow.java
@@ -49,7 +49,7 @@ import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Type;
 import javax.lang.model.type.TypeKind;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ConstantOverflow",
     summary = "Compile-time constant expression overflows",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DateFormatConstant.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DateFormatConstant.java
@@ -42,7 +42,7 @@ import java.util.Objects;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "DateFormatConstant",
     summary = "DateFormat is not thread-safe, and should not be used as a constant field.",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DeadThread.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DeadThread.java
@@ -31,7 +31,7 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree.Kind;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "DeadThread",
     summary = "Thread created but not started",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DefaultCharset.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DefaultCharset.java
@@ -69,7 +69,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Scanner;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "DefaultCharset",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DescribeMatch.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DescribeMatch.java
@@ -32,7 +32,7 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "DescribeMatch",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DiscardedPostfixExpression.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DiscardedPostfixExpression.java
@@ -32,7 +32,7 @@ import com.sun.source.tree.UnaryTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.tree.JCTree.JCLambda;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "DiscardedPostfixExpression",
     summary = "The result of this unary operation on a lambda parameter is discarded",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DoNotCallChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DoNotCallChecker.java
@@ -41,7 +41,7 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import javax.lang.model.element.Modifier;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 // TODO(cushon): this should subsume ImmutableModification and LocalizableWrongToString
 @BugPattern(
     name = "DoNotCall",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DoubleBraceInitialization.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DoubleBraceInitialization.java
@@ -61,7 +61,7 @@ import java.util.Optional;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "DoubleBraceInitialization",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EmptyTopLevelDeclaration.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EmptyTopLevelDeclaration.java
@@ -29,7 +29,7 @@ import com.sun.source.tree.Tree;
 import java.util.ArrayList;
 import java.util.List;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "EmptyTopLevelDeclaration",
     summary = "Empty top-level type declaration",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ExpectedExceptionChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ExpectedExceptionChecker.java
@@ -36,7 +36,7 @@ import com.sun.source.tree.Tree;
 import java.util.List;
 import javax.annotation.Nullable;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ExpectedExceptionChecker",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ExpectedExceptionRefactoring.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ExpectedExceptionRefactoring.java
@@ -37,7 +37,7 @@ import com.sun.source.tree.VariableTree;
 import java.util.List;
 import javax.annotation.Nullable;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ExpectedExceptionRefactoring",
     summary = "Prefer assertThrows to ExpectedException",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ExtendsAutoValue.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ExtendsAutoValue.java
@@ -16,8 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.common.collect.Streams.stream;
-
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.SeverityLevel;
@@ -28,7 +26,6 @@ import com.google.errorprone.suppliers.Supplier;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.tools.javac.util.Name;
-import java.util.Objects;
 
 /** Makes sure that you are not extending a class that has @AutoValue as an annotation. */
 @BugPattern(
@@ -46,29 +43,24 @@ public final class ExtendsAutoValue extends BugChecker implements ClassTreeMatch
 
   @Override
   public Description matchClass(ClassTree tree, VisitorState state) {
+
+    if (!ASTHelpers.getGeneratedBy(ASTHelpers.getSymbol(tree), state).isEmpty()) {
+      // Skip generated code. Yes, I know we can do this via a flag but we should always ignore
+      // generated code, so to be sure, manually check it.
+      return Description.NO_MATCH;
+    }
+
     if (tree.getExtendsClause() == null) {
       // Doesn't extend anything, can't possibly be a violation.
       return Description.NO_MATCH;
     }
-
     if (!ASTHelpers.annotationsAmong(
             ASTHelpers.getSymbol(tree.getExtendsClause()), AUTOS.get(state), state)
         .isEmpty()) {
       // Violation: one of its superclasses extends AutoValue.
-      if (!isInGeneratedCode(state)) {
-        return buildDescription(tree).build();
-      }
+      return buildDescription(tree).build();
     }
 
     return Description.NO_MATCH;
-  }
-
-  private static boolean isInGeneratedCode(VisitorState state) {
-    // Skip generated code. Yes, I know we can do this via a flag but we should always ignore
-    // generated code, so to be sure, manually check it.
-    return stream(state.getPath())
-        .map(ASTHelpers::getSymbol)
-        .filter(Objects::nonNull)
-        .anyMatch(sym -> !ASTHelpers.getGeneratedBy(sym, state).isEmpty());
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FallThrough.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FallThrough.java
@@ -33,7 +33,7 @@ import com.sun.source.tree.SwitchTree;
 import com.sun.tools.javac.tree.JCTree;
 import java.util.regex.Pattern;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "FallThrough",
     altNames = "fallthrough",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FloatCast.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FloatCast.java
@@ -42,7 +42,7 @@ import java.util.EnumSet;
 import java.util.Set;
 import javax.lang.model.type.TypeKind;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "FloatCast",
     summary = "Use parentheses to make the precedence explicit",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FloatingPointLiteralPrecision.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FloatingPointLiteralPrecision.java
@@ -33,7 +33,7 @@ import com.sun.source.tree.LiteralTree;
 import com.sun.tools.javac.code.Type;
 import java.math.BigDecimal;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "FloatingPointLiteralPrecision",
     summary = "Floating point literal loses precision",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FunctionalInterfaceClash.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FunctionalInterfaceClash.java
@@ -49,7 +49,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "FunctionalInterfaceClash",
     summary = "Overloads will be ambiguous when passing lambda arguments.",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnAnnotation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnAnnotation.java
@@ -30,7 +30,7 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import java.lang.annotation.Annotation;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "GetClassOnAnnotation",
     summary = "Calling getClass() on an annotation may return a proxy class",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnEnum.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnEnum.java
@@ -30,7 +30,7 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "GetClassOnEnum",
     summary = "Calling getClass() on an enum may return a subclass of the enum type",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/HashtableContains.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/HashtableContains.java
@@ -39,7 +39,7 @@ import com.sun.tools.javac.util.List;
 import java.util.Hashtable;
 import java.util.concurrent.ConcurrentHashMap;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "HashtableContains",
     summary = "contains() is a legacy method that is equivalent to containsValue()",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IdentityBinaryExpression.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IdentityBinaryExpression.java
@@ -37,7 +37,7 @@ import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import java.util.Optional;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "IdentityBinaryExpression",
     altNames = "SelfEquality",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ImmutableModification.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ImmutableModification.java
@@ -33,7 +33,7 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Type;
 import java.util.Set;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ImmutableModification",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/Incomparable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Incomparable.java
@@ -35,7 +35,7 @@ import com.sun.source.tree.NewClassTree;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.util.List;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "Incomparable",
     summary = "Types contained in sorted collections must implement Comparable.",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IndexOfChar.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IndexOfChar.java
@@ -36,7 +36,7 @@ import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Types;
 import java.util.List;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "IndexOfChar",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InexactVarargsConditional.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InexactVarargsConditional.java
@@ -35,7 +35,7 @@ import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Types;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "InexactVarargsConditional",
     summary = "Conditional expression in varargs call contains array and non-array arguments",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InfiniteRecursion.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InfiniteRecursion.java
@@ -37,7 +37,7 @@ import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.SimpleTreeVisitor;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "InfiniteRecursion",
     summary = "This method always recurses, and will cause a StackOverflowError",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IntLongMath.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IntLongMath.java
@@ -40,7 +40,7 @@ import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Type;
 import javax.lang.model.type.TypeKind;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "IntLongMath",
     summary = "Expression of type int may overflow before being assigned to a long",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IsInstanceOfClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IsInstanceOfClass.java
@@ -38,7 +38,7 @@ import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.tree.JCTree;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "IsInstanceOfClass",
     summary = "The argument to Class#isInstance(Object) should not be a Class",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IterablePathParameter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IterablePathParameter.java
@@ -40,7 +40,7 @@ import com.sun.tools.javac.tree.JCTree.JCLambda.ParameterKind;
 import java.nio.file.Path;
 import javax.lang.model.element.ElementKind;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "IterablePathParameter",
     summary = "Path implements Iterable<Path>; prefer Collection<Path> for clarity",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JavaLangClash.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JavaLangClash.java
@@ -38,7 +38,7 @@ import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
 import com.sun.tools.javac.util.Name;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "JavaLangClash",
     summary = "Never reuse class names from java.lang",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JdkObsolete.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JdkObsolete.java
@@ -63,7 +63,7 @@ import com.sun.tools.javac.code.Types;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "JdkObsolete",
     summary = "Suggests alternatives to obsolete JDK classes.",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LogicalAssignment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LogicalAssignment.java
@@ -38,7 +38,7 @@ import com.sun.source.tree.ParenthesizedTree;
 import com.sun.source.tree.WhileLoopTree;
 import com.sun.tools.javac.tree.JCTree;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "LogicalAssignment",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LoopConditionChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LoopConditionChecker.java
@@ -46,7 +46,7 @@ import com.sun.source.util.SimpleTreeVisitor;
 import com.sun.source.util.TreeScanner;
 import com.sun.tools.javac.code.Symbol;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "LoopConditionChecker",
     summary = "Loop condition is never modified in loop body.",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MethodCanBeStatic.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MethodCanBeStatic.java
@@ -51,7 +51,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.lang.model.element.Modifier;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "MethodCanBeStatic",
     altNames = "static-method",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingCasesInEnumSwitch.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingCasesInEnumSwitch.java
@@ -34,7 +34,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.lang.model.element.ElementKind;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "MissingCasesInEnumSwitch",
     summary = "Switches on enum types should either handle all values, or have a default case.",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingDefault.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingDefault.java
@@ -36,7 +36,7 @@ import com.sun.tools.javac.code.Type;
 import java.util.Optional;
 import javax.lang.model.element.ElementKind;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "MissingDefault",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingOverride.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingOverride.java
@@ -35,7 +35,7 @@ import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import javax.lang.model.element.Modifier;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "MissingOverride",
     summary = "method overrides method in supertype; expected @Override",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MixedArrayDimensions.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MixedArrayDimensions.java
@@ -36,7 +36,7 @@ import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.parser.Tokens.TokenKind;
 import java.util.List;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "MixedArrayDimensions",
     summary = "C-style array declarations should not be used",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MockitoUsage.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MockitoUsage.java
@@ -34,7 +34,7 @@ import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
 import java.util.List;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "MockitoUsage",
     summary = "Missing method call for verify(mock) here",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MultiVariableDeclaration.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MultiVariableDeclaration.java
@@ -46,7 +46,7 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "MultiVariableDeclaration",
     summary = "Variable declarations should declare only one variable",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MultipleTopLevelClasses.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MultipleTopLevelClasses.java
@@ -32,7 +32,7 @@ import com.sun.source.tree.Tree;
 import java.util.ArrayList;
 import java.util.List;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "MultipleTopLevelClasses",
     altNames = {"TopLevel"},

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NCopiesOfChar.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NCopiesOfChar.java
@@ -34,7 +34,7 @@ import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Types;
 import java.util.List;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "NCopiesOfChar",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NarrowingCompoundAssignment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NarrowingCompoundAssignment.java
@@ -38,7 +38,7 @@ import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.tree.JCTree.JCBinary;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "NarrowingCompoundAssignment",
     summary = "Compound assignments may hide dangerous casts",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NullTernary.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NullTernary.java
@@ -27,7 +27,7 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ConditionalExpressionTree;
 import com.sun.source.tree.Tree.Kind;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "NullTernary",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NullableConstructor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NullableConstructor.java
@@ -31,7 +31,7 @@ import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.tools.javac.code.Symbol;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "NullableConstructor",
     summary = "Constructors should not be annotated with @Nullable since they cannot return null",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NullableVoid.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NullableVoid.java
@@ -32,7 +32,7 @@ import com.sun.source.tree.MethodTree;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import javax.lang.model.type.TypeKind;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "NullableVoid",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OperatorPrecedence.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OperatorPrecedence.java
@@ -36,7 +36,7 @@ import com.sun.tools.javac.tree.JCTree.JCBinary;
 import com.sun.tools.javac.tree.TreeInfo;
 import java.util.EnumSet;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "OperatorPrecedence",
     summary = "Use grouping parenthesis to make the operator precedence explicit",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OptionalEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OptionalEquality.java
@@ -25,7 +25,7 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.tools.javac.code.Type;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "OptionalEquality",
     summary = "Comparison using reference equality instead of value equality",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OrphanedFormatString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OrphanedFormatString.java
@@ -45,7 +45,7 @@ import edu.umd.cs.findbugs.formatStringChecker.Formatter;
 import edu.umd.cs.findbugs.formatStringChecker.MissingFormatArgumentException;
 import java.util.List;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "OrphanedFormatString",
     summary = "String literal contains format specifiers, but is not passed to a format method",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PackageInfo.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PackageInfo.java
@@ -25,7 +25,7 @@ import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.CompilationUnitTree;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "PackageInfo",
     summary = "Declaring types inside package-info.java files is very bad form",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PackageLocation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PackageLocation.java
@@ -30,7 +30,7 @@ import com.sun.source.tree.CompilationUnitTree;
 import com.sun.tools.javac.code.Symbol.PackageSymbol;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "PackageLocation",
     summary = "Package names should match the directory they are declared in",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ParameterComment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ParameterComment.java
@@ -42,7 +42,7 @@ import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.parser.Tokens.Comment;
 import java.util.stream.Stream;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ParameterComment",
     summary = "Non-standard parameter comment; prefer `/* paramName= */ arg`",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ParameterName.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ParameterName.java
@@ -52,7 +52,7 @@ import java.util.Deque;
 import java.util.List;
 import java.util.regex.Matcher;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ParameterName",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RandomCast.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RandomCast.java
@@ -37,7 +37,7 @@ import java.util.EnumSet;
 import java.util.Set;
 import javax.lang.model.type.TypeKind;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "RandomCast",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ReachabilityFenceUsage.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ReachabilityFenceUsage.java
@@ -30,7 +30,7 @@ import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.TryTree;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ReachabilityFenceUsage",
     summary = "reachabilityFence should always be called inside a finally block",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RedundantThrows.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RedundantThrows.java
@@ -42,7 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "RedundantThrows",
     summary = "Thrown exception is a subtype of another",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ReferenceEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ReferenceEquality.java
@@ -32,7 +32,7 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.util.Name;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ReferenceEquality",
     summary = "Comparison using reference equality instead of value equality",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StreamResourceLeak.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StreamResourceLeak.java
@@ -45,7 +45,7 @@ import com.sun.tools.javac.tree.JCTree;
 import java.util.List;
 import java.util.Objects;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "StreamResourceLeak",
     altNames = "FilesLinesLeak",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StreamToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StreamToString.java
@@ -27,7 +27,7 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.Tree;
 import java.util.Optional;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "StreamToString",
     summary = "Calling toString on a Stream does not provide useful information",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StringSplitter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StringSplitter.java
@@ -51,7 +51,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "StringSplitter",
     summary = "String.split(String) has surprising behavior",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SwitchDefault.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SwitchDefault.java
@@ -35,7 +35,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "SwitchDefault",
     summary = "The default case of a switch should appear at the end of the last statement group",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TestExceptionChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TestExceptionChecker.java
@@ -35,7 +35,7 @@ import com.sun.source.tree.StatementTree;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import java.util.List;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "TestExceptionChecker",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TestExceptionRefactoring.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TestExceptionRefactoring.java
@@ -27,7 +27,7 @@ import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.MethodTree;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "TestExceptionRefactoring",
     summary = "Prefer assertThrows to @Test(expected=...)",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThreadLocalUsage.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThreadLocalUsage.java
@@ -42,7 +42,7 @@ import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Type;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ThreadLocalUsage",
     summary = "ThreadLocals should be stored in static fields",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThrowNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThrowNull.java
@@ -28,7 +28,7 @@ import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.ThrowTree;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ThrowNull",
     summary = "Throwing 'null' always results in a NullPointerException being thrown.",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TryFailRefactoring.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TryFailRefactoring.java
@@ -45,7 +45,7 @@ import com.sun.source.tree.TryTree;
 import java.util.List;
 import java.util.Optional;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "TryFailRefactoring",
     summary = "Prefer assertThrows to try/fail",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
@@ -30,7 +30,7 @@ import com.sun.source.tree.MemberSelectTree;
 import com.sun.tools.javac.code.Symbol;
 import javax.lang.model.element.ElementKind;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "TypeParameterQualifier",
     summary = "Type parameter used as type qualifier",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryDefaultInEnumSwitch.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryDefaultInEnumSwitch.java
@@ -46,7 +46,7 @@ import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.ElementKind;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "UnnecessaryDefaultInEnumSwitch",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryLambda.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryLambda.java
@@ -63,7 +63,7 @@ import java.util.function.Predicate;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "UnnecessaryLambda",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryParentheses.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryParentheses.java
@@ -32,7 +32,7 @@ import com.sun.source.tree.ParenthesizedTree;
 import com.sun.source.tree.StatementTree;
 import com.sun.tools.javac.tree.JCTree;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "UnnecessaryParentheses",
     summary =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarySetDefault.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarySetDefault.java
@@ -62,7 +62,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "UnnecessarySetDefault",
     summary = "Unnecessary call to NullPointerTester#setDefault",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryStaticImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryStaticImport.java
@@ -28,7 +28,7 @@ import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.ImportTree;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "UnnecessaryStaticImport",
     summary = "Using static imports for types is unnecessary",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryTypeArgument.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryTypeArgument.java
@@ -36,7 +36,7 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.tree.JCTree;
 import java.util.List;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "UnnecessaryTypeArgument",
     summary = "Non-generic methods should not be invoked with type arguments",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnsafeFinalization.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnsafeFinalization.java
@@ -48,7 +48,7 @@ import java.util.stream.Stream;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.type.TypeKind;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "UnsafeFinalization",
     summary = "Finalizer may run before native code finishes execution",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnsynchronizedOverridesSynchronized.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnsynchronizedOverridesSynchronized.java
@@ -43,7 +43,7 @@ import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import javax.lang.model.element.Modifier;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "UnsynchronizedOverridesSynchronized",
     summary = "Unsynchronized method overrides a synchronized method.",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedAnonymousClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedAnonymousClass.java
@@ -31,7 +31,7 @@ import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.tree.JCTree;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "UnusedAnonymousClass",
     summary = "Instance created but never used",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/VarChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/VarChecker.java
@@ -42,7 +42,7 @@ import java.util.EnumSet;
 import java.util.Optional;
 import javax.lang.model.element.Modifier;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "Var",
     summary = "Non-constant variable missing @Var annotation",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/VarTypeName.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/VarTypeName.java
@@ -29,7 +29,7 @@ import com.sun.source.tree.Tree;
 import com.sun.source.tree.TypeParameterTree;
 import javax.lang.model.element.Name;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "VarTypeName",
     summary = "`var` should not be used as a type name.",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/WildcardImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/WildcardImport.java
@@ -50,7 +50,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.lang.model.element.ElementKind;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "WildcardImport",
     summary = "Wildcard imports, static or otherwise, should not be used",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/TruthIncompatibleType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/TruthIncompatibleType.java
@@ -42,7 +42,7 @@ import com.sun.source.util.SimpleTreeVisitor;
 import com.sun.tools.javac.code.Type;
 import javax.annotation.Nullable;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "TruthIncompatibleType",
     summary = "Argument is not compatible with the subject's type.",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatString.java
@@ -35,7 +35,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Locale;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(name = "FormatString", summary = "Invalid printf-style format string", severity = ERROR)
 public class FormatString extends BugChecker implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/DoubleCheckedLocking.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/DoubleCheckedLocking.java
@@ -53,7 +53,7 @@ import javax.annotation.Nullable;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 // TODO(cushon): allow @LazyInit on fields as a suppression mechanism?
 @BugPattern(
     name = "DoubleCheckedLocking",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByChecker.java
@@ -41,7 +41,7 @@ import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "GuardedBy",
     altNames = "GuardedByChecker",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableAnnotationChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableAnnotationChecker.java
@@ -42,7 +42,7 @@ import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import java.util.Collections;
 import java.util.Optional;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ImmutableAnnotationChecker",
     altNames = "Immutable",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableChecker.java
@@ -59,7 +59,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "Immutable",
     summary = "Type declaration annotated with @Immutable is not immutable",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableEnumChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableEnumChecker.java
@@ -41,7 +41,7 @@ import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ImmutableEnumChecker",
     altNames = "Immutable",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableRefactoring.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableRefactoring.java
@@ -36,7 +36,7 @@ import com.sun.source.util.TreePathScanner;
 import com.sun.tools.javac.code.Symbol;
 import java.util.Optional;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "ImmutableRefactoring",
     summary = "Refactors uses of the JSR 305 @Immutable to Error Prone's annotation",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/StaticGuardedByInstance.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/StaticGuardedByInstance.java
@@ -40,7 +40,7 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 import java.util.Map.Entry;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "StaticGuardedByInstance",
     summary = "Writes to static fields should not be guarded by instance locks",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/SynchronizeOnNonFinalField.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/SynchronizeOnNonFinalField.java
@@ -34,7 +34,7 @@ import com.sun.tools.javac.code.Symbol.VarSymbol;
 import java.util.stream.Stream;
 import javax.lang.model.element.Name;
 
-/** @author cushon@google.com (Liam Miller-Cushon) */
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
     name = "SynchronizeOnNonFinalField",
     summary =

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -50,6 +50,7 @@ import com.google.errorprone.bugpatterns.BoxedPrimitiveConstructor;
 import com.google.errorprone.bugpatterns.BoxedPrimitiveEquality;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.ByteBufferBackingArray;
+import com.google.errorprone.bugpatterns.CacheLoaderNull;
 import com.google.errorprone.bugpatterns.CannotMockFinalClass;
 import com.google.errorprone.bugpatterns.CanonicalDuration;
 import com.google.errorprone.bugpatterns.CatchAndPrintStackTrace;
@@ -641,6 +642,7 @@ public class BuiltInCheckerSuppliers {
           BoxedPrimitiveConstructor.class,
           BoxedPrimitiveEquality.class,
           ByteBufferBackingArray.class,
+          CacheLoaderNull.class,
           CannotMockFinalClass.class,
           CanonicalDuration.class,
           CatchAndPrintStackTrace.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/CacheLoaderNullTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/CacheLoaderNullTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** {@link CacheLoaderNull}Test */
+@RunWith(JUnit4.class)
+public class CacheLoaderNullTest {
+
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(CacheLoaderNull.class, getClass());
+
+  @Test
+  public void positive() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.cache.CacheLoader;",
+            "class Test {",
+            "  {",
+            "    new CacheLoader<String, String>() {",
+            "      @Override",
+            "      public String load(String key) {",
+            "        // BUG: Diagnostic contains:",
+            "        return null;",
+            "      }",
+            "    };",
+            "    abstract class MyCacheLoader extends CacheLoader<String, String> {}",
+            "    new MyCacheLoader() {",
+            "      @Override",
+            "      public String load(String key) {",
+            "        // BUG: Diagnostic contains:",
+            "        return null;",
+            "      }",
+            "    };",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.cache.CacheLoader;",
+            "import java.util.function.Supplier;",
+            "class Test {",
+            "  public String load(String key) {",
+            "    return null;",
+            "  }",
+            "  {",
+            "    new CacheLoader<String, String>() {",
+            "      @Override",
+            "      public String load(String key) {",
+            "        Supplier<String> s = () -> { return null; };",
+            "        Supplier<String> t = new Supplier<String>() {",
+            "          public String get() {",
+            "            return null;",
+            "          }",
+            "        };",
+            "        class MySupplier implements Supplier<String> {",
+            "          public String get() {",
+            "            return null;",
+            "          }",
+            "        };",
+            "        return \"\";",
+            "      }",
+            "    };",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ExtendsAutoValueTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ExtendsAutoValueTest.java
@@ -150,37 +150,4 @@ public class ExtendsAutoValueTest {
             "public class TestClass extends AutoClass {}")
         .doTest();
   }
-
-  @Test
-  public void extendsAutoValue_innerClassExtends() {
-    helper
-        .addSourceLines(
-            "TestClass.java",
-            "import com.google.auto.value.AutoValue;",
-            "@AutoValue class AutoClass {}",
-            "",
-            "public class TestClass {",
-            "  // BUG: Diagnostic contains: ExtendsAutoValue",
-            "  public class Extends extends AutoClass {}",
-            "}")
-        .doTest();
-  }
-
-  @Test
-  public void extendsAutoValue_innerClassExtends_generated() {
-    helper
-        .addSourceLines(
-            "TestClass.java",
-            "import com.google.auto.value.AutoValue;",
-            (RuntimeVersion.isAtLeast9()
-                ? "import javax.annotation.processing.Generated;"
-                : "import javax.annotation.Generated;"),
-            "@AutoValue class AutoClass {}",
-            "",
-            "@Generated(\"generator\")",
-            "public class TestClass {",
-            "  public class Extends extends AutoClass {}",
-            "}")
-        .doTest();
-  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ExtendsAutoValueTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ExtendsAutoValueTest.java
@@ -150,4 +150,37 @@ public class ExtendsAutoValueTest {
             "public class TestClass extends AutoClass {}")
         .doTest();
   }
+
+  @Test
+  public void extendsAutoValue_innerClassExtends() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import com.google.auto.value.AutoValue;",
+            "@AutoValue class AutoClass {}",
+            "",
+            "public class TestClass {",
+            "  // BUG: Diagnostic contains: ExtendsAutoValue",
+            "  public class Extends extends AutoClass {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void extendsAutoValue_innerClassExtends_generated() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import com.google.auto.value.AutoValue;",
+            (RuntimeVersion.isAtLeast9()
+                ? "import javax.annotation.processing.Generated;"
+                : "import javax.annotation.Generated;"),
+            "@AutoValue class AutoClass {}",
+            "",
+            "@Generated(\"generator\")",
+            "public class TestClass {",
+            "  public class Extends extends AutoClass {}",
+            "}")
+        .doTest();
+  }
 }

--- a/docs/bugpattern/InterruptedExceptionSwallowed.md
+++ b/docs/bugpattern/InterruptedExceptionSwallowed.md
@@ -21,7 +21,7 @@ element, or the caught exception.
 
 ```java
 try {
-  future.get();
+  ...
 } catch (@SuppressWarnings("InterruptedExceptionSwallowed") Exception e) {
   throw new IllegalStateException(e);
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't use future.get() in the suppression example, for fear that readers will think suppressing interruption on futures is appropriate. There isn't really a good case for suppression, so just use an ellipsis for now.

9b87db2f311286a24dfbda1d838a00b682e76d9a

-------

<p> Detect implementations of CacheLoader#load that return null

The method is specified to not return null; returning null will
result in an exception when the load is loaded.

ebb3722d554782c338361f9df70547f0a2ab6979

-------

<p> Add "create" to the list of bad static identifiers.

a5da9000e91ce8123d886aa092c0cd45cdccfbf8

-------

<p> Make bugpattern javadoc compliant with the style guide

which requires class javadoc to have a summary fragment, and disallows
javadoc that contains only an `@author` tag.

5beed5e0f6f1caaeac274b28099f7b01fac8fec6

-------

<p> ExtendsAutoValue: walk up the tree to see if an enclosing class is @Generated

ca1875488fd82c2952c7b7e9cf31650d76b5539a

-------

<p> Automated g4 rollback of changelist 285340669.

*** Reason for rollback ***

Broke tests.

*** Original change description ***

ExtendsAutoValue: walk up the tree to see if an enclosing class is @Generated

***

beac7c05f4307c1e69ad2af356a2e1f9686df114