### PR TITLE
MOE Sync 2020-01-07

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingSuperCall.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingSuperCall.java
@@ -38,14 +38,11 @@ import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
-import com.sun.source.tree.NewClassTree;
-import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.TreeScanner;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import java.util.Arrays;
-import java.util.List;
 import javax.lang.model.element.Modifier;
 
 /** @author eaftan@google.com (Eddie Aftandilian) */
@@ -183,28 +180,16 @@ public class MissingSuperCall extends BugChecker
     }
 
     @Override
-    public Boolean visitNewClass(NewClassTree node, Void unused) {
-      Boolean r = scan(node.getEnclosingExpression(), null);
-      r = scanAndReduce(node.getIdentifier(), r);
-      r = scanAndReduce(node.getTypeArguments(), r);
-      r = scanAndReduce(node.getArguments(), r);
-      // don't descend into class body, if it exists
-      return r;
-    }
-
-    @Override
     public Boolean visitClass(ClassTree node, Void unused) {
-      // don't descend into local classes
+      // don't descend into classes
       return false;
     }
 
     @Override
     public Boolean visitLambdaExpression(LambdaExpressionTree node, Void unused) {
-      Boolean r = scan(node.getParameters(), null);
-      r = scanAndReduce(node.getBody(), r);
-      return r;
+      // don't descend into lambdas
+      return null;
     }
-
     @Override
     public Boolean visitMethodInvocation(MethodInvocationTree tree, Void unused) {
       boolean result = false;
@@ -221,13 +206,6 @@ public class MissingSuperCall extends BugChecker
       return result || super.visitMethodInvocation(tree, unused);
     }
 
-    private Boolean scanAndReduce(List<? extends Tree> node, Boolean r) {
-      return reduce(scan(node, null), r);
-    }
-
-    private Boolean scanAndReduce(Tree node, Boolean r) {
-      return reduce(scan(node, null), r);
-    }
 
     @Override
     public Boolean reduce(Boolean b1, Boolean b2) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/InterruptedExceptionSwallowedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/InterruptedExceptionSwallowedTest.java
@@ -152,6 +152,26 @@ public final class InterruptedExceptionSwallowedTest {
   }
 
   @Test
