### PR TITLE
Make summary of InjectOnConstructorOfAbstractClass consistent

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectOnConstructorOfAbstractClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectOnConstructorOfAbstractClass.java
@@ -46,7 +46,7 @@ import com.sun.source.tree.MethodTree;
 @BugPattern(
     name = "InjectOnConstructorOfAbstractClass",
     summary =
-        "Constructors on abstract classes are never directly @Injected, only the constructors"
+        "Constructors on abstract classes are never directly @Inject'ed, only the constructors"
             + " of their subclasses can be @Inject'ed.",
     severity = WARNING,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)


### PR DESCRIPTION
The first sentence says @Injected and the second one says @Inject'ed.

Change the first one to @Inject'ed so it's consistent.
