### PR TITLE
MOE Sync 2020-01-08

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingSuperCall.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingSuperCall.java
@@ -188,8 +188,9 @@ public class MissingSuperCall extends BugChecker
     @Override
     public Boolean visitLambdaExpression(LambdaExpressionTree node, Void unused) {
       // don't descend into lambdas
-      return null;
+      return false;
     }
+
     @Override
     public Boolean visitMethodInvocation(MethodInvocationTree tree, Void unused) {
       boolean result = false;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/Utils.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/Utils.java
@@ -32,6 +32,7 @@ import com.sun.tools.javac.tree.EndPosTable;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
+import com.sun.tools.javac.util.Position;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -65,6 +66,9 @@ final class Utils {
     int startPos = getStartPosition(docTree, state);
     int endPos =
         (int) positions.getEndPosition(compilationUnitTree, getDocCommentTree(state), docTree);
+    if (endPos == Position.NOPOS) {
+      return SuggestedFix.builder().build();
+    }
     return SuggestedFix.replace(startPos, endPos, replacement);
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make visit methods more consistent

follow-up to c6c372c06186d09a9011be9a2728deec591ff860

a6b88264615da025e3b4e1abe516116a92cf9dfe

-------

<p> MissingSummary: don't fail in the case that javac fails to provide an endpos for @see.

Fixes external #1444

d7e586657a31c61a3c8037a5697c26c2d6fb0071