### PR TITLE
MOE Sync 2020-02-19

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnored.java
@@ -36,6 +36,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.bugpatterns.BugChecker.ReturnTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LambdaExpressionTree;
@@ -339,7 +340,7 @@ public final class FutureReturnValueIgnored extends AbstractReturnValueIgnored
               (t, s) -> t.getMode() == ReferenceMode.INVOKE,
               FutureReturnValueIgnored::isObjectReturningMethodReferenceExpression,
               not((t, s) -> isWhitelistedInterfaceType(ASTHelpers.getType(t), s)),
-              not((t, s) -> isThrowingFunctionalInterface(ASTHelpers.getType(t), s)),
+              not((t, s) -> Matchers.isThrowingFunctionalInterface(ASTHelpers.getType(t), s)),
               specializedMatcher())
           .matches(tree, state)) {
         return describeMatch(tree);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InsecureCipherMode.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InsecureCipherMode.java
@@ -18,133 +18,73 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.method.MethodMatchers.constructor;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
-import com.sun.tools.javac.tree.JCTree;
+import com.sun.source.tree.NewClassTree;
 
 /** @author avenet@google.com (Arnaud J. Venet) */
 @BugPattern(
     name = "InsecureCryptoUsage",
     altNames = {"InsecureCipherMode"},
     summary =
-        "A standard cryptographic operation is used in a mode that is prone to vulnerabilities",
+        "Usage of the Java Cryptography API is insecure because it is prone to vulnerabilities.",
     documentSuppression = false,
     severity = ERROR)
-public class InsecureCipherMode extends BugChecker implements MethodInvocationTreeMatcher {
-  private static final String MESSAGE_BASE = "Insecure usage of a crypto API: ";
-
-  private static final Matcher<ExpressionTree> CIPHER_GETINSTANCE_MATCHER =
-      staticMethod().onClass("javax.crypto.Cipher").named("getInstance");
-
-  private static final Matcher<ExpressionTree> KEY_STRUCTURE_GETINSTANCE_MATCHER =
+public class InsecureCipherMode extends BugChecker
+    implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
+  private static final Matcher<ExpressionTree> BLOCKED_CRYPTO_EXPRESSIONS =
       anyOf(
+          staticMethod().onClass("javax.crypto.Cipher").named("getInstance"),
+          staticMethod().onClass("javax.crypto.KeyAgreement").named("getInstance"),
+          staticMethod().onClass("javax.crypto.Mac").named("getInstance"),
           staticMethod().onClass("java.security.KeyPairGenerator").named("getInstance"),
-          staticMethod().onClass("java.security.KeyFactory").named("getInstance"),
-          staticMethod().onClass("javax.crypto.KeyAgreement").named("getInstance"));
+          staticMethod().onClass("java.security.MessageDigest").named("getInstance"),
+          staticMethod().onClass("java.security.Signature").named("getInstance"));
+
+  private static final Matcher<NewClassTree> BLOCKED_CRYPTO_CLASSES =
+      anyOf(
+          constructor().forClass("javax.crypto.CipherInputStream"),
+          constructor().forClass("javax.crypto.CipherOutputStream"));
 
 
-  private Description buildErrorMessage(MethodInvocationTree tree, String explanation) {
-    Description.Builder description = buildDescription(tree);
-    String message = MESSAGE_BASE + explanation + ".";
-    description.setMessage(message);
-    return description.build();
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    Description description = checkMethodInvocation(tree, state);
+
+
+    return description;
   }
 
-  private Description identifyEcbVulnerability(MethodInvocationTree tree) {
-    // We analyze the first argument of all the overloads of Cipher.getInstance().
-    Object argument = ASTHelpers.constValue((JCTree) tree.getArguments().get(0));
-    if (argument == null) {
-      // We flag call sites where the transformation string is dynamically computed.
-      return buildErrorMessage(
-          tree, "the transformation is not a compile-time constant expression");
-    }
-    // Otherwise, we know that the transformation is specified by a string literal.
-    String transformation = (String) argument;
-
-    // We exclude stream ciphers (this check only makes sense for block ciphers), i.e., the RC4
-    // cipher. The name of this algorithm is "ARCFOUR" in the SunJce and "ARC4" in Conscrypt.
-    // Some other providers like JCraft also seem to use the name "RC4".
-    if (transformation.matches("ARCFOUR.*")
-        || transformation.matches("ARC4.*")
-        || transformation.matches("RC4.*")) {
-      return Description.NO_MATCH;
-    }
-
-    if (!transformation.matches(".*/.*/.*")) {
-      // The mode and padding shall be explicitly specified. We don't allow default settings to be
-      // used, regardless of the algorithm and provider.
-      return buildErrorMessage(tree, "the mode and padding must be explicitly specified");
-    }
-
-    if (transformation.matches(".*/ECB/.*")
-        && !transformation.matches("RSA/.*")
-        && !transformation.matches("AESWrap/.*")) {
-      // Otherwise, ECB mode should be explicitly specified in order to trigger the check. RSA
-      // is an exception, as this transformation doesn't actually implement a block cipher
-      // encryption mode (the input is limited by the size of the key). AESWrap is another
-      // exception, because this algorithm is only used to encrypt encryption keys.
-      return buildErrorMessage(tree, "ECB mode must not be used");
-    }
-
-    if (transformation.matches("ECIES.*") || transformation.matches("DHIES.*")) {
-      // Existing implementations of IES-based algorithms use ECB under the hood and must also be
-      // flagged as vulnerable. See b/30424901 for a more detailed rationale.
-      return buildErrorMessage(tree, "IES-based algorithms use ECB mode and are insecure");
-    }
-
-    return Description.NO_MATCH;
-  }
-
-  private Description identifyDiffieHellmanAndDsaVulnerabilities(MethodInvocationTree tree) {
-    // The first argument holds a string specifying the algorithm used for the operation
-    // considered.
-    Object argument = ASTHelpers.constValue((JCTree) tree.getArguments().get(0));
-    if (argument == null) {
-      // We flag call sites where the algorithm specification string is dynamically computed.
-      return buildErrorMessage(
-          tree, "the algorithm specification is not a compile-time constant expression");
-    }
-    // Otherwise, we know that the algorithm is specified by a string literal.
-    String algorithm = (String) argument;
-
-    if (algorithm.matches("DH")) {
-      // Most implementations of Diffie-Hellman on prime fields have vulnerabilities. See b/31574444
-      // for a more detailed rationale.
-      return buildErrorMessage(tree, "using Diffie-Hellman on prime fields is insecure");
-    }
-
-    if (algorithm.matches("DSA")) {
-      // Some crypto libraries may accept invalid DSA signatures in specific configurations (see
-      // b/30262692 for details).
-      return buildErrorMessage(tree, "using DSA is insecure");
+  Description checkMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (BLOCKED_CRYPTO_EXPRESSIONS.matches(tree, state)) {
+      String message = "Use of these APIs is considered insecure";
+      state.reportMatch(buildDescription(tree).setMessage(message).build());
     }
 
     return Description.NO_MATCH;
   }
 
   @Override
-  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-    Description description = checkInvocation(tree, state);
+  public Description matchNewClass(NewClassTree tree, VisitorState state) {
+    Description description = checkClassInvocation(tree, state);
 
 
     return description;
   }
 
-  Description checkInvocation(MethodInvocationTree tree, VisitorState state) {
-    if (CIPHER_GETINSTANCE_MATCHER.matches(tree, state)) {
-      return identifyEcbVulnerability(tree);
-    }
-
-    if (KEY_STRUCTURE_GETINSTANCE_MATCHER.matches(tree, state)) {
-      return identifyDiffieHellmanAndDsaVulnerabilities(tree);
+  Description checkClassInvocation(NewClassTree tree, VisitorState state) {
+    if (BLOCKED_CRYPTO_CLASSES.matches(tree, state)) {
+      String message = "Use of these APIs is considered insecure";
+      state.reportMatch(buildDescription(tree).setMessage(message).build());
     }
 
     return Description.NO_MATCH;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NullOptional.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NullOptional.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.fixes.SuggestedFixes.qualifyType;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.Matchers.methodCallInDeclarationOfThrowingRunnable;
+import static com.google.errorprone.predicates.TypePredicates.anyOf;
+import static com.google.errorprone.predicates.TypePredicates.isDescendantOf;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.google.errorprone.util.ASTHelpers.hasDirectAnnotationWithSimpleName;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.predicates.TypePredicate;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.Tree.Kind;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Type.ArrayType;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/** Flags passing literal null to {@code Optional}-accepting APIs. */
+@BugPattern(
+    name = "NullOptional",
+    summary =
+        "Passing a literal null to an Optional parameter is almost certainly a mistake. Did you"
+            + " mean to provide an empty Optional?",
+    severity = WARNING)
+public final class NullOptional extends BugChecker
+    implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
+  private static final TypePredicate GUAVA_OPTIONAL =
+      isDescendantOf("com.google.common.base.Optional");
+  private static final TypePredicate OPTIONAL =
+      anyOf(GUAVA_OPTIONAL, isDescendantOf("java.util.Optional"));
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    handleMethodInvocation(getSymbol(tree), tree.getArguments(), state);
+    return NO_MATCH;
+  }
+
+  @Override
+  public Description matchNewClass(NewClassTree tree, VisitorState state) {
+    handleMethodInvocation(getSymbol(tree), tree.getArguments(), state);
+    return NO_MATCH;
+  }
+
+  private void handleMethodInvocation(
+      @Nullable MethodSymbol symbol, List<? extends ExpressionTree> arguments, VisitorState state) {
+    if (symbol == null) {
+      return;
+    }
+    Iterator<VarSymbol> parameters = symbol.getParameters().iterator();
+    VarSymbol parameter = null;
+    Type parameterType = null;
+    for (ExpressionTree argument : arguments) {
+      parameter = parameters.hasNext() ? parameters.next() : parameter;
+      parameterType = parameter.type;
+      if (symbol.isVarArgs() && !parameters.hasNext()) {
+        parameterType = ((ArrayType) parameter.type).elemtype;
+      }
+      if (argument.getKind() == Kind.NULL_LITERAL
+          && OPTIONAL.apply(parameterType, state)
+          && !hasDirectAnnotationWithSimpleName(parameter, "Nullable")) {
+        if (methodCallInDeclarationOfThrowingRunnable(state)) {
+          return;
+        }
+        SuggestedFix.Builder fix = SuggestedFix.builder();
+        fix.replace(
+            argument,
+            String.format(
+                "%s.%s()",
+                qualifyType(state, fix, parameterType.tsym),
+                GUAVA_OPTIONAL.apply(parameterType, state) ? "absent" : "empty"));
+        state.reportMatch(describeMatch(argument, fix.build()));
+      }
+    }
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/StronglyTypeTime.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/StronglyTypeTime.java
@@ -72,7 +72,7 @@ public final class StronglyTypeTime extends BugChecker implements CompilationUni
           // Java time.
           staticMethod()
               .onClass("java.time.Duration")
-              .namedAnyOf("ofDays", "ofHours", "ofMillis", "ofMinutes", "ofNanos", "ofSeconds")
+              .namedAnyOf("ofNanos", "ofMillis", "ofSeconds", "ofMinutes", "ofHours", "ofDays")
               .withParameters("long"),
           staticMethod()
               .onClass("java.time.Instant")

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/StronglyTypeTime.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/StronglyTypeTime.java
@@ -187,7 +187,7 @@ public final class StronglyTypeTime extends BugChecker implements CompilationUni
 
   private static final Pattern TIME_UNIT_REMOVER =
       Pattern.compile(
-          "((_?IN)?_?(MILLI|NANO|HOUR|DAY|MINUTE|MIN|SECOND|MSEC|NSEC|SEC|_MS|_NS)S?)?$",
+          "((_?IN)?_?(NANO|NANOSECOND|NSEC|_NS|MICRO|MSEC|MICROSECOND|MILLI|MILLISECOND|_MS|SEC|SECOND|MINUTE|MIN|HOUR|DAY)S?)?$",
           Pattern.CASE_INSENSITIVE);
 
   /** Tries to strip any time-related suffix off the field name. */

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/StronglyTypeTime.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/StronglyTypeTime.java
@@ -224,7 +224,9 @@ public final class StronglyTypeTime extends BugChecker implements CompilationUni
             && isConsideredFinal(symbol)
             && variableTree.getInitializer() != null
             && (isSameType(type, state.getSymtab().intType, state)
-                || isSameType(type, state.getSymtab().longType, state))
+                || isSameType(type, state.getSymtab().longType, state)
+                || isSameType(type, state.getSymtab().floatType, state)
+                || isSameType(type, state.getSymtab().doubleType, state))
             && !isSuppressed(variableTree)) {
           fields.put(symbol, getCurrentPath());
         }

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -209,6 +209,7 @@ import com.google.errorprone.bugpatterns.NonCanonicalType;
 import com.google.errorprone.bugpatterns.NonFinalCompileTimeConstant;
 import com.google.errorprone.bugpatterns.NonOverridingEquals;
 import com.google.errorprone.bugpatterns.NonRuntimeAnnotation;
+import com.google.errorprone.bugpatterns.NullOptional;
 import com.google.errorprone.bugpatterns.NullTernary;
 import com.google.errorprone.bugpatterns.NullableConstructor;
 import com.google.errorprone.bugpatterns.NullablePrimitive;
@@ -739,6 +740,7 @@ public class BuiltInCheckerSuppliers {
           NullableConstructor.class,
           NullablePrimitive.class,
           NullableVoid.class,
+          NullOptional.class,
           ObjectsHashCodePrimitive.class,
           ObjectToString.class,
           OperatorPrecedence.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/JUnit4TestNotRunTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/JUnit4TestNotRunTest.java
@@ -16,9 +16,11 @@
 
 package com.google.errorprone.bugpatterns;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.FixChoosers;
 import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.ErrorProneFlags;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -31,7 +33,8 @@ public class JUnit4TestNotRunTest {
       CompilationTestHelper.newInstance(JUnit4TestNotRun.class, getClass());
 
   private final BugCheckerRefactoringTestHelper refactoringHelper =
-      BugCheckerRefactoringTestHelper.newInstance(new JUnit4TestNotRun(), getClass());
+      BugCheckerRefactoringTestHelper.newInstance(
+          new JUnit4TestNotRun(ErrorProneFlags.empty()), getClass());
 
   @Test
   public void testPositiveCase1() {
@@ -314,6 +317,7 @@ public class JUnit4TestNotRunTest {
             "public abstract class Test {",
             "  public void testDoSomething() {}",
             "}")
+        .setArgs(ImmutableList.of("-XepOpt:JUnit4TestNotRun:DoNotRequireRunWith=false"))
         .doTest();
   }
 
@@ -484,12 +488,18 @@ public class JUnit4TestNotRunTest {
 
   @Test
   public void testNegativeCase1() {
-    compilationHelper.addSourceFile("JUnit4TestNotRunNegativeCase1.java").doTest();
+    compilationHelper
+        .addSourceFile("JUnit4TestNotRunNegativeCase1.java")
+        .setArgs(ImmutableList.of("-XepOpt:JUnit4TestNotRun:DoNotRequireRunWith=false"))
+        .doTest();
   }
 
   @Test
   public void testNegativeCase2() {
-    compilationHelper.addSourceFile("JUnit4TestNotRunNegativeCase2.java").doTest();
+    compilationHelper
+        .addSourceFile("JUnit4TestNotRunNegativeCase2.java")
+        .setArgs(ImmutableList.of("-XepOpt:JUnit4TestNotRun:DoNotRequireRunWith=false"))
+        .doTest();
   }
 
   @Test
@@ -499,7 +509,10 @@ public class JUnit4TestNotRunTest {
 
   @Test
   public void testNegativeCase4() {
-    compilationHelper.addSourceFile("JUnit4TestNotRunNegativeCase4.java").doTest();
+    compilationHelper
+        .addSourceFile("JUnit4TestNotRunNegativeCase4.java")
+        .setArgs(ImmutableList.of("-XepOpt:JUnit4TestNotRun:DoNotRequireRunWith=false"))
+        .doTest();
   }
 
   @Test

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NullOptionalTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NullOptionalTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link NullOptional}. */
+@RunWith(JUnit4.class)
+public final class NullOptionalTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(NullOptional.class, getClass());
+
+  private final BugCheckerRefactoringTestHelper refactoringHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new NullOptional(), getClass());
+
+  @Test
+  public void simplePositiveCase() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "class Test {",
+            "  void a(Optional<Object> o) {}",
+            "  void test() {",
+            "    a(null);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "class Test {",
+            "  void a(Optional<Object> o) {}",
+            "  void test() {",
+            "    a(Optional.empty());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void annotatedWithNullable_noMatch() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "import javax.annotation.Nullable;",
+            "class Test {",
+            "  void a(@Nullable Optional<Object> o) {}",
+            "  void test() {",
+            "    a(null);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void notPassingNull_noMatch() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "class Test {",
+            "  void a(Optional<Object> o) {}",
+            "  void test() {",
+            "    a(Optional.empty());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void withinAssertThrows_noMatch() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import static org.junit.Assert.assertThrows;",
+            "import java.util.Optional;",
+            "class Test {",
+            "  void a(Optional<Object> o) {}",
+            "  void test() {",
+            "    assertThrows(NullPointerException.class, () -> a(null));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void lastVarArgsParameter_match() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "class Test {",
+            "  @SafeVarargs",
+            "  private final void a(int a, Optional<Object>... o) {}",
+            "  void test() {",
+            "    // BUG: Diagnostic contains:",
+            "    a(1, Optional.empty(), null);",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/InsecureCipherModeNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/InsecureCipherModeNegativeCases.java
@@ -16,139 +16,19 @@
 
 package com.google.errorprone.bugpatterns.testdata;
 
-
-import java.security.KeyFactory;
-import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-
 import javax.crypto.Cipher;
-import javax.crypto.KeyAgreement;
-import javax.crypto.NoSuchPaddingException;
 
 /**
  * @author avenet@google.com (Arnaud J. Venet)
  */
 public class InsecureCipherModeNegativeCases {
-  static Cipher aesCipher;
   static {
     // We don't handle any exception as this code is not meant to be executed.
     try {
-      aesCipher = Cipher.getInstance("AES/CBC/NoPadding");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static final String AES_STRING = "AES/CBC/NoPadding";
-  static Cipher aesCipherWithConstantString;
-  static {
-    try {
-      aesCipherWithConstantString = Cipher.getInstance(AES_STRING);
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher aesCipherWithProvider;
-  static {
-    try {
-      aesCipherWithProvider = Cipher.getInstance("AES/CBC/NoPadding", "My Provider");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchProviderException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher arc4CipherConscrypt;
-  static {
-    try {
-      arc4CipherConscrypt = Cipher.getInstance("ARC4", "Conscrypt");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchProviderException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher rc4CipherJsch;
-  static {
-    try {
-      rc4CipherJsch = Cipher.getInstance("RC4", "JSch");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchProviderException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher arcfourCipherSunJce;
-  static {
-    try {
-      arcfourCipherSunJce = Cipher.getInstance("ARCFOUR/ECB/NoPadding");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher desCipher;
-  static {
-    try {
-      desCipher = Cipher.getInstance("DES/CBC/NoPadding");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher rsaCipher;
-  static {
-    try {
-      rsaCipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher aesWrapCipher;
-  static {
-    try {
-      aesWrapCipher = Cipher.getInstance("AESWrap/ECB/NoPadding");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  public void ellipticCurveDiffieHellman() {
-    KeyFactory keyFactory;
-    KeyAgreement keyAgreement;
-    KeyPairGenerator keyPairGenerator;
-    final String ecdh = "ECDH";
-    try {
-      keyFactory = KeyFactory.getInstance(ecdh);
-      keyAgreement = KeyAgreement.getInstance("ECDH");
-      keyPairGenerator = KeyPairGenerator.getInstance("EC" + "DH");
+      int keyLength = Cipher.getMaxAllowedKeyLength("AES");
     } catch (NoSuchAlgorithmException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
-
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/InsecureCipherModePositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/InsecureCipherModePositiveCases.java
@@ -16,12 +16,20 @@
 
 package com.google.errorprone.bugpatterns.testdata;
 
-import java.security.KeyFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.security.Signature;
 import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.CipherOutputStream;
 import javax.crypto.KeyAgreement;
+import javax.crypto.Mac;
 import javax.crypto.NoSuchPaddingException;
 
 /** @author avenet@google.com (Arnaud J. Venet) */
@@ -30,24 +38,9 @@ public class InsecureCipherModePositiveCases {
 
   static {
     try {
-      // BUG: Diagnostic contains: the mode and padding must be explicitly specified
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
       defaultAesCipher = Cipher.getInstance("AES");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher defaultRsaCipher;
-
-  static {
-    try {
-      // BUG: Diagnostic contains: the mode and padding must be explicitly specified
-      defaultRsaCipher = Cipher.getInstance("RSA");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
@@ -57,37 +50,9 @@ public class InsecureCipherModePositiveCases {
 
   static {
     try {
-      // BUG: Diagnostic contains: the mode and padding must be explicitly specified
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
       defaultAesCipherWithConstantString = Cipher.getInstance(AES_STRING);
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher explicitAesCipher;
-
-  static {
-    try {
-      // BUG: Diagnostic contains: ECB mode must not be used
-      explicitAesCipher = Cipher.getInstance("AES/ECB/NoPadding");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher explicitDesCipher;
-
-  static {
-    try {
-      // BUG: Diagnostic contains: ECB mode must not be used
-      explicitDesCipher = Cipher.getInstance("DES/ECB/NoPadding");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
@@ -96,38 +61,9 @@ public class InsecureCipherModePositiveCases {
 
   static {
     try {
-      // BUG: Diagnostic contains: ECB mode must not be used
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
       explicitDesCipherWithProvider = Cipher.getInstance("DES/ECB/NoPadding", "My Provider");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchProviderException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static String transformation;
-
-  static {
-    try {
-      transformation = "DES/CBC/NoPadding";
-      // BUG: Diagnostic contains: the transformation is not a compile-time constant
-      Cipher cipher = Cipher.getInstance(transformation);
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static void transformationAsParameter(String transformation) {
-    try {
-      // BUG: Diagnostic contains: the transformation is not a compile-time constant
-      Cipher cipher = Cipher.getInstance(transformation);
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException | NoSuchProviderException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
@@ -138,7 +74,7 @@ public class InsecureCipherModePositiveCases {
     // Make sure that the checker is enabled inside constructors.
     public CipherWrapper() {
       try {
-        // BUG: Diagnostic contains: the mode and padding must be explicitly specified
+        // BUG: Diagnostic contains: Use of these APIs is considered insecure
         cipher = Cipher.getInstance("AES");
       } catch (NoSuchAlgorithmException e) {
         // We don't handle any exception as this code is not meant to be executed.
@@ -148,90 +84,91 @@ public class InsecureCipherModePositiveCases {
     }
   }
 
-  static Cipher complexCipher1;
+  static Mac mac;
 
   static {
     try {
-      String algorithm = "AES";
-      // BUG: Diagnostic contains: the transformation is not a compile-time constant
-      complexCipher1 = Cipher.getInstance(algorithm);
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      mac = Mac.getInstance("HmacSHA1");
+
     } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
 
-  static Cipher complexCipher2;
+  static MessageDigest messageDigest;
 
   static {
     try {
-      String transformation = "AES";
-      transformation += "/ECB";
-      transformation += "/NoPadding";
-      // BUG: Diagnostic contains: the transformation is not a compile-time constant
-      complexCipher2 = Cipher.getInstance(transformation);
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      messageDigest = MessageDigest.getInstance("SHA");
+
     } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
 
-  static Cipher IesCipher;
+  static Signature sig;
 
   static {
     try {
-      // BUG: Diagnostic contains: the mode and padding must be explicitly specified
-      IesCipher = Cipher.getInstance("ECIES");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("ECIES/DHAES/NoPadding");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("ECIESWITHAES/NONE/PKCS5Padding");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("DHIESWITHAES/DHAES/PKCS7Padding");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("ECIESWITHDESEDE/NONE/NOPADDING");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("DHIESWITHDESEDE/DHAES/PKCS5PADDING");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("ECIESWITHAES/CBC/PKCS7PADDING");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("ECIESWITHAES-CBC/NONE/PKCS5PADDING");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("ECIESwithDESEDE-CBC/DHAES/NOPADDING");
-
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      sig = Signature.getInstance("SHA1withRSA");
     } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
 
-  interface StringProvider {
-    String get();
-  }
+  static KeyAgreement keyAgreement;
 
-  public void keyOperations(StringProvider provider) {
-    KeyFactory keyFactory;
-    KeyAgreement keyAgreement;
-    KeyPairGenerator keyPairGenerator;
-    final String dh = "DH";
+  static {
     try {
-      // BUG: Diagnostic contains: compile-time constant
-      keyFactory = KeyFactory.getInstance(provider.get());
-      // BUG: Diagnostic contains: Diffie-Hellman on prime fields
-      keyFactory = KeyFactory.getInstance(dh);
-      // BUG: Diagnostic contains: DSA
-      keyAgreement = KeyAgreement.getInstance("DSA");
-      // BUG: Diagnostic contains: compile-time constant
-      keyAgreement = KeyAgreement.getInstance(provider.get());
-      // BUG: Diagnostic contains: Diffie-Hellman on prime fields
-      keyPairGenerator = KeyPairGenerator.getInstance(dh);
-      // BUG: Diagnostic contains: compile-time constant
-      keyPairGenerator = KeyPairGenerator.getInstance(provider.get());
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      keyAgreement = KeyAgreement.getInstance("ECDH");
     } catch (NoSuchAlgorithmException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
+
+  static KeyPairGenerator keyPairGenerator;
+
+  static {
+    try {
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      keyPairGenerator = KeyPairGenerator.getInstance("EC" + "DH");
+    } catch (NoSuchAlgorithmException e) {
+      // We don't handle any exception as this code is not meant to be executed.
+    }
+  }
+
+  static CipherInputStream inputStream;
+
+  static {
+    try {
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      Cipher cipher = Cipher.getInstance("AES");
+      File file = new File("ok");
+      FileInputStream in = new FileInputStream(file);
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      inputStream = new CipherInputStream(in, cipher);
+    } catch (FileNotFoundException | NoSuchAlgorithmException | NoSuchPaddingException e) {
+      // We don't handle any exception as this code is not meant to be executed.
+    }
+  }
+
+  static CipherOutputStream outputStream;
+
+  static {
+    try {
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      Cipher cipher = Cipher.getInstance("AES");
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      outputStream = new CipherOutputStream(os, cipher);
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+      // We don't handle any exception as this code is not meant to be executed.
+    }
+  }
+
+
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/StronglyTypeTimeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/StronglyTypeTimeTest.java
@@ -270,4 +270,28 @@ public final class StronglyTypeTimeTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void milliseconds() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import java.time.Duration;",
+            "class Test {",
+            "  private static final long F1_RETRY_MILLISECONDS = 5000;",
+            "  public Duration frobber() {",
+            "    return Duration.ofMillis(F1_RETRY_MILLISECONDS);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.time.Duration;",
+            "class Test {",
+            "  private static final Duration F1_RETRY = Duration.ofMillis(5000);",
+            "  public Duration frobber() {",
+            "    return F1_RETRY;",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/docs/bugpattern/GuardedBy.md
+++ b/docs/bugpattern/GuardedBy.md
@@ -192,36 +192,43 @@ public void increment() {
 
 #### Limitations
 
-Locks are resolved lexically
+Anonymous classes and lambdas need to re-acquire locks that may be held by an
+enclosing block. For example, consider:
 
 ```java
 class Transaction {
   @GuardedBy("this")
   int x;
 
-  interface Handler {
-    void apply();
-  }
-
-  public void handle() {
-    runHandler(new Handler() {
-      @Override
-      public void apply() {
-        x++;  // Error: access of 'x' not guarded by 'Transaction.this'
-      }
+  public synchronized void handle() {
+    doSomething(() -> {
+      x++;  // Error: access of 'x' not guarded by 'Transaction.this'
     });
-  }
-
-  private synchronized void runHandler(Handler handler) {
-    handler.apply();
   }
 }
 ```
 
-In this example, the analysis is unable to guarantee that callers of the Handler
-created in 'handle' will be holding the required lock. The analysis is purely
-intra-procedural, so it is unable to observe that the only caller (runHandler)
-does in fact hold the necessary lock.
+The analysis is intra-procedural, meaning it doesn't consider the implementation
+of `doSomething`.
+
+The checker doesn't know if `doSomething` immediately calls the provided lambda
+while the lock is still held by the enclosing method `handle`, for example:
+
+```java
+private void doSomething(Runnable r) {
+  r.run();
+}
+```
+
+... or whether the lambda could be called later after `handle` has released the
+lock, for example:
+
+```java
+private void doSomething(Runnable r) {
+  // runs `r` at some point in the future
+  someExecutor.execute(r);
+}
+```
 
 #### False negatives with aliasing
 

--- a/docs/bugpattern/ImmutableEnumChecker.md
+++ b/docs/bugpattern/ImmutableEnumChecker.md
@@ -16,6 +16,11 @@ To make enums immutable, ensure:
         that are built in to Error Prone (e.g. `java.lang.String`,
         `java.util.UUID`), or are annotated with
         `com.google.errorprone.annotations.Immutable`.
+
+        Other versions of the annotation, such as
+        `javax.annotation.concurrent.Immutable`, are currently *not* recognized.
+        See https://errorprone.info/bugpattern/Immutable for additional discussion.
+
     *   If the type you're using inside the enum can be annotated with
         `@Immutable`, you should do that:
 

--- a/docs/bugpattern/InsecureCryptoUsage.md
+++ b/docs/bugpattern/InsecureCryptoUsage.md
@@ -1,25 +1,15 @@
 This checker looks for usages of standard cryptographic algorithms in
-configurations that are prone to vulnerabilities. There are currently three
+configurations that are prone to vulnerabilities. There are currently a few
 classes of problems that are covered by this checker:
 
-*   Creating an instance of `javax.crypto.Cipher` using either the default
-    settings or the notoriously insecure ECB mode. In particular, Java's default
-    `Cipher.getInstance(AES)` returns a cipher object that operates in ECB mode.
-    Dynamically constructed transformation strings are also flagged, as they may
-    conceal an instance of ECB mode. The problem with ECB mode is that
-    encrypting the same block of plaintext always yields the same block of
-    ciphertext. Hence, repetitions in the plaintext translate into repetitions
-    in the ciphertext, which can be readily used to conduct cryptanalysis. The
-    use of IES-based cipher algorithms also raises an error, as all currently
-    available implementations use ECB mode under the hood.
+*   Creating an instance of any of the following is considered insecure:
 
-*   Using the Diffie-Hellmann protocol on prime fields. Most library
-    implementations of Diffie-Hellman on prime fields have serious issues that
-    can be exploited by an attacker. Any operation that may involve this
-    protocol will be flagged by the checker. Implementations of the protocol
-    based on elliptic curves (ECDH) are secure and should be used instead.
-
-*   Using DSA for digital signatures. Some widely used crypto libraries accept
-    invalid DSA signatures in specific configurations. The checker will flag all
-    cryptographic operations that may involve DSA.
+    *   `javax.crypto.Cipher`
+    *   `javax.crypto.KeyAgreement`
+    *   `javax.crypto.Mac`
+    *   `javax.crypto.CipherInputStream`
+    *   `javax.crypto.CipherOutputStream`
+    *   `java.security.KeyPairGenerator`
+    *   `java.security.MessageDigest`
+    *   `java.security.Signature`
 

--- a/docs/bugpattern/NullOptional.md
+++ b/docs/bugpattern/NullOptional.md
@@ -1,0 +1,19 @@
+Passing a literal `null` to an `Optional` accepting parameter is likely a bug.
+`Optional` is already designed to encode missing values through a non-`null`
+instance.
+
+```java
+Optional<Integer> double(Optional<Integer> i) {
+  return i.map(i -> i * 2);
+}
+
+Optional<Integer> doubled = double(null);
+```
+
+```java
+Optional<Integer> doubled = double(Optional.empty());
+```
+
+This is a scenario that can easily happen when refactoring code from accepting
+`@Nullable` parameters to accept `Optional`s. Note that the check will not match
+if the parameter is explicitly annotated `@Nullable`.

--- a/docs/bugpattern/OverlappingQualifierAndScopeAnnotation.md
+++ b/docs/bugpattern/OverlappingQualifierAndScopeAnnotation.md
@@ -36,5 +36,5 @@ day, as the `@Provides` method applies the `DayScoped` scoping only to the
 to create a new instance every time a `Spender` is created.
 
 If `@DayScope` wasn't a `Qualifier`, the provider method would do the right
-thing: the un-annotated `Announce` binding would be scoped to DayScope,
+thing: the un-annotated `Allowance` binding would be scoped to `DayScope`,
 implemented by a single `DailyAllowance` instance per day.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a check for passing a literal `null` as an `Optional` parameter.

18b252f314049c48ddc174840810e6fea95f321a

-------

<p> Fix minor typo in OverlappingQualifierAndScopeAnnotation

5238eee241f2522c9da72765c9c6093435bf694c

-------

<p> Add JodaTime.ofSeconds(double) and ofMicros(long) to the StronglyTypeTime analyzer.

#goodtime

745b64d44fcb73aa06017dddd73e878386ca8209

-------

<p> Update description to warn of incompatible look-alike annotations.

7cd9f8f1248fe5cf2ae13e671cdccf94ec686cb5

-------

<p> Allow StronglyTypeTime to find `double` and `float` variables passed to factories.

296955e2c1a61441697f4e2127122f90f8183442

-------

<p> Expand the StronglyTypeTime.TIME_UNIT_REMOVER regex.

#goodtime

91fd93f82a0edc0b35e5a4911415af3b8845071e

-------

<p> Clarify limitations of GuardedBy for lambdas and anonymous classes

914306cbfa2271c03e870cbd0040fe6649621d55

-------

<p> Add more restricted insecure Java crypto APIs to InsecureCryptoUsage. These are meant to be enforced internally only and are stripped for the open source version.

eeef596bfe5cf0c841e11403797d4f6b34716b12

-------

<p> Remove accidental quadraticity from the flagged off code path in JUnit4TestNotRun.

4af9e369ed1b1ce4be924c047ef04eccdaa9422d