### PR TITLE
MOE Sync 2020-01-17

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/BugCheckerInfo.java
+++ b/check_api/src/main/java/com/google/errorprone/BugCheckerInfo.java
@@ -29,6 +29,7 @@ import com.sun.source.tree.Tree;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -237,7 +238,7 @@ public class BugCheckerInfo implements Serializable {
   }
 
   public Set<Class<? extends Annotation>> customSuppressionAnnotations() {
-    return customSuppressionAnnotations;
+    return Collections.unmodifiableSet(customSuppressionAnnotations);
   }
 
   public boolean disableable() {

--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -360,9 +360,12 @@ public class SuggestedFixes {
         continue;
       }
       String className = typeName.substring(startOfClass + 1);
-      Symbol found = FindIdentifiers.findIdent(className, state, KindSelector.VAL_TYP);
+      // startOfClass + 1 to skip a leading '.'
+      String firstPartOfClassName = typeName.substring(startOfClass + 1, endOfClass);
+      Symbol found = FindIdentifiers.findIdent(firstPartOfClassName, state, KindSelector.VAL_TYP);
       // No clashing name: import it and return.
-      if (found == null) {
+      if (found == null
+          || found.getQualifiedName().contentEquals(typeName.substring(0, endOfClass))) {
         fix.addImport(typeName.substring(0, endOfClass));
         return className;
       }

--- a/check_api/src/main/java/com/google/errorprone/matchers/JUnitMatchers.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/JUnitMatchers.java
@@ -42,6 +42,7 @@ import static com.google.errorprone.util.ASTHelpers.getSymbol;
 import static javax.lang.model.element.NestingKind.TOP_LEVEL;
 
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
@@ -53,7 +54,6 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.ClassType;
-import com.sun.tools.javac.tree.JCTree;
 import java.util.Arrays;
 import java.util.Collection;
 import javax.lang.model.element.Modifier;
@@ -223,7 +223,7 @@ public class JUnitMatchers {
     return new Matcher<ExpressionTree>() {
       @Override
       public boolean matches(ExpressionTree t, VisitorState state) {
-        Type type = ((JCTree) t).type;
+        Type type = ASTHelpers.getType(t);
         // Expect a class type.
         if (!(type instanceof ClassType)) {
           return false;

--- a/check_api/src/main/java/com/google/errorprone/suppliers/Suppliers.java
+++ b/check_api/src/main/java/com/google/errorprone/suppliers/Suppliers.java
@@ -27,7 +27,6 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Type;
-import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 
@@ -247,7 +246,7 @@ public class Suppliers {
       new Supplier<Type>() {
         @Override
         public Type get(VisitorState state) {
-          return ((JCTree) state.findEnclosing(ClassTree.class)).type;
+          return ASTHelpers.getType(state.findEnclosing(ClassTree.class));
         }
       };
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AbstractReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AbstractReturnValueIgnored.java
@@ -58,7 +58,6 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 import com.sun.tools.javac.tree.JCTree.JCIdent;
-import com.sun.tools.javac.tree.JCTree.JCMemberReference;
 import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -98,8 +97,7 @@ public abstract class AbstractReturnValueIgnored extends BugChecker
                       not(
                           (t, s) ->
                               allowInExceptionThrowers()
-                                  && isThrowingFunctionalInterface(
-                                      ((JCMemberReference) t).type, s)),
+                                  && isThrowingFunctionalInterface(ASTHelpers.getType(t), s)),
                       specializedMatcher()));
 
   @Override
@@ -119,7 +117,7 @@ public abstract class AbstractReturnValueIgnored extends BugChecker
 
   private static boolean isVoidReturningMethodReferenceExpression(
       MemberReferenceTree tree, VisitorState state) {
-    return functionalInterfaceReturnsExactlyVoid(((JCMemberReference) tree).type, state);
+    return functionalInterfaceReturnsExactlyVoid(ASTHelpers.getType(tree), state);
   }
 
   private static boolean isVoidReturningLambdaExpression(Tree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadShiftAmount.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadShiftAmount.java
@@ -29,6 +29,7 @@ import com.google.errorprone.fixes.Fix;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LiteralTree;
@@ -36,7 +37,6 @@ import com.sun.source.tree.Tree.Kind;
 import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
-import com.sun.tools.javac.tree.JCTree;
 
 /**
  * @author bill.pugh@gmail.com (Bill Pugh)
@@ -60,7 +60,7 @@ public class BadShiftAmount extends BugChecker implements BinaryTreeMatcher {
       new Matcher<BinaryTree>() {
         @Override
         public boolean matches(BinaryTree tree, VisitorState state) {
-          Type leftType = ((JCTree) tree.getLeftOperand()).type;
+          Type leftType = ASTHelpers.getType(tree.getLeftOperand());
           Types types = state.getTypes();
           Symtab symtab = state.getSymtab();
           if (!(types.isSameType(leftType, symtab.intType))

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ForEachIterable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ForEachIterable.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.Matchers.instanceMethod;
+import static com.google.errorprone.util.ASTHelpers.getReceiver;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.google.errorprone.util.ASTHelpers.getType;
+import static com.google.errorprone.util.ASTHelpers.getUpperBound;
+import static com.google.errorprone.util.ASTHelpers.stripParentheses;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.fixes.SuggestedFixes;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.BlockTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.ForLoopTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.StatementTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.tree.WhileLoopTree;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.TypeTag;
+import com.sun.tools.javac.tree.JCTree;
+import java.util.List;
+
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
+@BugPattern(
+    name = "ForEachIterable",
+    summary = "This loop can be replaced with an enhanced for loop.",
+    severity = SUGGESTION)
+public class ForEachIterable extends BugChecker implements VariableTreeMatcher {
+
+  private static final Matcher<ExpressionTree> HAS_NEXT =
+      instanceMethod().onDescendantOf("java.util.Iterator").named("hasNext");
+
+  private static final Matcher<ExpressionTree> NEXT =
+      instanceMethod().onDescendantOf("java.util.Iterator").named("next");
+
+  private static final Matcher<ExpressionTree> ITERATOR =
+      instanceMethod().onDescendantOf("java.lang.Iterable").named("iterator").withParameters();
+
+  @Override
+  public Description matchVariable(VariableTree tree, VisitorState state) {
+    if (!ASTHelpers.isSameType(getType(tree.getType()), state.getSymtab().iteratorType, state)) {
+      return NO_MATCH;
+    }
+    Tree parent = state.getPath().getParentPath().getLeaf();
+    if (parent instanceof BlockTree) {
+      return matchWhile(tree, (BlockTree) parent, state);
+    }
+    if (parent instanceof ForLoopTree) {
+      return matchFor(tree, (ForLoopTree) parent, state);
+    }
+    return NO_MATCH;
+  }
+
+  /**
+   * Match for loops that can be rewritten to enhanced-for, e.g.:
+   *
+   * <pre>{@code
+   * for (Iterator<T> iterator = list.iterator(); iterator.hasNext(); ) {
+   *   doSomething(iterator.next());
+   * }
+   * }</pre>
+   */
+  private Description matchFor(VariableTree tree, ForLoopTree forTree, VisitorState state) {
+    List<? extends StatementTree> initializer = forTree.getInitializer();
+    if (initializer.size() != 1 || !getOnlyElement(initializer).equals(tree)) {
+      return NO_MATCH;
+    }
+    if (!forTree.getUpdate().isEmpty()) {
+      return NO_MATCH;
+    }
+    return match(
+        tree,
+        state,
+        ((JCTree) forTree).getStartPosition(),
+        forTree.getCondition(),
+        forTree.getStatement());
+  }
+
+  private Description matchWhile(VariableTree tree, BlockTree blockTree, VisitorState state) {
+    List<? extends StatementTree> statements = blockTree.getStatements();
+    int nextIdx = statements.indexOf(tree) + 1;
+    if (nextIdx >= statements.size()) {
+      return NO_MATCH;
+    }
+    StatementTree next = statements.get(nextIdx);
+    if (!(next instanceof WhileLoopTree)) {
+      return NO_MATCH;
+    }
+    VarSymbol iterator = getSymbol(tree);
+    for (int i = nextIdx + 1; i < statements.size(); i++) {
+      if (!findUses(state, statements.get(i), iterator).isEmpty()) {
+        return NO_MATCH;
+      }
+    }
+    WhileLoopTree whileLoop = (WhileLoopTree) next;
+    return match(
+        tree,
+        state,
+        ((JCTree) tree).getStartPosition(),
+        whileLoop.getCondition(),
+        whileLoop.getStatement());
+  }
+
+  private Description match(
+      VariableTree tree,
+      VisitorState state,
+      int startPosition,
+      ExpressionTree condition,
+      StatementTree body) {
+    if (tree.getInitializer() == null || !ITERATOR.matches(tree.getInitializer(), state)) {
+      return NO_MATCH;
+    }
+    VarSymbol iterator = getSymbol(tree);
+    if (!isHasNext(iterator, stripParentheses(condition), state)) {
+      return NO_MATCH;
+    }
+    ImmutableList<TreePath> uses = findUses(state, body, iterator);
+    if (uses.size() != 1 || !uses.stream().allMatch(p -> isNext(tree, state, p))) {
+      return NO_MATCH;
+    }
+    Type iteratorType =
+        state.getTypes().asSuper(getType(tree.getType()), state.getSymtab().iteratorType.tsym);
+    if (iteratorType == null || iteratorType.getTypeArguments().isEmpty()) {
+      return NO_MATCH;
+    }
+    SuggestedFix.Builder fix = SuggestedFix.builder();
+    VariableTree existingVariable = existingVariable(iterator, body, state);
+    String replacement;
+    if (existingVariable != null) {
+      replacement = existingVariable.getName().toString();
+      fix.delete(existingVariable);
+    } else {
+      replacement = "element";
+      uses.forEach(
+          p -> {
+            TreePath path = p.getParentPath().getParentPath();
+            switch (path.getParentPath().getLeaf().getKind()) {
+              case EXPRESSION_STATEMENT:
+                fix.delete(path.getParentPath().getLeaf());
+                break;
+              default:
+                fix.replace(path.getLeaf(), replacement);
+                break;
+            }
+          });
+    }
+    Type elementType = getOnlyElement(iteratorType.getTypeArguments());
+    if (elementType.hasTag(TypeTag.WILDCARD)) {
+      elementType = getUpperBound(elementType, state.getTypes());
+    }
+    fix.replace(
+        startPosition,
+        ((JCTree) body).getStartPosition(),
+        String.format(
+            "for (%s %s : %s) ",
+            SuggestedFixes.prettyType(state, fix, elementType),
+            replacement,
+            state.getSourceForNode(getReceiver(tree.getInitializer()))));
+    return describeMatch(tree, fix.build());
+  }
+
+  private ImmutableList<TreePath> findUses(
+      VisitorState state, StatementTree body, VarSymbol iterator) {
+    ImmutableList.Builder<TreePath> uses = ImmutableList.builder();
+    new TreePathScanner<Void, Void>() {
+      @Override
+      public Void visitIdentifier(IdentifierTree identifierTree, Void unused) {
+        if (iterator.equals(getSymbol(identifierTree))) {
+          uses.add(getCurrentPath());
+        }
+        return super.visitIdentifier(identifierTree, null);
+      }
+    }.scan(state.withPath(new TreePath(state.getPath().getParentPath(), body)).getPath(), null);
+    return uses.build();
+  }
+
+  private static VariableTree existingVariable(
+      VarSymbol varSymbol, StatementTree body, VisitorState state) {
+    if (!(body instanceof BlockTree)) {
+      return null;
+    }
+    List<? extends StatementTree> statements = ((BlockTree) body).getStatements();
+    if (statements.isEmpty()) {
+      return null;
+    }
+    StatementTree first = statements.iterator().next();
+    if (!(first instanceof VariableTree)) {
+      return null;
+    }
+    VariableTree variableTree = (VariableTree) first;
+    if (variableTree.getInitializer() == null) {
+      return null;
+    }
+    if (!NEXT.matches(variableTree.getInitializer(), state)) {
+      return null;
+    }
+    if (!varSymbol.equals(ASTHelpers.getSymbol(getReceiver(variableTree.getInitializer())))) {
+      return null;
+    }
+    return variableTree;
+  }
+
+  private static boolean isNext(VariableTree tree, VisitorState state, TreePath p) {
+    Tree parentTree = p.getParentPath().getLeaf();
+    if (!(parentTree instanceof ExpressionTree)) {
+      return false;
+    }
+    ExpressionTree parent = (ExpressionTree) parentTree;
+    return NEXT.matches(parent, state) && getSymbol(tree).equals(getSymbol(getReceiver(parent)));
+  }
+
+  private static boolean isHasNext(
+      VarSymbol iterator, ExpressionTree condition, VisitorState state) {
+    return HAS_NEXT.matches(condition, state) && iterator.equals(getSymbol(getReceiver(condition)));
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnored.java
@@ -50,8 +50,6 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.TypeVariableSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.TypeTag;
-import com.sun.tools.javac.tree.JCTree.JCLambda;
-import com.sun.tools.javac.tree.JCTree.JCMemberReference;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 import java.util.ArrayDeque;
@@ -302,7 +300,7 @@ public final class FutureReturnValueIgnored extends AbstractReturnValueIgnored
 
   private static boolean isObjectReturningMethodReferenceExpression(
       MemberReferenceTree tree, VisitorState state) {
-    return functionalInterfaceReturnsObject(((JCMemberReference) tree).type, state);
+    return functionalInterfaceReturnsObject(ASTHelpers.getType(tree), state);
   }
 
   private static boolean isObjectReturningLambdaExpression(Tree tree, VisitorState state) {
@@ -310,7 +308,7 @@ public final class FutureReturnValueIgnored extends AbstractReturnValueIgnored
       return false;
     }
 
-    Type type = ((JCLambda) tree).type;
+    Type type = ASTHelpers.getType(tree);
     return functionalInterfaceReturnsObject(type, state)
         && !isWhitelistedInterfaceType(type, state);
   }
@@ -340,8 +338,8 @@ public final class FutureReturnValueIgnored extends AbstractReturnValueIgnored
       if (allOf(
               (t, s) -> t.getMode() == ReferenceMode.INVOKE,
               FutureReturnValueIgnored::isObjectReturningMethodReferenceExpression,
-              not((t, s) -> isWhitelistedInterfaceType(((JCMemberReference) t).type, s)),
-              not((t, s) -> isThrowingFunctionalInterface(((JCMemberReference) t).type, s)),
+              not((t, s) -> isWhitelistedInterfaceType(ASTHelpers.getType(t), s)),
+              not((t, s) -> isThrowingFunctionalInterface(ASTHelpers.getType(t), s)),
               specializedMatcher())
           .matches(tree, state)) {
         return describeMatch(tree);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InvalidPatternSyntax.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InvalidPatternSyntax.java
@@ -30,9 +30,9 @@ import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
-import com.sun.tools.javac.tree.JCTree.JCExpression;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -51,8 +51,8 @@ public class InvalidPatternSyntax extends BugChecker implements MethodInvocation
       new Matcher<ExpressionTree>() {
         @Override
         public boolean matches(ExpressionTree tree, VisitorState state) {
-          Object value = ((JCExpression) tree).type.constValue();
-          return value instanceof String && !isValidSyntax((String) value);
+          String value = ASTHelpers.constValue(tree, String.class);
+          return value != null && !isValidSyntax(value);
         }
 
         private boolean isValidSyntax(String regex) {
@@ -105,7 +105,7 @@ public class InvalidPatternSyntax extends BugChecker implements MethodInvocation
     // TODO: Suggest fixes for more situations.
     Description.Builder descriptionBuilder = buildDescription(methodInvocationTree);
     ExpressionTree arg = methodInvocationTree.getArguments().get(0);
-    String value = (String) ((JCExpression) arg).type.constValue();
+    String value = ASTHelpers.constValue(arg, String.class);
     String reasonInvalid = "";
 
     if (".".equals(value)) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StringBuilderInitWithChar.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StringBuilderInitWithChar.java
@@ -45,7 +45,7 @@ public class StringBuilderInitWithChar extends BugChecker implements NewClassTre
             state.getSymtab().stringBuilderType, ASTHelpers.getType(tree.getIdentifier()), state)
         && tree.getArguments().size() == 1) {
       ExpressionTree argument = tree.getArguments().get(0);
-      Type type = ((JCTree) argument).type;
+      Type type = ASTHelpers.getType(argument);
       if (type.getKind() == TypeKind.CHAR) {
         if (argument.getKind() == Kind.CHAR_LITERAL) {
           char ch = (Character) ((LiteralTree) argument).getValue();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThrowIfUncheckedKnownChecked.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThrowIfUncheckedKnownChecked.java
@@ -29,12 +29,12 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
-import com.sun.tools.javac.tree.JCTree;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.UnionType;
 
@@ -60,7 +60,7 @@ public class ThrowIfUncheckedKnownChecked extends BugChecker
       new Matcher<ExpressionTree>() {
         @Override
         public boolean matches(ExpressionTree tree, VisitorState state) {
-          Type type = ((JCTree) tree).type;
+          Type type = ASTHelpers.getType(tree);
           if (type.isUnion()) {
             for (TypeMirror alternative : ((UnionType) type).getAlternatives()) {
               if (!isKnownCheckedException(state, (Type) alternative)) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedAnonymousClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedAnonymousClass.java
@@ -29,7 +29,6 @@ import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
-import com.sun.tools.javac.tree.JCTree;
 
 /** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
@@ -68,7 +67,7 @@ public class UnusedAnonymousClass extends BugChecker implements NewClassTreeMatc
           break;
       }
     }
-    if (!sideEffectFreeConstructor(((JCTree) newClassTree.getIdentifier()).type.tsym, state)) {
+    if (!sideEffectFreeConstructor(ASTHelpers.getType(newClassTree.getIdentifier()).tsym, state)) {
       return Description.NO_MATCH;
     }
     return describeMatch(newClassTree);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedMethod.java
@@ -266,11 +266,13 @@ public final class UnusedMethod extends BugChecker implements CompilationUnitTre
   private static boolean exemptedByAnnotation(
       List<? extends AnnotationTree> annotations, VisitorState state) {
     for (AnnotationTree annotation : annotations) {
-      if (((JCAnnotation) annotation).type != null) {
-        TypeSymbol tsym = ((JCAnnotation) annotation).type.tsym;
-        if (EXEMPTING_METHOD_ANNOTATIONS.contains(tsym.getQualifiedName().toString())) {
-          return true;
-        }
+      Type annotationType = getType(annotation);
+      if (annotationType == null) {
+        continue;
+      }
+      TypeSymbol tsym = annotationType.tsym;
+      if (EXEMPTING_METHOD_ANNOTATIONS.contains(tsym.getQualifiedName().toString())) {
+        return true;
       }
     }
     return false;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
@@ -90,7 +90,6 @@ import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.tree.JCTree;
-import com.sun.tools.javac.tree.JCTree.JCAnnotation;
 import com.sun.tools.javac.tree.JCTree.JCAssign;
 import com.sun.tools.javac.tree.JCTree.JCAssignOp;
 import com.sun.tools.javac.util.Position;
@@ -519,11 +518,13 @@ public final class UnusedVariable extends BugChecker implements CompilationUnitT
   private static boolean exemptedByAnnotation(
       List<? extends AnnotationTree> annotations, VisitorState state) {
     for (AnnotationTree annotation : annotations) {
-      if (((JCAnnotation) annotation).type != null) {
-        TypeSymbol tsym = ((JCAnnotation) annotation).type.tsym;
-        if (EXEMPTING_VARIABLE_ANNOTATIONS.contains(tsym.getQualifiedName().toString())) {
-          return true;
-        }
+      Type annotationType = ASTHelpers.getType(annotation);
+      if (annotationType == null) {
+        continue;
+      }
+      TypeSymbol tsym = annotationType.tsym;
+      if (EXEMPTING_VARIABLE_ANNOTATIONS.contains(tsym.getQualifiedName().toString())) {
+        return true;
       }
     }
     return false;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/StrictFormatStringValidation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/StrictFormatStringValidation.java
@@ -37,7 +37,6 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
-import com.sun.tools.javac.tree.JCTree.JCExpression;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -128,7 +127,7 @@ public class StrictFormatStringValidation {
     Types types = state.getTypes();
     ImmutableList.Builder<Type> calleeFormatArgTypesBuilder = ImmutableList.builder();
     for (ExpressionTree formatArgExpression : args) {
-      calleeFormatArgTypesBuilder.add(types.erasure(((JCExpression) formatArgExpression).type));
+      calleeFormatArgTypesBuilder.add(types.erasure(ASTHelpers.getType(formatArgExpression)));
     }
     ImmutableList<Type> calleeFormatArgTypes = calleeFormatArgTypesBuilder.build();
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/UnnecessaryCheckNotNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/UnnecessaryCheckNotNull.java
@@ -46,7 +46,6 @@ import com.sun.source.util.TreePath;
 import com.sun.source.util.TreeScanner;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
-import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCIdent;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -161,7 +160,7 @@ public class UnnecessaryCheckNotNull extends BugChecker implements MethodInvocat
     if ((arg1 instanceof BinaryTree
             || arg1.getKind() == Kind.METHOD_INVOCATION
             || arg1.getKind() == Kind.LOGICAL_COMPLEMENT)
-        && state.getTypes().isSameType(((JCExpression) arg1).type, state.getSymtab().booleanType)) {
+        && state.getTypes().isSameType(ASTHelpers.getType(arg1), state.getSymtab().booleanType)) {
       return describeMatch(arg1, createCheckArgumentOrStateCall(methodInvocationTree, state, arg1));
     }
 

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -113,6 +113,7 @@ import com.google.errorprone.bugpatterns.Finally;
 import com.google.errorprone.bugpatterns.FloatCast;
 import com.google.errorprone.bugpatterns.FloatingPointAssertionWithinEpsilon;
 import com.google.errorprone.bugpatterns.FloatingPointLiteralPrecision;
+import com.google.errorprone.bugpatterns.ForEachIterable;
 import com.google.errorprone.bugpatterns.ForOverrideChecker;
 import com.google.errorprone.bugpatterns.FunctionalInterfaceClash;
 import com.google.errorprone.bugpatterns.FunctionalInterfaceMethodChanged;
@@ -832,6 +833,7 @@ public class BuiltInCheckerSuppliers {
           FieldCanBeLocal.class,
           FieldMissingNullable.class,
           FunctionalInterfaceClash.class,
+          ForEachIterable.class,
           FuzzyEqualsShouldNotBeUsedInEqualsMethod.class,
           HardCodedSdCardPath.class,
           ImmutableRefactoring.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ForEachIterableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ForEachIterableTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** {@link ForEachIterable}Test */
+@RunWith(JUnit4.class)
+public class ForEachIterableTest {
+
+  @Test
+  public void positive() {
+    BugCheckerRefactoringTestHelper.newInstance(new ForEachIterable(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "import java.util.Iterator;",
+            "abstract class Test<T> {",
+            "  abstract void doSomething(T element);",
+            "  void iteratorFor(Iterable<T> list) {",
+            "    for (Iterator<T> iterator = list.iterator(); iterator.hasNext(); ) {",
+            "      doSomething(iterator.next());",
+            "    }",
+            "  }",
+            "  void iteratorWhile(Iterable<T> list) {",
+            "    Iterator<T> iterator = list.iterator();",
+            "    while (iterator.hasNext()) {",
+            "      doSomething(iterator.next());",
+            "    }",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "import java.util.Iterator;",
+            "abstract class Test<T> {",
+            "  abstract void doSomething(T element);",
+            "  void iteratorFor(Iterable<T> list) {",
+            "    for (T element : list) {",
+            "      doSomething(element);",
+            "    }",
+            "  }",
+            "  void iteratorWhile(Iterable<T> list) {",
+            "    for (T element : list) {",
+            "      doSomething(element);",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void reuseVariable() {
+    BugCheckerRefactoringTestHelper.newInstance(new ForEachIterable(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "import java.util.Iterator;",
+            "abstract class Test<T> {",
+            "  abstract void doSomething(T element);",
+            "  void iteratorWhile(Iterable<T> list) {",
+            "    Iterator<T> iterator = list.iterator();",
+            "    while (iterator.hasNext()) {",
+            "      T t = iterator.next();",
+            "      doSomething(t);",
+            "    }",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "import java.util.Iterator;",
+            "abstract class Test<T> {",
+            "  abstract void doSomething(T element);",
+            "  void iteratorWhile(Iterable<T> list) {",
+            "    for (T t : list) {",
+            "      doSomething(t);",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void wildcard() {
+    BugCheckerRefactoringTestHelper.newInstance(new ForEachIterable(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "import java.util.Iterator;",
+            "abstract class Test {",
+            "  abstract void doSomething(Object element);",
+            "  void iteratorWhile(Iterable<?> list) {",
+            "    Iterator<?> iterator = list.iterator();",
+            "    while (iterator.hasNext()) {",
+            "      doSomething(iterator.next());",
+            "    }",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "import java.util.Iterator;",
+            "abstract class Test {",
+            "  abstract void doSomething(Object element);",
+            "  void iteratorWhile(Iterable<?> list) {",
+            "    for (Object element : list) {",
+            "      doSomething(element);",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void empty() {
+    BugCheckerRefactoringTestHelper.newInstance(new ForEachIterable(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "import java.util.Iterator;",
+            "abstract class Test {",
+            "  abstract void doSomething(Object element);",
+            "  void iteratorWhile(Iterable<?> list) {",
+            "    Iterator<?> iterator = list.iterator();",
+            "    while (iterator.hasNext()) {",
+            "      iterator.next();",
+            "    }",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "import java.util.Iterator;",
+            "abstract class Test {",
+            "  abstract void doSomething(Object element);",
+            "  void iteratorWhile(Iterable<?> list) {",
+            "    for (Object element : list) {",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void wildcardExtends() {
+    BugCheckerRefactoringTestHelper.newInstance(new ForEachIterable(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "import java.util.Iterator;",
+            "abstract class Test {",
+            "  abstract void doSomething(String element);",
+            "  void iteratorWhile(Iterable<? extends String> list) {",
+            "    Iterator<? extends String> iterator = list.iterator();",
+            "    while (iterator.hasNext()) {",
+            "      iterator.next();",
+            "    }",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "import java.util.Iterator;",
+            "abstract class Test {",
+            "  abstract void doSomething(String element);",
+            "  void iteratorWhile(Iterable<? extends String> list) {",
+            "    for (String element : list) {",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative() {
+    CompilationTestHelper.newInstance(ForEachIterable.class, getClass())
+        .addSourceLines(
+            "in/Test.java",
+            "import java.util.Iterator;",
+            "abstract class Test<T> {",
+            "  abstract void doSomething(T element);",
+            "  void forUpdate(Iterable<T> list) {",
+            "    for (Iterator<T> it = list.iterator(); it.hasNext(); it.next()) {",
+            "      doSomething(it.next());",
+            "    }",
+            "  }",
+            "  void forMultiVariable(Iterable<T> list) {",
+            "    for (Iterator<T> iterator = list.iterator(), y = null; iterator.hasNext(); ) {",
+            "      doSomething(iterator.next());",
+            "    }",
+            "  }",
+            "  void forTwoStep(Iterable<T> list) {",
+            "    for (Iterator<T> iterator = list.iterator(); iterator.hasNext(); ) {",
+            "      doSomething(iterator.next());",
+            "      doSomething(iterator.next());",
+            "    }",
+            "  }",
+            "  void whileTwoStep(Iterable<T> list) {",
+            "    Iterator<T> iterator = list.iterator();",
+            "    while (iterator.hasNext()) {",
+            "      doSomething(iterator.next());",
+            "      doSomething(iterator.next());",
+            "    }",
+            "  }",
+            "  void whileUseOutsideLoop(Iterable<T> list) {",
+            "    Iterator<T> iterator = list.iterator();",
+            "    while (iterator.hasNext()) {",
+            "      doSomething(iterator.next());",
+            "    }",
+            "    doSomething(iterator.next());",
+            "  }",
+            "  void forIteratorUse(Iterable<?> list) {",
+            "    Iterator<?> iterator = list.iterator();",
+            "    while (iterator.hasNext()) {",
+            "      iterator.next();",
+            "      iterator.remove();",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
+++ b/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
@@ -647,6 +647,69 @@ public class SuggestedFixesTest {
     qualifyDeeplyNestedType(new ReplaceReturnTypeString("pkg.Outer.Inner.Innermost"));
   }
 
+  @Test
+  public void qualifiedName() {
+    BugCheckerRefactoringTestHelper.newInstance(new ReplaceReturnTypeString("foo.A.B"), getClass())
+        .addInputLines(
+            "foo/A.java", //
+            "package foo;",
+            "public class A {",
+            "  public static class B {}",
+            "}")
+        .expectUnchanged()
+        .addInputLines(
+            "bar/A.java", //
+            "package bar;",
+            "public class A extends foo.A {}")
+        .expectUnchanged()
+        .addInputLines(
+            "bar/Test.java", //
+            "package bar;",
+            "public interface Test {",
+            "  A.B foo();",
+            "}")
+        .addOutputLines(
+            "bar/Test.java", //
+            "package bar;",
+            "import foo.A.B;",
+            "public interface Test {",
+            "  B foo();",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void qualifiedName2() {
+    BugCheckerRefactoringTestHelper.newInstance(new ReplaceReturnTypeString("foo.A.B"), getClass())
+        .addInputLines(
+            "foo/A.java", //
+            "package foo;",
+            "public class A {",
+            "  public static class B {}",
+            "}")
+        .expectUnchanged()
+        .addInputLines(
+            "bar/A.java", //
+            "package bar;",
+            "public class A extends foo.A {}")
+        .expectUnchanged()
+        .addInputLines("bar/B.java", "package bar;", "public class B {}")
+        .expectUnchanged()
+        .addInputLines(
+            "bar/Test.java", //
+            "package bar;",
+            "public interface Test {",
+            "  A.B foo();",
+            "}")
+        .addOutputLines(
+            "bar/Test.java", //
+            "package bar;",
+            "public interface Test {",
+            "  foo.A.B foo();",
+            "}")
+        .doTest();
+  }
+
   private void qualifyDeeplyNestedType(BugChecker bugChecker) {
     BugCheckerRefactoringTestHelper.newInstance(bugChecker, getClass())
         .addInputLines(

--- a/docs/bugpattern/MissingDefault.md
+++ b/docs/bugpattern/MissingDefault.md
@@ -13,6 +13,8 @@ If the unhandled cases should be impossible, add a `default` clause that throws
 `AssertionError`:
 
 ```java
+enum State { READY, DONE, RUNNING, BLOCKED }
+
 switch (state) {
   case READY:
     return true;
@@ -27,13 +29,14 @@ If having execution fall out of the switch is intentional, add a `default`
 clause with a comment:
 
 ```java
+enum State { READY, DONE, RUNNING, BLOCKED }
+
 switch (state) {
   case READY:
     return true;
   case DONE:
     return false;
-  default:
-    // fall out
+  default: // continue below to handle RUNNING/BLOCKED/etc.
 }
 ```
 

--- a/docs/bugpattern/UnnecessaryDefaultInEnumSwitch.md
+++ b/docs/bugpattern/UnnecessaryDefaultInEnumSwitch.md
@@ -65,11 +65,13 @@ default from an exhaustive enum switch.
 Before:
 
 ```java
-boolean isReady(State state) {
+enum State { ON, OFF }
+
+boolean isOn(State state) {
   switch (state) {
-    case READY:
+    case ON:
       return true;
-    case DONE:
+    case OFF:
       return false;
     default:
       throw new AssertionError("unknown state: " + state);
@@ -80,11 +82,13 @@ boolean isReady(State state) {
 After:
 
 ```java
-boolean isReady(State state) {
+enum State { ON, OFF }
+
+boolean isOn(State state) {
   switch (state) {
-    case READY:
+    case ON:
       return true;
-    case DONE:
+    case OFF:
       return false;
   }
   throw new AssertionError("unknown state: " + state);
@@ -96,11 +100,13 @@ boolean isReady(State state) {
 Before:
 
 ```java
-boolean isReady(State state) {
+enum State { ON, OFF }
+
+boolean isOn(State state) {
   switch (state) {
-    case READY:
+    case ON:
       return true;
-    case DONE:
+    case OFF:
       break;
     default:
       break;
@@ -112,11 +118,13 @@ boolean isReady(State state) {
 After:
 
 ```java
-boolean isReady(State state) {
+enum State { ON, OFF }
+
+boolean isOn(State state) {
   switch (state) {
-    case READY:
+    case ON:
       return true;
-    case DONE:
+    case OFF:
       break;
   }
   return false;


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Try to make exhaustiveness clearer in enum switch examples

6039d5dca30595d3470315703b4e8d5f4d0fcaa6

-------

<p> Move Iterator-to-enhanced-for-loop refactoring to Error Prone

c722b403891207c9d7cd129b707750c58c02c75c

-------

<p> Make getCustomSuppressionAnnotations unmodifiable

1c2eb6d794bfb617c5e9a1b69b6dbf0d255b8258

-------

<p> Fix a bug in qualifyType.

2306017879670d1eebd380a20e498f6ac51a102e

-------

<p> Use ASTHelpers.getType(e) instead of ((JCTree) e).type

abaa78880cc83b844a643dc0e8921946936d3959