+  public void thrownByClose_inherited() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.concurrent.Future;",
+            "class Test {",
+            "  class ThrowingParent implements AutoCloseable {",
+            "    public void close() throws InterruptedException {}",
+            "  }",
+            "  class ThrowingChild extends ThrowingParent {}",
+            "  // BUG: Diagnostic contains:",
+            "  void test() throws Exception {",
+            "    try (ThrowingChild t = new ThrowingChild()) {",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void thrownByClose_swallowedSilently() {
     compilationHelper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MissingSuperCallTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MissingSuperCallTest.java
@@ -376,4 +376,50 @@ public class MissingSuperCallTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void lambdas() {
+    compilationHelper
+        .addSourceLines(
+            "Super.java",
+            "import android.support.annotation.CallSuper;",
+            "public class Super {",
+            "  @CallSuper public void doIt() {}",
+            "  public void wrongToCall() {}",
+            "}")
+        .addSourceLines(
+            "Sub.java",
+            "public class Sub extends Super {",
+            "  // BUG: Diagnostic contains:",
+            "  // This method overrides Super#doIt, which is annotated with @CallSuper,",
+            "  // but does not call the super method",
+            "  @Override public void doIt() {",
+            "    Runnable r = () -> super.doIt();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void methodReferences() {
+    compilationHelper
+        .addSourceLines(
+            "Super.java",
+            "import android.support.annotation.CallSuper;",
+            "public class Super {",
+            "  @CallSuper public void doIt() {}",
+            "  public void wrongToCall() {}",
+            "}")
+        .addSourceLines(
+            "Sub.java",
+            "public class Sub extends Super {",
+            "  // BUG: Diagnostic contains:",
+            "  // This method overrides Super#doIt, which is annotated with @CallSuper,",
+            "  // but does not call the super method",
+            "  @Override public void doIt() {",
+            "    Runnable r = super::doIt;",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/testdata/UnnecessaryCheckNotNullPrimitivePositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/testdata/UnnecessaryCheckNotNullPrimitivePositiveCases.java
@@ -75,9 +75,9 @@ public class UnnecessaryCheckNotNullPrimitivePositiveCases {
     Preconditions.checkNotNull(a != null);
     // BUG: Diagnostic contains: Preconditions.checkNotNull(a)
     Preconditions.checkNotNull(a == null);
-    // BUG: Diagnostic contains: Preconditions.checkState(int1 == int2)
+    // BUG: Diagnostic contains: checkState(int1 == int2)
     Preconditions.checkNotNull(int1 == int2);
-    // BUG: Diagnostic contains: Preconditions.checkState(int1 > int2)
+    // BUG: Diagnostic contains: checkState(int1 > int2)
     Preconditions.checkNotNull(int1 > int2);
     // BUG: Diagnostic contains: remove this line
     Preconditions.checkNotNull(boolean1 ? int1 : int2);

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UnnecessaryBoxedVariableCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UnnecessaryBoxedVariableCases.java
@@ -16,6 +16,8 @@
 
 package com.google.errorprone.bugpatterns.testdata;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -184,6 +186,24 @@ class UnnecessaryBoxedVariableCases {
     @Nullable Integer i = 0;
     @javax.annotation.Nullable Integer j = 0;
     int k = i + j;
+  }
+
+  static int positive_nullChecked_expression(Integer i) {
+    return checkNotNull(i);
+  }
+
+  static int positive_nullChecked_expression_message(Integer i) {
+    return checkNotNull(i, "Null: [%s]", i);
+  }
+
+  static int positive_nullChecked_statement(Integer i) {
+    checkNotNull(i);
+    return i;
+  }
+
+  static int positive_nullChecked_statement_message(Integer i) {
+    checkNotNull(i, "Null: [%s]", i);
+    return i;
   }
 
   private void methodPrimitiveArg(int i) {}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UnnecessaryBoxedVariableCases_expected.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/UnnecessaryBoxedVariableCases_expected.java
@@ -16,6 +16,8 @@
 
 package com.google.errorprone.bugpatterns.testdata;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -183,6 +185,22 @@ class UnnecessaryBoxedVariableCases {
     int i = 0;
     int j = 0;
     int k = i + j;
+  }
+
+  static int positive_nullChecked_expression(int i) {
+    return i;
+  }
+
+  static int positive_nullChecked_expression_message(int i) {
+    return i;
+  }
+
+  static int positive_nullChecked_statement(int i) {
+    return i;
+  }
+
+  static int positive_nullChecked_statement_message(int i) {
+    return i;
   }
 
   private void methodPrimitiveArg(int i) {}

--- a/docs/bugpattern/DoNotCall.md
+++ b/docs/bugpattern/DoNotCall.md
@@ -3,13 +3,8 @@ annotation (`com.google.errorprone.annotations.DoNotCall`).
 
 The check disallows invocations and method references of the annotated method.
 
-There are a few situations where this can be useful:
-
-*   methods that are required to satisfy the contract of an interface, but that
-    are not supported
-
-*   the method works, but its implementation should always be inlined into your
-    own code
+There are a few situations where this can be useful, including methods that are
+required to satisfy the contract of an interface, but that are not supported.
 
 A method annotated with `@DoNotCall` should always be `final` or `abstract`. If
 an `abstract` method is annotated `@DoNotCall` Error Prone will ensure all

--- a/docs/bugpattern/LiteProtoToString.md
+++ b/docs/bugpattern/LiteProtoToString.md
@@ -13,9 +13,9 @@ message.
   }
 ```
 
-The fix will be highly dependent on the case in point. There may be an
-identifier associated with the message that would be useful to log, or even some
-serialized version of the entire proto.
+The fix will be highly dependent on the case at hand. There may be an identifier
+associated with the message that would be useful to log, or even some serialized
+version of the entire proto.
 
 NOTE: Logging fields of a proto will force those fields to be retained after
 optimization. This is not an issue if they're already being used, but writing a

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.2</version>
+        <version>3.8.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> UnnecessaryBoxedVariable: don't consider invocations of checkNotNull/verifyNotNull/requireNonNull as boxed usages.

d6fccbd52a4c13c2aafaaa4a5dc00d46dfa87a7b

-------

<p> InterruptedExceptionSwallowed: Handle classes that inherit implementations of AutoCloseable.close

8d74d2466cb4fff32f04e709d139903fc3a5d51e

-------

<p> Bump maven-compiler-plugin version to 3.8.1.

Fixes #1458

fd3c60a9485231e5bf4cce045a06b3b362596625

-------

<p> Various docs changes.

29789d6cbc69ab190c4c76366c54717ad2874eda

-------

<p> MissingSuperCall: Ignore super calls inside lambdas

follow-up to 96b175973bc741ab9f211f3e75e0b5123aa3f5ce

1850c4ac6f0fb25861b5244e37910b1ae667dd4a

-------

<p> AlmostJavadoc: skip desugared enum subclasses, as these lead to duplicate positions.

17abebd06d20df5ee724a3c6fdaf76df2ba3faeb

-------

<p> UnnecessaryCheckNotNull: be more careful about qualifying the precondition we want to use.

And encourage static importing it; that is the Java practices guidance after all.

This introduces a SuggestedFixes helper to get a name to refer to methods that we want to try to static import, but fall back to qualifying if necessary.

This addresses PR #1433, though not in the same way.

b920acfb06376caaa674f3c3af1983d3e42d27d9