### PR TITLE
MOE Sync 2019-12-17

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/RestrictedApiCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/RestrictedApiCheckerTest.java
@@ -45,6 +45,7 @@ public class RestrictedApiCheckerTest {
             "class Testcase {",
             "  void foo(RestrictedApiMethods m) {",
             "    m.normalMethod();",
+            "    m.accept(m::normalMethod);",
             "  }",
             "}")
         .doTest();
@@ -60,6 +61,8 @@ public class RestrictedApiCheckerTest {
             "  void foo(RestrictedApiMethods m) {",
             "    // BUG: Diagnostic contains: lorem",
             "    m.restrictedMethod();",
+            "    // BUG: Diagnostic contains: lorem",
+            "    m.accept(m::restrictedMethod);",
             "  }",
             "}")
         .expectResult(Result.ERROR)
@@ -78,6 +81,10 @@ public class RestrictedApiCheckerTest {
             "    m.restrictedMethod();",
             "    // BUG: Diagnostic contains: ipsum",
             "    m.dontCallMe();",
+            "    // BUG: Diagnostic contains: lorem",
+            "    m.accept(m::restrictedMethod);",
+            "    // BUG: Diagnostic contains: ipsum",
+            "    m.accept(m::dontCallMe);",
             "  }",
             "}")
         .expectResult(Result.ERROR)
@@ -93,6 +100,7 @@ public class RestrictedApiCheckerTest {
             "class Testcase {",
             "  void foo(RestrictedApiMethods m) {",
             "    m.restrictedMethod();",
+            "    m.accept(m::restrictedMethod);",
             "  }",
             "}")
         .expectResult(Result.OK)
@@ -109,6 +117,8 @@ public class RestrictedApiCheckerTest {
             "  void foo() {",
             "    // BUG: Diagnostic contains: lorem",
             "    RestrictedApiMethods.restrictedStaticMethod();",
+            "    // BUG: Diagnostic contains: lorem",
+            "    RestrictedApiMethods.accept(RestrictedApiMethods::restrictedStaticMethod);",
             "  }",
             "}")
         .expectResult(Result.ERROR)
@@ -125,7 +135,23 @@ public class RestrictedApiCheckerTest {
             "  void foo() {",
             "    // BUG: Diagnostic contains: lorem",
             "    new RestrictedApiMethods(0);",
+            "    // BUG: Diagnostic contains: lorem",
+            "    RestrictedApiMethods.accept(RestrictedApiMethods::new);",
             "  }",
+            "}")
+        .expectResult(Result.ERROR)
+        .doTest();
+  }
+
+  @Test
+  public void testImplicitRestrictedConstructorProhibited() {
+    helper
+        .addSourceLines(
+            "Testcase.java",
+            "package com.google.errorprone.bugpatterns.testdata;",
+            "class Testcase extends RestrictedApiMethods {",
+            "  // BUG: Diagnostic contains: lorem",
+            "  public Testcase() {}",
             "}")
         .expectResult(Result.ERROR)
         .doTest();
@@ -142,6 +168,8 @@ public class RestrictedApiCheckerTest {
             "  void foo(RestrictedApiMethods m) {",
             "    // BUG: Diagnostic contains: [RestrictedApi]",
             "    m.restrictedMethod();",
+            "    // BUG: Diagnostic contains: [RestrictedApi]",
+            "    m.accept(m::restrictedMethod);",
             "  }",
             "}")
         .expectResult(Result.OK)
@@ -158,6 +186,7 @@ public class RestrictedApiCheckerTest {
             "  @Whitelist",
             "  void foo(RestrictedApiMethods m) {",
             "    m.restrictedMethod();",
+            "    m.accept(m::restrictedMethod);",
             "  }",
             "}")
         .expectResult(Result.OK)

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/RestrictedApiMethods.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/RestrictedApiMethods.java
@@ -32,6 +32,13 @@ public class RestrictedApiMethods implements IFaceWithRestriction {
       whitelistAnnotations = {Whitelist.class},
       whitelistWithWarningAnnotations = {WhitelistWithWarning.class},
       link = "")
+  public RestrictedApiMethods() {}
+
+  @RestrictedApi(
+      explanation = "lorem",
+      whitelistAnnotations = {Whitelist.class},
+      whitelistWithWarningAnnotations = {WhitelistWithWarning.class},
+      link = "")
   public RestrictedApiMethods(int restricted) {}
 
   @RestrictedApi(
@@ -69,6 +76,8 @@ public class RestrictedApiMethods implements IFaceWithRestriction {
       return 42;
     }
   }
+
+  public static void accept(Runnable r) {}
 }
 
 interface IFaceWithRestriction {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Automated g4 rollback of changelist 280704295.

*** Reason for rollback ***

Roll forward, remaining violations were fixed.

*** Original change description ***

Automated g4 rollback of changelist 280516200.

*** Reason for rollback ***

Unblock Java Builder Release.

We will roll this forward again once the depot builds cleanly with the changes to RestrictedApiChecker.

*** Original change description ***

Extend RestrictedApiChecker to forbid method references

***

***

df225f019dfd9af8a81add5e235ec7174b0e6eb7