### PR TITLE
MOE Sync 2020-01-13

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/LossyPrimitiveCompare.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LossyPrimitiveCompare.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.code.Symtab;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Types;
+import java.util.function.Predicate;
+
+/**
+ * Checker to prevent usages of comparison methods where both the operands undergo lossy widening.
+ *
+ * @author awturner@google.com (Andy Turner)
+ */
+@BugPattern(
+    name = "LossyPrimitiveCompare",
+    summary = "Using an unnecessarily-wide comparison method can lead to lossy comparison",
+    explanation =
+        "Implicit widening conversions when comparing two primitives with methods like"
+            + " Float.compare can lead to lossy comparison. For example,"
+            + " `Float.compare(Integer.MAX_VALUE, Integer.MAX_VALUE - 1) == 0`. Use a compare"
+            + " method with non-lossy conversion, or ideally no conversion if possible.",
+    severity = ERROR,
+    providesFix = REQUIRES_HUMAN_ATTENTION)
+public class LossyPrimitiveCompare extends BugChecker implements MethodInvocationTreeMatcher {
+  private static final Matcher<ExpressionTree> COMPARE_MATCHER =
+      staticMethod().onClassAny("java.lang.Float", "java.lang.Double").named("compare");
+
+  private static final Matcher<ExpressionTree> FLOAT_COMPARE_MATCHER =
+      staticMethod().onClass("java.lang.Float").named("compare");
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (!COMPARE_MATCHER.matches(tree, state)) {
+      return Description.NO_MATCH;
+    }
+
+    Types types = state.getTypes();
+    Symtab symtab = state.getSymtab();
+    ImmutableList<Type> argTypes =
+        tree.getArguments().stream().map(ASTHelpers::getType).collect(toImmutableList());
+    Predicate<Type> argsAreConvertible =
+        type -> argTypes.stream().allMatch(t -> types.isConvertible(t, type));
+
+    if (argsAreConvertible.test(symtab.byteType)
+        || argsAreConvertible.test(symtab.charType)
+        || argsAreConvertible.test(symtab.shortType)) {
+      // These types can be converted to float and double without loss.
+    } else if (argsAreConvertible.test(symtab.intType)) {
+      // Only need to fix in the case of Float.compare, because int can be converted to double
+      // without loss.
+      if (FLOAT_COMPARE_MATCHER.matches(tree, state)) {
+        return describeMatch(tree, SuggestedFix.replace(tree.getMethodSelect(), "Integer.compare"));
+      }
+    } else if (argsAreConvertible.test(symtab.longType)) {
+      return describeMatch(tree, SuggestedFix.replace(tree.getMethodSelect(), "Long.compare"));
+    }
+
+    return Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MisusedDateFormat.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MisusedDateFormat.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.constructor;
+import static com.google.errorprone.matchers.Matchers.instanceMethod;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+import static com.google.errorprone.util.ASTHelpers.constValue;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import java.util.Optional;
+import javax.lang.model.element.ElementKind;
+
+/** Base class for checks which find common errors in date format patterns. */
+public abstract class MisusedDateFormat extends BugChecker
+    implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
+
+  private static final String JAVA_SIMPLE_DATE_FORMAT = "java.text.SimpleDateFormat";
+
+  private static final String ICU_SIMPLE_DATE_FORMAT = "com.ibm.icu.text.SimpleDateFormat";
+
+  private static final Matcher<NewClassTree> PATTERN_CTOR_MATCHER =
+      anyOf(
+          constructor().forClass(JAVA_SIMPLE_DATE_FORMAT).withParameters("java.lang.String"),
+          constructor()
+              .forClass(JAVA_SIMPLE_DATE_FORMAT)
+              .withParameters("java.lang.String", "java.text.DateFormatSymbols"),
+          constructor()
+              .forClass(JAVA_SIMPLE_DATE_FORMAT)
+              .withParameters("java.lang.String", "java.util.Locale"),
+          constructor().forClass(ICU_SIMPLE_DATE_FORMAT).withParameters("java.lang.String"),
+          constructor()
+              .forClass(ICU_SIMPLE_DATE_FORMAT)
+              .withParameters("java.lang.String", "com.ibm.icu.text.DateFormatSymbols"),
+          constructor()
+              .forClass(ICU_SIMPLE_DATE_FORMAT)
+              .withParameters(
+                  "java.lang.String",
+                  "com.ibm.icu.text.DateFormatSymbols",
+                  "com.ibm.icu.util.ULocale"),
+          constructor()
+              .forClass(ICU_SIMPLE_DATE_FORMAT)
+              .withParameters("java.lang.String", "java.util.Locale"),
+          constructor()
+              .forClass(ICU_SIMPLE_DATE_FORMAT)
+              .withParameters("java.lang.String", "java.lang.String", "com.ibm.icu.util.ULocale"),
+          constructor()
+              .forClass(ICU_SIMPLE_DATE_FORMAT)
+              .withParameters("java.lang.String", "com.ibm.icu.util.ULocale"));
+
+  /** Matches methods that take a pattern as the first argument. */
+  private static final Matcher<ExpressionTree> PATTERN_MATCHER =
+      anyOf(
+          instanceMethod().onExactClass(JAVA_SIMPLE_DATE_FORMAT).named("applyPattern"),
+          instanceMethod().onExactClass(JAVA_SIMPLE_DATE_FORMAT).named("applyLocalizedPattern"),
+          instanceMethod().onExactClass(ICU_SIMPLE_DATE_FORMAT).named("applyPattern"),
+          instanceMethod().onExactClass(ICU_SIMPLE_DATE_FORMAT).named("applyLocalizedPattern"),
+          staticMethod().onClass("java.time.format.DateTimeFormatter").named("ofPattern"));
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (!PATTERN_MATCHER.matches(tree, state)) {
+      return NO_MATCH;
+    }
+    String argument = constValue(tree.getArguments().get(0), String.class);
+    if (argument == null) {
+      return NO_MATCH;
+    }
+    return constructDescription(tree, tree.getArguments().get(0), state);
+  }
+
+  @Override
+  public Description matchNewClass(NewClassTree tree, VisitorState state) {
+    if (!PATTERN_CTOR_MATCHER.matches(tree, state)) {
+      return NO_MATCH;
+    }
+    return constructDescription(tree, tree.getArguments().get(0), state);
+  }
+
+  /**
+   * Override this method to provide a rewritten date format pattern from {@code pattern}. An empty
+   * optional indicates that {@code pattern} does not need rewriting.
+   */
+  abstract Optional<String> rewriteTo(String pattern);
+
+  private Description constructDescription(
+      Tree tree, ExpressionTree patternArg, VisitorState state) {
+    return Optional.ofNullable(constValue(patternArg, String.class))
+        .flatMap(this::rewriteTo)
+        .map(replacement -> describeMatch(tree, replaceArgument(patternArg, replacement, state)))
+        .orElse(NO_MATCH);
+  }
+
+  private static SuggestedFix replaceArgument(
+      ExpressionTree patternArg, String replacement, VisitorState state) {
+    String quotedReplacement = String.format("\"%s\"", replacement);
+    if (patternArg.getKind() == Kind.STRING_LITERAL) {
+      return SuggestedFix.replace(patternArg, quotedReplacement);
+    }
+    Symbol sym = getSymbol(patternArg);
+    if (!(sym instanceof VarSymbol) || sym.getKind() != ElementKind.FIELD) {
+      return SuggestedFix.builder().build();
+    }
+    SuggestedFix.Builder fix = SuggestedFix.builder();
+    new TreeScanner<Void, Void>() {
+      @Override
+      public Void visitVariable(VariableTree node, Void unused) {
+        if (sym.equals(getSymbol(node))
+            && node.getInitializer() != null
+            && node.getInitializer().getKind() == Kind.STRING_LITERAL) {
+          fix.replace(node.getInitializer(), quotedReplacement);
+          return null;
+        }
+        return super.visitVariable(node, null);
+      }
+    }.scan(state.getPath().getCompilationUnit(), null);
+    return fix.build();
+  }
+
+  static String replaceFormatChar(String format, char from, char to) {
+    StringBuilder builder = new StringBuilder();
+    parseDateFormat(
+        format,
+        new DateFormatConsumer() {
+          @Override
+          public void consumeLiteral(char literal) {
+            builder.append(literal);
+          }
+
+          @Override
+          public void consumeSpecial(char special) {
+            builder.append(special == from ? to : special);
+          }
+        });
+    return builder.toString();
+  }
+
+  static void parseDateFormat(String format, DateFormatConsumer consumer) {
+    for (int pos = 0; pos < format.length(); ++pos) {
+      char c = format.charAt(pos);
+      if (c == '\'') {
+        consumer.consumeSpecial('\'');
+        pos++;
+        for (; pos < format.length(); ++pos) {
+          consumer.consumeLiteral(format.charAt(pos));
+          if (format.charAt(pos) == '\'') {
+            if (pos + 1 < format.length() && format.charAt(pos + 1) == '\'') {
+              consumer.consumeSpecial('\'');
+              pos++; // Increment another to skip the escaped '
+            } else {
+              break;
+            }
+          }
+        }
+      } else {
+        consumer.consumeSpecial(c);
+      }
+    }
+  }
+
+  interface DateFormatConsumer {
+    /** Consumes a literal (escaped) character. */
+    void consumeLiteral(char literal);
+
+    /** Consumes a special (format) character. */
+    void consumeSpecial(char special);
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -166,6 +166,7 @@ import com.google.errorprone.bugpatterns.LockNotBeforeTry;
 import com.google.errorprone.bugpatterns.LogicalAssignment;
 import com.google.errorprone.bugpatterns.LongLiteralLowerCaseSuffix;
 import com.google.errorprone.bugpatterns.LoopConditionChecker;
+import com.google.errorprone.bugpatterns.LossyPrimitiveCompare;
 import com.google.errorprone.bugpatterns.MathAbsoluteRandom;
 import com.google.errorprone.bugpatterns.MathRoundIntLong;
 import com.google.errorprone.bugpatterns.MethodCanBeStatic;
@@ -561,6 +562,7 @@ public class BuiltInCheckerSuppliers {
           LiteByteStringUtf8.class,
           LocalDateTemporalAmount.class,
           LoopConditionChecker.class,
+          LossyPrimitiveCompare.class,
           MathRoundIntLong.class,
           MislabeledAndroidString.class,
           MissingSuperCall.class,

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -175,6 +175,7 @@ import com.google.errorprone.bugpatterns.MissingFail;
 import com.google.errorprone.bugpatterns.MissingOverride;
 import com.google.errorprone.bugpatterns.MissingSuperCall;
 import com.google.errorprone.bugpatterns.MissingTestCall;
+import com.google.errorprone.bugpatterns.MisusedDayOfYear;
 import com.google.errorprone.bugpatterns.MisusedWeekYear;
 import com.google.errorprone.bugpatterns.MixedArrayDimensions;
 import com.google.errorprone.bugpatterns.MixedDescriptors;
@@ -564,6 +565,7 @@ public class BuiltInCheckerSuppliers {
           MislabeledAndroidString.class,
           MissingSuperCall.class,
           MissingTestCall.class,
+          MisusedDayOfYear.class,
           MisusedWeekYear.class,
           MockitoCast.class,
           MockitoUsage.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ExtendsAutoValueTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ExtendsAutoValueTest.java
@@ -16,6 +16,8 @@
 
 package com.google.errorprone.bugpatterns;
 
+import com.google.auto.value.processor.AutoValueProcessor;
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.util.RuntimeVersion;
 import org.junit.Test;
@@ -27,7 +29,8 @@ import org.junit.runners.JUnit4;
 public class ExtendsAutoValueTest {
 
   private final CompilationTestHelper helper =
-      CompilationTestHelper.newInstance(ExtendsAutoValue.class, getClass());
+      CompilationTestHelper.newInstance(ExtendsAutoValue.class, getClass())
+          .setArgs(ImmutableList.of("-processor", AutoValueProcessor.class.getName()));
 
   @Test
   public void extendsAutoValue_goodNoSuperclass() {
@@ -118,7 +121,7 @@ public class ExtendsAutoValueTest {
             "OuterClass.java",
             "import com.google.auto.value.AutoValue;",
             "public class OuterClass { ",
-            "  @AutoValue class AutoClass {}",
+            "  @AutoValue abstract static class AutoClass {}",
             "  // BUG: Diagnostic contains: ExtendsAutoValue",
             "  class TestClass extends AutoClass {}",
             "}")

--- a/core/src/test/java/com/google/errorprone/bugpatterns/LossyPrimitiveCompareTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/LossyPrimitiveCompareTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** @author awturner@google.com (Andy Turner) */
+@RunWith(JUnit4.class)
+public class LossyPrimitiveCompareTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(LossyPrimitiveCompare.class, getClass());
+
+  @Test
+  public void doubleCompare() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  int[] results = {",
+            "    // BUG: Diagnostic contains: Long.compare(0L, 0L)",
+            "    Double.compare(0L, 0L),",
+            "    // BUG: Diagnostic contains: Long.compare(Long.valueOf(0L), 0L)",
+            "    Double.compare(Long.valueOf(0L), 0L),",
+            "",
+            "    // Not lossy.",
+            "    Double.compare((byte) 0, (byte) 0),",
+            "    Double.compare((short) 0, (short) 0),",
+            "    Double.compare('0', '0'),",
+            "    Double.compare(0, 0),",
+            "    Double.compare(0.f, 0.f),",
+            "    Double.compare(0.0, 0.0),",
+            "  };",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void floatCompare() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  int[] results = {",
+            "    // BUG: Diagnostic contains: Long.compare(0L, 0L)",
+            "    Float.compare(0L, 0L),",
+            "    // BUG: Diagnostic contains: Long.compare(Long.valueOf(0L), 0L)",
+            "    Float.compare(Long.valueOf(0L), 0L),",
+            "    // BUG: Diagnostic contains: Integer.compare(0, 0)",
+            "    Float.compare(0, 0),",
+            "    // BUG: Diagnostic contains: Integer.compare(0, Integer.valueOf(0))",
+            "    Float.compare(0, Integer.valueOf(0)),",
+            "",
+            "    // Not lossy.",
+            "    Float.compare((byte) 0, (byte) 0),",
+            "    Float.compare((short) 0, (short) 0),",
+            "    Float.compare('0', '0'),",
+            "    Float.compare(0.f, 0.f),",
+            "  };",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MisusedDayOfYearTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MisusedDayOfYearTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link MisusedDayOfYear}. */
+@RunWith(JUnit4.class)
+public final class MisusedDayOfYearTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(MisusedDayOfYear.class, getClass());
+
+  private final BugCheckerRefactoringTestHelper refactoringHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new MisusedDayOfYear(), getClass());
+
+  @Test
+  public void positive() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import java.time.format.DateTimeFormatter;",
+            "class Test {",
+            "  static {",
+            "    DateTimeFormatter.ofPattern(\"yy-MM-DD\");",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.time.format.DateTimeFormatter;",
+            "class Test {",
+            "  static {",
+            "    DateTimeFormatter.ofPattern(\"yy-MM-dd\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void noDayOfYear_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.time.format.DateTimeFormatter;",
+            "class Test {",
+            "  static {",
+            "    DateTimeFormatter.ofPattern(\"yy-MM-dd\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void noMonthOfYear_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.time.format.DateTimeFormatter;",
+            "class Test {",
+            "  static {",
+            "    DateTimeFormatter.ofPattern(\"yy-DD\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void escapedInQuotes() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.time.format.DateTimeFormatter;",
+            "class Test {",
+            "  static {",
+            "    DateTimeFormatter.ofPattern(\"'D'yy-MM-dd\");",
+            "    DateTimeFormatter.ofPattern(\"'D'''yy-MM-dd\");",
+            "    DateTimeFormatter.ofPattern(\"'''D'yy-MM-dd\");",
+            "    DateTimeFormatter.ofPattern(\"'D''D'yy-MM-dd\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void escapedInQuotes_butAlsoAsSpecialChar() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import java.time.format.DateTimeFormatter;",
+            "class Test {",
+            "  static {",
+            "    DateTimeFormatter.ofPattern(\"'D'yy-MM-DD\");",
+            "    DateTimeFormatter.ofPattern(\"'D'''yy-MM-DD\");",
+            "    DateTimeFormatter.ofPattern(\"'''D'yy-MM-DD\");",
+            "    DateTimeFormatter.ofPattern(\"'D''D'yy-MM-DD\");",
+            "    DateTimeFormatter.ofPattern(\"'M'yy-DD\");",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.time.format.DateTimeFormatter;",
+            "class Test {",
+            "  static {",
+            "    DateTimeFormatter.ofPattern(\"'D'yy-MM-dd\");",
+            "    DateTimeFormatter.ofPattern(\"'D'''yy-MM-dd\");",
+            "    DateTimeFormatter.ofPattern(\"'''D'yy-MM-dd\");",
+            "    DateTimeFormatter.ofPattern(\"'D''D'yy-MM-dd\");",
+            "    DateTimeFormatter.ofPattern(\"'M'yy-DD\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByCheckerTest.java
@@ -1752,4 +1752,28 @@ public class GuardedByCheckerTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void suppressionOnMethod() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "package threadsafety;",
+            "import javax.annotation.concurrent.GuardedBy;",
+            "class Test {",
+            "  final Object lock = null;",
+            "  void foo() {",
+            "    class Foo extends Object {",
+            "      @GuardedBy(\"lock\") int x;",
+            "      @SuppressWarnings(\"GuardedBy\")",
+            "      void m() {",
+            "        synchronized (lock) {",
+            "          int z = x++;",
+            "        }",
+            "      }",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/StronglyTypeTimeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/StronglyTypeTimeTest.java
@@ -244,4 +244,30 @@ public final class StronglyTypeTimeTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void whenJodaAndJavaInstantUsed_fullyQualifiesName() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import java.time.Instant;",
+            "class Test {",
+            "  private static final long FOO_MILLIS = 100L;",
+            "  private static final Instant INSTANT = null;",
+            "  public org.joda.time.Instant get() {",
+            "    return new org.joda.time.Instant(FOO_MILLIS);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.time.Instant;",
+            "class Test {",
+            "  private static final org.joda.time.Instant FOO = new org.joda.time.Instant(100L);",
+            "  private static final Instant INSTANT = null;",
+            "  public org.joda.time.Instant get() {",
+            "    return FOO;",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> StronglyTypeTime: qualify the type correctly.

I always forget that this method takes the VisitorState partly for the TreePath. It's a little ironically error-prone...

7ea13b93322d168be25c1d732d64bfcca165a5b3

-------

<p> MisusedDayOfYear: flag date formats with D where M is also used.

Fixes external #1462

7ed6f717f8fe1c31bcd196f78250f7bf4f8b387f

-------

<p> LossyPrimitiveCompare: disallow usage of Float.compare and Double.compare if the arguments undergo a lossy widening conversion

a68919e8257e6e41017d6b77b87e3ef6c13ce5b6

-------

<p> ExtendsAutoValueTest: run the AutoValue processor at test time.

8f7722144460cc16bff5fd925dd040f7314e47b7

-------

<p> LockScanner: check suppressions more.

I found some odd cases where @SuppressWarnings doesn't suppress as you would expect.

b205fe3a207553dd0f815cb4e2e28c3449805f74