### PR TITLE
MOE Sync 2020-01-16

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/Overrides.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Overrides.java
@@ -28,7 +28,6 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
-import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import java.util.Iterator;
 import java.util.List;
@@ -50,7 +49,7 @@ public class Overrides extends BugChecker implements MethodTreeMatcher {
   @Override
   public Description matchMethod(MethodTree methodTree, VisitorState state) {
     MethodSymbol methodSymbol = ASTHelpers.getSymbol(methodTree);
-    boolean isVarargs = (methodSymbol.flags() & Flags.VARARGS) != 0;
+    boolean isVarargs = methodSymbol.isVarArgs();
 
     Set<MethodSymbol> superMethods = ASTHelpers.findSuperMethods(methodSymbol, state.getTypes());
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionIncompatibleType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionIncompatibleType.java
@@ -283,8 +283,9 @@ public class CollectionIncompatibleType extends BugChecker
     @Nullable
     @Override
     Type extractSourceType(MemberReferenceTree tree, VisitorState state) {
+      Type descriptorType = state.getTypes().findDescriptorType(getType(tree));
       return extractTypeArgAsMemberOfSupertype(
-          getType(tree).getParameterTypes().get(0),
+          descriptorType.getParameterTypes().get(0),
           state.getSymbolFromString(collectionType),
           0,
           state.getTypes());
@@ -315,8 +316,9 @@ public class CollectionIncompatibleType extends BugChecker
     @Nullable
     @Override
     Type extractTargetType(MemberReferenceTree tree, VisitorState state) {
+      Type descriptorType = state.getTypes().findDescriptorType(getType(tree));
       return extractTypeArgAsMemberOfSupertype(
-          getType(tree).getParameterTypes().get(1),
+          descriptorType.getParameterTypes().get(1),
           state.getSymbolFromString(collectionType),
           0,
           state.getTypes());

--- a/core/src/main/java/com/google/errorprone/bugpatterns/overloading/ParameterTree.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/overloading/ParameterTree.java
@@ -21,7 +21,8 @@ import com.google.common.base.Preconditions;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
-import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import java.util.Set;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
@@ -85,6 +86,10 @@ abstract class ParameterTree {
 
   // TODO(hanuszczak): This should probably be moved to ASTHelpers.
   private static boolean isVariableTreeVarArgs(VariableTree variableTree) {
-    return (ASTHelpers.getSymbol(variableTree).flags() & Flags.VARARGS) != 0;
+    Symbol sym = ASTHelpers.getSymbol(variableTree);
+    Preconditions.checkArgument(
+        sym.owner instanceof MethodSymbol, "sym must be a parameter to a method");
+    MethodSymbol method = (MethodSymbol) sym.owner;
+    return method.isVarArgs() && method.getParameters().last() == sym;
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ConstantFieldTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ConstantFieldTest.java
@@ -26,7 +26,7 @@ import org.junit.runners.JUnit4;
 /** {@link ConstantField}Test */
 @RunWith(JUnit4.class)
 public class ConstantFieldTest {
-  CompilationTestHelper compilationHelper =
+  private final CompilationTestHelper compilationHelper =
       CompilationTestHelper.newInstance(ConstantField.class, getClass());
 
   @Test
@@ -58,30 +58,6 @@ public class ConstantFieldTest {
             "class Test {",
             "  // BUG: Diagnostic contains: 'Object constantCaseName = 42;'",
             "  Object CONSTANT_CASE_NAME = 42;",
-            "}")
-        .doTest();
-  }
-
-  @Test
-  public void typo() {
-    compilationHelper
-        .addSourceLines(
-            "Test.java",
-            "class Test {",
-            "  // BUG: Diagnostic contains: PROJECT_DATA_SUBDIRECTORY",
-            "  private static final String PROJECT_DATA_SUBDIREcTORY = \".project\";",
-            "}")
-        .doTest();
-  }
-
-  @Test
-  public void snakeCase() {
-    compilationHelper
-        .addSourceLines(
-            "Test.java",
-            "class Test {",
-            "  // BUG: Diagnostic contains: SNAKE_CASE_VARIABLE",
-            "  private static final String snake_case_variable = \"Kayla\";",
             "}")
         .doTest();
   }
@@ -151,25 +127,6 @@ public class ConstantFieldTest {
   }
 
   @Test
-  public void primitivesAreConstant() {
-    compilationHelper
-        .addSourceLines(
-            "Test.java",
-            "class Test {",
-            "  // BUG: Diagnostic contains:"
-                + " ints are immutable, field should be named 'CONSTANT'",
-            "  static final int constant = 42;",
-            "  // BUG: Diagnostic contains:"
-                + " Integers are immutable, field should be named 'BOXED_CONSTANT'",
-            "  static final Integer boxedConstant = 42;",
-            "  // BUG: Diagnostic contains:"
-                + " Strings are immutable, field should be named 'STRING_CONSTANT'",
-            "  static final String stringConstant = \"\";",
-            "}")
-        .doTest();
-  }
-
-  @Test
   public void primitivesAreConstant_negative() {
     compilationHelper
         .addSourceLines(
@@ -192,32 +149,6 @@ public class ConstantFieldTest {
             "class Test implements Serializable {",
             "  private static final long serialVersionUID = 1L;",
             "  private static final ObjectStreamField[] serialPersistentFields = {};",
-            "}")
-        .doTest();
-  }
-
-  @Test
-  public void positiveEnum() {
-    compilationHelper
-        .addSourceLines(
-            "Test.java",
-            "import javax.lang.model.element.ElementKind;",
-            "interface Test {",
-            "  // BUG: Diagnostic contains: 'ElementKind KIND = ElementKind.FIELD;'",
-            "  ElementKind Kind = ElementKind.FIELD;",
-            "}")
-        .doTest();
-  }
-
-  @Test
-  public void cppStyle() {
-    compilationHelper
-        .addSourceLines(
-            "Test.java",
-            "import javax.lang.model.element.ElementKind;",
-            "interface Test {",
-            "  // BUG: Diagnostic contains: int MAX_FOOS = 42",
-            "  static final int kMaxFoos = 42;",
             "}")
         .doTest();
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't show PreferJavaTimeOverload suggestions for Android users.

#goodtime

d030b994db1b29a519c04ef333fb6aa289a20e64

-------

<p> Remove part of ConstantField that overlaps with ConstantCaseForConstants.

a61313b715448d44a00228489c210daf3effe8f4

-------

<p> Fix remaining checks for Flags.VARARGS on VarSymbols.

The one on CompileTimeConstantChecker could create more ERRORs, so it's flagged.

I think it makes sense to just ban using Flags.VARARGS via a check_contents; it's such an easy mistake to make otherwise.

8c40bb687456d303ba2ea7bca7c18edfb552176d

-------

<p> CollectionIncompatibleType: use getDescriptorType to resolve method references properly.

This is an ERROR check, but matching method references is already flagged. Previously it was crashing (woo).

8a6b66576d4f6217b0e8dc989310b3789ecef5e9