### PR TITLE
Fix #1451: SuggestedFixes.renameMethodInvocation doesn't modify params

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -586,9 +586,14 @@ public class SuggestedFixes {
       throw malformedMethodInvocationTree(tree);
     }
     List<ErrorProneToken> tokens = state.getOffsetTokens(startPos, state.getEndPosition(tree));
+    int depth = 0;
     for (ErrorProneToken token : Lists.reverse(tokens)) {
-      if (token.kind() == TokenKind.IDENTIFIER && token.name().equals(identifier)) {
+      if (depth == 0 && token.kind() == TokenKind.IDENTIFIER && token.name().equals(identifier)) {
         return SuggestedFix.replace(token.pos(), token.endPos(), replacement);
+      } else if (token.kind() == Tokens.TokenKind.RPAREN) {
+        depth++;
+      } else if (token.kind() == Tokens.TokenKind.LPAREN) {
+        depth--;
       }
     }
     throw malformedMethodInvocationTree(tree);

--- a/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
+++ b/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
@@ -1344,6 +1344,43 @@ public class SuggestedFixesTest {
         .doTest(TEXT_MATCH);
   }
 
+  @BugPattern(
+          name = "RenameMethodChecker2",
+          summary = "RenameMethodChecker2",
+          severity = ERROR,
+          providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+  private static class RenameMethodChecker2 extends BugChecker
+          implements MethodInvocationTreeMatcher {
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+      return describeMatch(tree, SuggestedFixes.renameMethodInvocation(tree, "singleton", state));
+    }
+  }
+
+  @Test
+  public void renameMethodInvocationWithArg() {
+    BugCheckerRefactoringTestHelper.newInstance(new RenameMethodChecker2(), getClass())
+        .addInputLines(
+            "Test.java",
+            "import java.util.Collections;",
+            "class Test {",
+            "  Integer singletonList = 1;",
+            "  Object foo = Collections.<Integer /* foo */>singletonList(singletonList);",
+            "  Object bar = Collections.<Integer>/* foo */singletonList(singletonList);",
+            "  Object baz = Collections.<Integer>  singletonList  (singletonList);",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.util.Collections;",
+            "class Test {",
+            "  Integer singletonList = 1;",
+            "  Object foo = Collections.<Integer /* foo */>singleton(singletonList);",
+            "  Object bar = Collections.<Integer>/* foo */singleton(singletonList);",
+            "  Object baz = Collections.<Integer>  singleton  (singletonList);",
+            "}")
+        .doTest(TEXT_MATCH);
+  }
+
   /**
    * Test checker that raises a diagnostic with the result of {@link SuggestedFixes#qualifyType} on
    * new instances.


### PR DESCRIPTION
`renameMethodInvocation` tracks paren depth in order to avoid
erroneously renaming parameter identifiers instead of the method.