### PR TITLE
Upgrade to Checker Framework 3.1.0

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
+++ b/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
@@ -49,7 +49,6 @@ import javax.tools.JavaCompiler;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
-import org.checkerframework.javacutil.AnnotationUtils;
 
 /** An Error Prone compiler that implements {@link javax.tools.JavaCompiler}. */
 public class BaseErrorProneJavaCompiler implements JavaCompiler {
@@ -91,7 +90,6 @@ public class BaseErrorProneJavaCompiler implements JavaCompiler {
     if (refactoringCollection[0] != null) {
       task.addTaskListener(new RefactoringTask(task.getContext(), refactoringCollection[0]));
     }
-    task.addTaskListener(new CFCacheClearingListener());
     return task;
   }
 
@@ -265,23 +263,6 @@ public class BaseErrorProneJavaCompiler implements JavaCompiler {
         PrintWriter out = Log.instance(context).getWriter(WriterKind.NOTICE);
         out.println(refactoringResult.message());
         out.flush();
-      }
-    }
-  }
-
-  /**
-   * A listener that clears out a global Checker Framework cache at the end of compilation. This
-   * prevents a memory leak in cases where the compiler is being run in memory as part of a daemon
-   * process.
-   *
-   * <p>See https://github.com/typetools/checker-framework/issues/1482
-   */
-  private static class CFCacheClearingListener implements TaskListener {
-
-    @Override
-    public void finished(TaskEvent e) {
-      if (e.getKind() == Kind.COMPILATION) {
-        AnnotationUtils.clear();
       }
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <javac.version>9+181-r4173-1</javac.version>
     <autovalue.version>1.5.3</autovalue.version>
     <junit.version>4.13-beta-1</junit.version>
-    <dataflow.version>3.0.0</dataflow.version>
+    <dataflow.version>3.1.0</dataflow.version>
     <mockito.version>2.25.0</mockito.version>
     <compile.testing.version>0.18</compile.testing.version>
     <caffeine.version>2.7.0</caffeine.version>


### PR DESCRIPTION
Remove the call to `AnnotationUtils.clear()`, which was removed in this release.  Calling that method was a quick fix for a memory-leaking cache, but that cache no longer exists.

[NullAway can't update](https://github.com/uber/NullAway/pull/377#issuecomment-570947243) its Checker Framework dependency because of this call to `AnnotationUtils.clear()`.  NullAway's maintainer, who is the one who [added this call to Error Prone](https://github.com/google/error-prone/commit/c2e4cfa64a9ed856824c1e3193f35a114d95e7a3) in the first place, suggested I open this PR to remove it.