### PR TITLE
MOE Sync 2020-01-10

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/MisusedDateFormat.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MisusedDateFormat.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.constructor;
+import static com.google.errorprone.matchers.Matchers.instanceMethod;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+import static com.google.errorprone.util.ASTHelpers.constValue;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import java.util.Optional;
+import javax.lang.model.element.ElementKind;
+
+/** Base class for checks which find common errors in date format patterns. */
+public abstract class MisusedDateFormat extends BugChecker
+    implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
+
+  private static final String JAVA_SIMPLE_DATE_FORMAT = "java.text.SimpleDateFormat";
+
+  private static final String ICU_SIMPLE_DATE_FORMAT = "com.ibm.icu.text.SimpleDateFormat";
+
+  private static final Matcher<NewClassTree> PATTERN_CTOR_MATCHER =
+      anyOf(
+          constructor().forClass(JAVA_SIMPLE_DATE_FORMAT).withParameters("java.lang.String"),
+          constructor()
+              .forClass(JAVA_SIMPLE_DATE_FORMAT)
+              .withParameters("java.lang.String", "java.text.DateFormatSymbols"),
+          constructor()
+              .forClass(JAVA_SIMPLE_DATE_FORMAT)
+              .withParameters("java.lang.String", "java.util.Locale"),
+          constructor().forClass(ICU_SIMPLE_DATE_FORMAT).withParameters("java.lang.String"),
+          constructor()
+              .forClass(ICU_SIMPLE_DATE_FORMAT)
+              .withParameters("java.lang.String", "com.ibm.icu.text.DateFormatSymbols"),
+          constructor()
+              .forClass(ICU_SIMPLE_DATE_FORMAT)
+              .withParameters(
+                  "java.lang.String",
+                  "com.ibm.icu.text.DateFormatSymbols",
+                  "com.ibm.icu.util.ULocale"),
+          constructor()
+              .forClass(ICU_SIMPLE_DATE_FORMAT)
+              .withParameters("java.lang.String", "java.util.Locale"),
+          constructor()
+              .forClass(ICU_SIMPLE_DATE_FORMAT)
+              .withParameters("java.lang.String", "java.lang.String", "com.ibm.icu.util.ULocale"),
+          constructor()
+              .forClass(ICU_SIMPLE_DATE_FORMAT)
+              .withParameters("java.lang.String", "com.ibm.icu.util.ULocale"));
+
+  /** Matches methods that take a pattern as the first argument. */
+  private static final Matcher<ExpressionTree> PATTERN_MATCHER =
+      anyOf(
+          instanceMethod().onExactClass(JAVA_SIMPLE_DATE_FORMAT).named("applyPattern"),
+          instanceMethod().onExactClass(JAVA_SIMPLE_DATE_FORMAT).named("applyLocalizedPattern"),
+          instanceMethod().onExactClass(ICU_SIMPLE_DATE_FORMAT).named("applyPattern"),
+          instanceMethod().onExactClass(ICU_SIMPLE_DATE_FORMAT).named("applyLocalizedPattern"),
+          staticMethod().onClass("java.time.format.DateTimeFormatter").named("ofPattern"));
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (!PATTERN_MATCHER.matches(tree, state)) {
+      return NO_MATCH;
+    }
+    String argument = constValue(tree.getArguments().get(0), String.class);
+    if (argument == null) {
+      return NO_MATCH;
+    }
+    return constructDescription(tree, tree.getArguments().get(0), state);
+  }
+
+  @Override
+  public Description matchNewClass(NewClassTree tree, VisitorState state) {
+    if (!PATTERN_CTOR_MATCHER.matches(tree, state)) {
+      return NO_MATCH;
+    }
+    return constructDescription(tree, tree.getArguments().get(0), state);
+  }
+
+  /**
+   * Override this method to provide a rewritten date format pattern from {@code pattern}. An empty
+   * optional indicates that {@code pattern} does not need rewriting.
+   */
+  abstract Optional<String> rewriteTo(String pattern);
+
+  private Description constructDescription(
+      Tree tree, ExpressionTree patternArg, VisitorState state) {
+    return Optional.ofNullable(constValue(patternArg, String.class))
+        .flatMap(this::rewriteTo)
+        .map(replacement -> describeMatch(tree, replaceArgument(patternArg, replacement, state)))
+        .orElse(NO_MATCH);
+  }
+
+  private static SuggestedFix replaceArgument(
+      ExpressionTree patternArg, String replacement, VisitorState state) {
+    String quotedReplacement = String.format("\"%s\"", replacement);
+    if (patternArg.getKind() == Kind.STRING_LITERAL) {
+      return SuggestedFix.replace(patternArg, quotedReplacement);
+    }
+    Symbol sym = getSymbol(patternArg);
+    if (!(sym instanceof VarSymbol) || sym.getKind() != ElementKind.FIELD) {
+      return SuggestedFix.builder().build();
+    }
+    SuggestedFix.Builder fix = SuggestedFix.builder();
+    new TreeScanner<Void, Void>() {
+      @Override
+      public Void visitVariable(VariableTree node, Void unused) {
+        if (sym.equals(getSymbol(node))
+            && node.getInitializer() != null
+            && node.getInitializer().getKind() == Kind.STRING_LITERAL) {
+          fix.replace(node.getInitializer(), quotedReplacement);
+          return null;
+        }
+        return super.visitVariable(node, null);
+      }
+    }.scan(state.getPath().getCompilationUnit(), null);
+    return fix.build();
+  }
+
+  static String replaceFormatChar(String format, char from, char to) {
+    StringBuilder builder = new StringBuilder();
+    parseDateFormat(
+        format,
+        new DateFormatConsumer() {
+          @Override
+          public void consumeLiteral(char literal) {
+            builder.append(literal);
+          }
+
+          @Override
+          public void consumeSpecial(char special) {
+            builder.append(special == from ? to : special);
+          }
+        });
+    return builder.toString();
+  }
+
+  static void parseDateFormat(String format, DateFormatConsumer consumer) {
+    for (int pos = 0; pos < format.length(); ++pos) {
+      char c = format.charAt(pos);
+      if (c == '\'') {
+        consumer.consumeSpecial('\'');
+        pos++;
+        for (; pos < format.length(); ++pos) {
+          consumer.consumeLiteral(format.charAt(pos));
+          if (format.charAt(pos) == '\'') {
+            if (pos + 1 < format.length() && format.charAt(pos + 1) == '\'') {
+              consumer.consumeSpecial('\'');
+              pos++; // Increment another to skip the escaped '
+            } else {
+              break;
+            }
+          }
+        }
+      } else {
+        consumer.consumeSpecial(c);
+      }
+    }
+  }
+
+  interface DateFormatConsumer {
+    /** Consumes a literal (escaped) character. */
+    void consumeLiteral(char literal);
+
+    /** Consumes a special (format) character. */
+    void consumeSpecial(char special);
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -175,6 +175,7 @@ import com.google.errorprone.bugpatterns.MissingFail;
 import com.google.errorprone.bugpatterns.MissingOverride;
 import com.google.errorprone.bugpatterns.MissingSuperCall;
 import com.google.errorprone.bugpatterns.MissingTestCall;
+import com.google.errorprone.bugpatterns.MisusedDayOfYear;
 import com.google.errorprone.bugpatterns.MisusedWeekYear;
 import com.google.errorprone.bugpatterns.MixedArrayDimensions;
 import com.google.errorprone.bugpatterns.MixedDescriptors;
@@ -564,6 +565,7 @@ public class BuiltInCheckerSuppliers {
           MislabeledAndroidString.class,
           MissingSuperCall.class,
           MissingTestCall.class,
+          MisusedDayOfYear.class,
           MisusedWeekYear.class,
           MockitoCast.class,
           MockitoUsage.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MisusedDayOfYearTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MisusedDayOfYearTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link MisusedDayOfYear}. */
+@RunWith(JUnit4.class)
+public final class MisusedDayOfYearTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(MisusedDayOfYear.class, getClass());
+
+  private final BugCheckerRefactoringTestHelper refactoringHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new MisusedDayOfYear(), getClass());
+
+  @Test
+  public void positive() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import java.time.format.DateTimeFormatter;",
+            "class Test {",
+            "  static {",
+            "    DateTimeFormatter.ofPattern(\"yy-MM-DD\");",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.time.format.DateTimeFormatter;",
+            "class Test {",
+            "  static {",
+            "    DateTimeFormatter.ofPattern(\"yy-MM-dd\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void noDayOfYear_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.time.format.DateTimeFormatter;",
+            "class Test {",
+            "  static {",
+            "    DateTimeFormatter.ofPattern(\"yy-MM-dd\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void noMonthOfYear_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.time.format.DateTimeFormatter;",
+            "class Test {",
+            "  static {",
+            "    DateTimeFormatter.ofPattern(\"yy-DD\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void escapedInQuotes() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.time.format.DateTimeFormatter;",
+            "class Test {",
+            "  static {",
+            "    DateTimeFormatter.ofPattern(\"'D'yy-MM-dd\");",
+            "    DateTimeFormatter.ofPattern(\"'D'''yy-MM-dd\");",
+            "    DateTimeFormatter.ofPattern(\"'''D'yy-MM-dd\");",
+            "    DateTimeFormatter.ofPattern(\"'D''D'yy-MM-dd\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void escapedInQuotes_butAlsoAsSpecialChar() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import java.time.format.DateTimeFormatter;",
+            "class Test {",
+            "  static {",
+            "    DateTimeFormatter.ofPattern(\"'D'yy-MM-DD\");",
+            "    DateTimeFormatter.ofPattern(\"'D'''yy-MM-DD\");",
+            "    DateTimeFormatter.ofPattern(\"'''D'yy-MM-DD\");",
+            "    DateTimeFormatter.ofPattern(\"'D''D'yy-MM-DD\");",
+            "    DateTimeFormatter.ofPattern(\"'M'yy-DD\");",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.time.format.DateTimeFormatter;",
+            "class Test {",
+            "  static {",
+            "    DateTimeFormatter.ofPattern(\"'D'yy-MM-dd\");",
+            "    DateTimeFormatter.ofPattern(\"'D'''yy-MM-dd\");",
+            "    DateTimeFormatter.ofPattern(\"'''D'yy-MM-dd\");",
+            "    DateTimeFormatter.ofPattern(\"'D''D'yy-MM-dd\");",
+            "    DateTimeFormatter.ofPattern(\"'M'yy-DD\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/StronglyTypeTimeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/StronglyTypeTimeTest.java
@@ -244,4 +244,30 @@ public final class StronglyTypeTimeTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void whenJodaAndJavaInstantUsed_fullyQualifiesName() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import java.time.Instant;",
+            "class Test {",
+            "  private static final long FOO_MILLIS = 100L;",
+            "  private static final Instant INSTANT = null;",
+            "  public org.joda.time.Instant get() {",
+            "    return new org.joda.time.Instant(FOO_MILLIS);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.time.Instant;",
+            "class Test {",
+            "  private static final org.joda.time.Instant FOO = new org.joda.time.Instant(100L);",
+            "  private static final Instant INSTANT = null;",
+            "  public org.joda.time.Instant get() {",
+            "    return FOO;",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> StronglyTypeTime: qualify the type correctly.

I always forget that this method takes the VisitorState partly for the TreePath. It's a little ironically error-prone...

bda581280958e7937c20bbc164a62a2d93b610cf

-------

<p> MisusedDayOfYear: flag date formats with D where M is also used.

Fixes #1462

dc5d0376928ede515e6ee8e2412314b10020afc5