### PR TITLE
MOE Sync 2020-02-03

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -1283,15 +1283,17 @@ public class ASTHelpers {
     }
   }
 
-  /** Returns the value of the {@code @Generated} annotation on the top-level class, if present. */
+  /**
+   * Returns the value of the {@code @Generated} annotation on encosing classes, if present.
+   *
+   * <p>Although {@code @Generated} can be applied to non-class progam elements, there are no known
+   * cases of that happening, so it isn't supported here.
+   */
   public static ImmutableSet<String> getGeneratedBy(VisitorState state) {
-    ClassTree outerClass = null;
-    for (Tree enclosing : state.getPath()) {
-      if (enclosing instanceof ClassTree) {
-        outerClass = (ClassTree) enclosing;
-      }
-    }
-    return outerClass == null ? ImmutableSet.of() : getGeneratedBy(getSymbol(outerClass), state);
+    return Streams.stream(state.getPath())
+        .filter(ClassTree.class::isInstance)
+        .flatMap(enclosing -> getGeneratedBy(getSymbol(enclosing), state).stream())
+        .collect(toImmutableSet());
   }
 
 

--- a/check_api/src/main/java/com/google/errorprone/util/Visibility.java
+++ b/check_api/src/main/java/com/google/errorprone/util/Visibility.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.util;
+
+import static com.google.errorprone.util.ASTHelpers.enclosingClass;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.google.errorprone.util.ASTHelpers.getType;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.errorprone.VisitorState;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MemberReferenceTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.code.Symbol.PackageSymbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
+import java.util.Set;
+import javax.lang.model.element.Modifier;
+
+/**
+ * Describes visibilities available via VisibleForTesting annotations, and provides methods to
+ * establish whether a given {@link Tree} should be visible.
+ */
+public enum Visibility implements Comparable<Visibility> {
+  // In order of ascending visibility.
+  NONE {
+    @Override
+    public boolean shouldBeVisible(Tree tree, VisitorState state) {
+      return false;
+    }
+
+    @Override
+    public boolean shouldBeVisible(Symbol symbol, VisitorState state) {
+      return false;
+    }
+
+    @Override
+    public String description() {
+      return "not be used";
+    }
+  },
+  PRIVATE {
+    @Override
+    public boolean shouldBeVisible(Tree tree, VisitorState state) {
+      return shouldBeVisible(getSymbol(tree), state);
+    }
+
+    @Override
+    public boolean shouldBeVisible(Symbol symbol, VisitorState state) {
+      Symbol outermostClass = null;
+      for (Tree parent : state.getPath()) {
+        if (parent instanceof ClassTree) {
+          outermostClass = getSymbol(parent);
+        }
+      }
+      return outermostClass == null || ASTHelpers.outermostClass(symbol).equals(outermostClass);
+    }
+
+    @Override
+    public String description() {
+      return "private visibility";
+    }
+  },
+  PACKAGE_PRIVATE {
+    @Override
+    public boolean shouldBeVisible(Tree tree, VisitorState state) {
+      return PACKAGE_PRIVATE.shouldBeVisible(getSymbol(tree), state);
+    }
+
+    @Override
+    public boolean shouldBeVisible(Symbol symbol, VisitorState state) {
+      JCCompilationUnit compilationUnit = (JCCompilationUnit) state.getPath().getCompilationUnit();
+      PackageSymbol packge = compilationUnit.packge;
+      // TODO(ghm): Should we handle the default (unnamed) package here?
+      return symbol.packge().equals(packge);
+    }
+
+    @Override
+    public String description() {
+      return "default (package private) visibility";
+    }
+  },
+  PROTECTED {
+    // Rules https://docs.oracle.com/javase/specs/jls/se7/html/jls-6.html#jls-6.6.2
+    @Override
+    public boolean shouldBeVisible(Tree tree, VisitorState state) {
+      if (PACKAGE_PRIVATE.shouldBeVisible(tree, state)) {
+        return true;
+      }
+      Symbol symbol = getSymbol(tree);
+      ClassTree classTree = ASTHelpers.findEnclosingNode(state.getPath(), ClassTree.class);
+      if (symbol.isStatic()) {
+        if (classTree == null) {
+          return false;
+        }
+        return hasEnclosingClassExtending(enclosingClass(symbol).type, state, classTree);
+      }
+      // Anonymous subclasses will match on the synthetic constructor.
+      if (tree instanceof NewClassTree) {
+        return false;
+      }
+      if (!(tree instanceof ExpressionTree)) {
+        return hasEnclosingClassExtending(enclosingClass(symbol).type, state, classTree);
+      }
+      if (tree instanceof MemberSelectTree
+          && ((MemberSelectTree) tree).getIdentifier().contentEquals("super")) {
+        // Allow qualified super calls.
+        return true;
+      }
+      if (tree instanceof MemberSelectTree || tree instanceof MemberReferenceTree) {
+        ExpressionTree receiver = ASTHelpers.getReceiver((ExpressionTree) tree);
+        return receiver.toString().equals("super")
+            || hasEnclosingClassOfSuperType(getType(receiver), state, classTree);
+      }
+      // If there's no receiver, we must be accessing it via an implicit "this", or we're
+      // using unqualified "super".
+      return true;
+    }
+
+    @Override
+    public boolean shouldBeVisible(Symbol symbol, VisitorState state) {
+      if (PACKAGE_PRIVATE.shouldBeVisible(symbol, state)) {
+        return true;
+      }
+      ClassTree classTree = ASTHelpers.findEnclosingNode(state.getPath(), ClassTree.class);
+      return classTree != null
+          && hasEnclosingClassExtending(enclosingClass(symbol).type, state, classTree);
+    }
+
+    private boolean hasEnclosingClassOfSuperType(
+        Type type, VisitorState state, ClassTree classTree) {
+      for (ClassSymbol encl = getSymbol(classTree); encl != null; encl = enclosingClass(encl)) {
+        if (encl.isStatic()) {
+          break;
+        }
+        if (ASTHelpers.isSubtype(type, encl.type, state)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private boolean hasEnclosingClassExtending(Type type, VisitorState state, ClassTree classTree) {
+      for (ClassSymbol encl = getSymbol(classTree); encl != null; encl = enclosingClass(encl)) {
+        if (encl.isStatic()) {
+          break;
+        }
+        if (ASTHelpers.isSubtype(encl.type, type, state)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    @Override
+    public String description() {
+      return "protected visibility";
+    }
+  },
+  PUBLIC {
+    @Override
+    public boolean shouldBeVisible(Tree tree, VisitorState state) {
+      return true;
+    }
+
+    @Override
+    public boolean shouldBeVisible(Symbol symbol, VisitorState state) {
+      return true;
+    }
+
+    @Override
+    public String description() {
+      return "public visibility";
+    }
+  };
+
+  /**
+   * Whether {@code tree} should be visible from the path in {@code state} assuming we're in prod
+   * code.
+   */
+  public abstract boolean shouldBeVisible(Tree tree, VisitorState state);
+
+  /**
+   * Whether {@code symbol} should be visible from the path in {@code state} assuming we're in prod
+   * code.
+   */
+  public abstract boolean shouldBeVisible(Symbol symbol, VisitorState state);
+
+  public static Visibility fromModifiers(Set<Modifier> modifiers) {
+    if (modifiers.contains(Modifier.PRIVATE)) {
+      return Visibility.PRIVATE;
+    }
+    if (modifiers.contains(Modifier.PUBLIC)) {
+      return Visibility.PUBLIC;
+    }
+    if (modifiers.contains(Modifier.PROTECTED)) {
+      return Visibility.PROTECTED;
+    }
+    return Visibility.PACKAGE_PRIVATE;
+  }
+
+
+  public boolean isAtLeastAsRestrictiveAs(Visibility visibility) {
+    return compareTo(visibility) <= 0;
+  }
+
+  public boolean isMoreVisibleThan(Visibility visibility) {
+    return compareTo(visibility) > 0;
+  }
+
+  /**
+   * A fragment describing this visibility, to fit in a phrase like "restricted to [...]".
+   *
+   * <p>This is complicated by {@code NONE}, which doesn't describe a Java visibility.
+   */
+  public abstract String description();
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DefaultCharset.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DefaultCharset.java
@@ -83,13 +83,13 @@ public class DefaultCharset extends BugChecker
     implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
 
   enum CharsetFix {
-    UTF_8_FIX("UTF_8") {
+    UTF_8_FIX("UTF_8", "Specify UTF-8") {
       @Override
       void addImport(SuggestedFix.Builder fix, VisitorState state) {
         fix.addStaticImport("java.nio.charset.StandardCharsets.UTF_8");
       }
     },
-    DEFAULT_CHARSET_FIX("Charset.defaultCharset()") {
+    DEFAULT_CHARSET_FIX("Charset.defaultCharset()", "Specify default charset") {
       @Override
       void addImport(SuggestedFix.Builder fix, VisitorState state) {
         fix.addImport("java.nio.charset.Charset");
@@ -97,9 +97,11 @@ public class DefaultCharset extends BugChecker
     };
 
     final String replacement;
+    final String title;
 
-    CharsetFix(String replacement) {
+    CharsetFix(String replacement, String title) {
       this.replacement = replacement;
+      this.title = title;
     }
 
     String replacement() {
@@ -522,6 +524,7 @@ public class DefaultCharset extends BugChecker
       fix.postfixWith(Iterables.getLast(arguments), ", " + charset.replacement());
     }
     charset.addImport(fix, state);
+    fix.setShortDescription(charset.title);
     return fix.build();
   }
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DescribeMatch.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DescribeMatch.java
@@ -17,9 +17,11 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.Streams.stream;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
 
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.ProvidesFix;
@@ -29,6 +31,7 @@ import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 
@@ -58,6 +61,9 @@ public class DescribeMatch extends BugChecker implements MethodInvocationTreeMat
     if (!BUILD.matches(build, state)) {
       return NO_MATCH;
     }
+    if (withinBugChecker(state)) {
+      return NO_MATCH;
+    }
     ExpressionTree addFix = ASTHelpers.getReceiver(build);
     if (!ADD_FIX.matches(addFix, state)) {
       return NO_MATCH;
@@ -73,6 +79,16 @@ public class DescribeMatch extends BugChecker implements MethodInvocationTreeMat
             String.format(
                 "describeMatch(%s, %s)",
                 getArgument(state, buildDescription), getArgument(state, addFix))));
+  }
+
+  private static boolean withinBugChecker(VisitorState state) {
+    return stream(state.getPath())
+        .anyMatch(
+            t ->
+                t instanceof ClassTree
+                    && getSymbol(t)
+                        .getQualifiedName()
+                        .contentEquals(BugChecker.class.getCanonicalName()));
   }
 
   private static String getArgument(VisitorState state, ExpressionTree tree) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/DescribeMatchTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/DescribeMatchTest.java
@@ -54,4 +54,25 @@ public class DescribeMatchTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void noMatchInBugChecker() {
+    testHelper
+        .addInputLines(
+            "BugChecker.java",
+            "package com.google.errorprone.bugpatterns;",
+            "import com.google.errorprone.fixes.Fix;",
+            "import com.sun.source.tree.Tree;",
+            "import com.google.errorprone.matchers.Description;",
+            "abstract class BugChecker {",
+            "  Description.Builder buildDescription(Tree tree) {",
+            "    return null;",
+            "  }",
+            "  Description fix(Tree tree, Fix fix) {",
+            "    return buildDescription(tree).addFix(fix).build();",
+            "  }",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NonCanonicalTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NonCanonicalTypeTest.java
@@ -69,6 +69,29 @@ public final class NonCanonicalTypeTest {
   }
 
   @Test
+  public void notVisibleFromUsageSite() {
+    compilationHelper
+        .addSourceLines(
+            "foo/A.java", //
+            "package foo;",
+            "class A {",
+            "  public static class C {}",
+            "}")
+        .addSourceLines(
+            "foo/B.java", //
+            "package foo;",
+            "public class B extends A {}")
+        .addSourceLines(
+            "D.java", //
+            "package bar;",
+            "import foo.B;",
+            "public interface D {",
+            "  B.C test();",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void positiveWithGenerics() {
     compilationHelper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringAnnotationCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringAnnotationCheckerTest.java
@@ -287,7 +287,7 @@ public class FormatStringAnnotationCheckerTest {
             "test/FormatStringTestCase.java",
             "package test;",
             "import static org.mockito.ArgumentMatchers.any;",
-            "import static org.mockito.Matchers.eq;",
+            "import static org.mockito.ArgumentMatchers.eq;",
             "import static org.mockito.Mockito.verify;",
             "import com.google.errorprone.annotations.FormatMethod;",
             "import com.google.errorprone.annotations.FormatString;",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringAnnotationCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringAnnotationCheckerTest.java
@@ -286,7 +286,7 @@ public class FormatStringAnnotationCheckerTest {
         .addSourceLines(
             "test/FormatStringTestCase.java",
             "package test;",
-            "import static org.mockito.Matchers.any;",
+            "import static org.mockito.ArgumentMatchers.any;",
             "import static org.mockito.Matchers.eq;",
             "import static org.mockito.Mockito.verify;",
             "import com.google.errorprone.annotations.FormatMethod;",


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> In getGeneratedBy, check each enclosing class instead of the outermost one

this rarely matters in practice, but @Generated can be applied to any
enclosing class.

468b4c94d349bef161b302d570e5908d2e7fffef

-------

<p> Give better titles to the suggested fixes for DefaultCharset

6c011210b58555826194964001fb869ba28b50e7

-------

<p> Migrate org.mockito.Matchers#any to org.mockito.ArgumentMatchers

The former are deprecated and replaced by the latter in Mockito 2.

d2bd978ea0441af4d1567693f396bc1492ecf4cc

-------

<p> DescribeMatch: don't match inside BugChecker.

e03ff5db015f8be14ef9dbc0b6c20b7a2482d15b

-------

<p> Migrate static imports of org.mockito.Matchers to org.mockito.ArgumentMatchers

The former is deprecated and replaced by the latter in Mockito 2.

4126c88bcd8ad6bd8569746cdb3243eaf9f8f716

-------

<p> Move Visibility into util package.

This seems sufficiently useful (and sufficiently useful for external users) that it might be nice to include.

3c40da798fc176197ae48e3f73e0708004586c1a

-------

<p> NonCanonicalType: don't report a finding if the canonical name is not visible.

3aa8681f592442fe71bcf1ff7aa126c18a1d4a25