### PR TITLE
MOE Sync 2020-02-10

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
@@ -112,6 +112,7 @@ public final class PreferJavaTimeOverload extends BugChecker
 
   private static final Matcher<ExpressionTree> IGNORED_APIS =
       anyOf(
+          staticMethod().onClass("org.jooq.impl.DSL").named("inline"),
           // any static method under org.assertj.*
           staticMethod()
               .onClass((type, state) -> type.toString().startsWith("org.assertj."))


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Ignore DSL.inline() in PreferJavaTimeOverload checker.

Fixes https://github.com/google/error-prone/issues/1504

2b1d640cf67155b975b3ce2bf2f8b202c03c8d68