### PR TITLE
MOE Sync 2020-01-09

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingSuperCall.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingSuperCall.java
@@ -188,8 +188,9 @@ public class MissingSuperCall extends BugChecker
     @Override
     public Boolean visitLambdaExpression(LambdaExpressionTree node, Void unused) {
       // don't descend into lambdas
-      return null;
+      return false;
     }
+
     @Override
     public Boolean visitMethodInvocation(MethodInvocationTree tree, Void unused) {
       boolean result = false;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/Utils.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/Utils.java
@@ -32,6 +32,7 @@ import com.sun.tools.javac.tree.EndPosTable;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
+import com.sun.tools.javac.util.Position;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -65,6 +66,9 @@ final class Utils {
     int startPos = getStartPosition(docTree, state);
     int endPos =
         (int) positions.getEndPosition(compilationUnitTree, getDocCommentTree(state), docTree);
+    if (endPos == Position.NOPOS) {
+      return SuggestedFix.builder().build();
+    }
     return SuggestedFix.replace(startPos, endPos, replacement);
   }
 

--- a/docs/bugpattern/FormatStringAnnotation.md
+++ b/docs/bugpattern/FormatStringAnnotation.md
@@ -30,6 +30,13 @@ We will then check that the format string and format arguments match.
 For more information on possible format string errors, see the documentation on
 the [FormatString check](FormatString).
 
+The import for `@FormatMethod` is:
+
+```java
+import com.google.errorprone.annotations.FormatMethod;
+```
+
+
 ## Suppression
 
 Suppress false positives by adding the suppression annotation


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make visit methods more consistent

follow-up to c6c372c06186d09a9011be9a2728deec591ff860

8de68069dabac5ca313e9ed5e5a76ad3b51f1313

-------

<p> MissingSummary: don't fail in the case that javac fails to provide an endpos for @see.

Fixes #1444

7b921902e73173b2909327b0d279e4efb55bd34d

-------

<p> Improve documentation for FormatStringAnnotation fix

b4652bd09e0de72b1c769f3ad28f0ff5c690f15a