### PR TITLE
Add `--release` flag support

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -79,6 +79,7 @@ import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types.DefaultTypeVisitor;
 import com.sun.tools.javac.main.Arguments;
+import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.parser.Tokens;
 import com.sun.tools.javac.parser.Tokens.Comment;
 import com.sun.tools.javac.parser.Tokens.TokenKind;
@@ -1023,9 +1024,15 @@ public class SuggestedFixes {
     Options originalOptions = Options.instance(javacTask.getContext());
     for (String key : originalOptions.keySet()) {
       String value = originalOptions.get(key);
-      if (key.equals("-Xplugin:") && value.startsWith("ErrorProne")) {
+      if (key.equals(Option.PLUGIN.getPrimaryName()) && value.startsWith("ErrorProne")) {
         // When using the -Xplugin Error Prone integration, disable Error Prone for speculative
         // recompiles to avoid infinite recursion.
+        continue;
+      }
+      if ((key.equals(Option.SOURCE.getPrimaryName()) || key.equals(Option.TARGET.getPrimaryName()))
+          && originalOptions.isSet(Option.RELEASE)) {
+        // javac does not allow -source and -target to be specified explicitly when --release is,
+        // but does add them in response to passing --release. Here we invert that operation.
         continue;
       }
       options.put(key, value);

--- a/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
+++ b/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
@@ -24,6 +24,7 @@ import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.isSameType;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
@@ -46,6 +47,7 @@ import com.google.errorprone.bugpatterns.RemoveUnusedImports;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.util.ASTHelpers;
+import com.google.errorprone.util.RuntimeVersion;
 import com.sun.source.doctree.LinkTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
@@ -1022,6 +1024,31 @@ public class SuggestedFixesTest {
   @Test
   public void compilesWithFixTest() {
     BugCheckerRefactoringTestHelper.newInstance(new CompilesWithFixChecker(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "class Test {",
+            "  void f() {",
+            "    int x = 0;",
+            "    int y = 1;",
+            "    System.err.println(y);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "class Test {",
+            "  void f() {",
+            "    int y = 1;",
+            "    System.err.println(y);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void compilesWithFix_releaseFlag() {
+    assumeTrue(RuntimeVersion.isAtLeast9());
+    BugCheckerRefactoringTestHelper.newInstance(new CompilesWithFixChecker(), getClass())
+        .setArgs("--release", "9")
         .addInputLines(
             "in/Test.java",
             "class Test {",


### PR DESCRIPTION
The java compiler [does not allow](https://hg.openjdk.java.net/jdk/jdk11/file/1ddf9a99e4ad/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Arguments.java#l297) `-source` and `-target` to be specified explicitly when `--release` is, but [does add them](https://hg.openjdk.java.net/jdk/jdk11/file/1ddf9a99e4ad/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Arguments.java#l315) in response to passing `--release`. As such `SuggestedFixes#compilesWithFix` must compensate for this by removing `-source` and `-target` before triggering another compilation round.

Fixes google/error-prone#1265.