### PR TITLE
MOE Sync 2019-12-23

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -1056,11 +1056,20 @@ public class SuggestedFixes {
   }
 
   /**
+   * Pretty-prints a Type for use in diagnostic messages, qualifying any enclosed type names using
+   * {@link #qualifyType}}.
+   */
+  public static String prettyType(Type type, @Nullable VisitorState state) {
+    return prettyType(state, /* existingFix= */ null, type);
+  }
+
+  /**
    * Pretty-prints a Type for use in fixes, qualifying any enclosed type names using {@link
    * #qualifyType}}.
    */
   public static String prettyType(
-      @Nullable VisitorState state, @Nullable SuggestedFix.Builder fix, Type type) {
+      @Nullable VisitorState state, @Nullable SuggestedFix.Builder existingFix, Type type) {
+    SuggestedFix.Builder fix = existingFix == null ? SuggestedFix.builder() : existingFix;
     return type.accept(
         new DefaultTypeVisitor<String, Void>() {
           @Override
@@ -1076,7 +1085,7 @@ public class SuggestedFixes {
           @Override
           public String visitClassType(Type.ClassType t, Void unused) {
             StringBuilder sb = new StringBuilder();
-            if (state == null || fix == null) {
+            if (state == null) {
               sb.append(t.tsym.getSimpleName());
             } else {
               sb.append(qualifyType(state, fix, t.tsym));

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadInstanceof.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadInstanceof.java
@@ -58,8 +58,7 @@ public final class BadInstanceof extends BugChecker implements InstanceOfTreeMat
     if (!isSubtype(getType(tree.getExpression()), getType(tree.getType()), state)) {
       return NO_MATCH;
     }
-    String subType =
-        SuggestedFixes.prettyType(state, /* fix= */ null, getType(tree.getExpression()));
+    String subType = SuggestedFixes.prettyType(getType(tree.getExpression()), state);
     String expression = state.getSourceForNode(tree.getExpression());
     String superType = state.getSourceForNode(tree.getType());
     if (isNonNull().matches(tree.getExpression(), state)) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ObjectToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ObjectToString.java
@@ -82,14 +82,11 @@ public class ObjectToString extends AbstractToString {
 
   @Override
   protected Optional<String> descriptionMessageForDefaultMatch(Type type, VisitorState state) {
-    String format =
-        "%1$s is final and does not override Object.toString, so converting it to a string"
-            + " will print its identity (e.g. `%2$s@ 4488aabb`) instead of useful information.";
     return Optional.of(
         String.format(
-            format,
-            SuggestedFixes.prettyType(state, /* fix= */ null, type),
-            type.tsym.getSimpleName()));
+            "%1$s is final and does not override Object.toString, so converting it to a string"
+                + " will print its identity (e.g. `%2$s@4488aabb`) instead of useful information.",
+            SuggestedFixes.prettyType(type, state), type.tsym.getSimpleName()));
   }
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThrowSpecificExceptions.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThrowSpecificExceptions.java
@@ -31,6 +31,7 @@ import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.ThrowTree;
 
 /** Bugpattern to discourage throwing base exception classes.. */
 @BugPattern(
@@ -50,7 +51,9 @@ public final class ThrowSpecificExceptions extends BugChecker implements NewClas
 
   @Override
   public Description matchNewClass(NewClassTree tree, VisitorState state) {
-    if (tree.getClassBody() != null || state.errorProneOptions().isTestOnlyTarget()) {
+    if (tree.getClassBody() != null
+        || !(state.getPath().getParentPath().getLeaf() instanceof ThrowTree)
+        || state.errorProneOptions().isTestOnlyTarget()) {
       return Description.NO_MATCH;
     }
     for (AbstractLikeException abstractLikeException : ABSTRACT_LIKE_EXCEPTIONS) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ObjectToStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ObjectToStringTest.java
@@ -25,7 +25,6 @@ import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.scanner.ScannerSupplier;
 import com.sun.source.tree.ClassTree;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -34,12 +33,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ObjectToStringTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(ObjectToString.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ObjectToString.class, getClass());
 
   @Test
   public void testPositiveCase() {
@@ -95,6 +90,25 @@ public class ObjectToStringTest {
             "  }",
             "}")
         .withClasspath(ObjectToStringTest.class, TestLib.class, TestLib.Two.class)
+        .doTest();
+  }
+
+  @Test
+  public void qualifiedName() {
+    compilationHelper
+        .addSourceLines(
+            "A.java", //
+            "class A {",
+            "  static final class B {}",
+            "}")
+        .addSourceLines(
+            "C.java",
+            "class C {",
+            "  String test() {",
+            "    // BUG: Diagnostic contains: A.B",
+            "    return new A.B().toString();",
+            "  }",
+            "}")
         .doTest();
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ThrowSpecificExceptionsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ThrowSpecificExceptionsTest.java
@@ -66,4 +66,17 @@ public final class ThrowSpecificExceptionsTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void dontMatchIfNotThrown() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "public class Test {",
+            "  StackTraceElement[] getStackTrace() {",
+            "    return new Throwable().getStackTrace();",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> ThrowSpecificExceptions: only match if the exception is being immediately thrown.

This should reduce false positives from exceptions being constructed for logging, or to retrieve stacks.

648ea533397d4514e7ddb35f814ccf0e559463cb

-------

<p> Make SuggestedFixes#prettyType use a qualifyType even when we're not generating a fix so we get better pretty names.

8679e604386efc3b01e9a1c796275f67a2f5aa91