### PR TITLE
MOE Sync 2020-03-02

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/bugpatterns/BugChecker.java
+++ b/check_api/src/main/java/com/google/errorprone/bugpatterns/BugChecker.java
@@ -82,6 +82,7 @@ import com.sun.source.tree.UnionTypeTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.tree.WhileLoopTree;
 import com.sun.source.tree.WildcardTree;
+import com.sun.source.util.TreePathScanner;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
@@ -541,5 +542,15 @@ public abstract class BugChecker implements Suppressible, Serializable {
         defaultSeverity(),
         supportsSuppressWarnings(),
         customSuppressionAnnotations());
+  }
+
+  /** A {@link TreePathScanner} which skips trees which are suppressed for this check. */
+  protected class SuppressibleTreePathScanner<A, B> extends TreePathScanner<A, B> {
+    @Override
+    public final A scan(Tree tree, B b) {
+      boolean isSuppressible =
+          tree instanceof ClassTree || tree instanceof MethodTree || tree instanceof VariableTree;
+      return isSuppressible && isSuppressed(tree) ? null : super.scan(tree, b);
+    }
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
@@ -35,12 +35,9 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.ImportTree;
-import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
-import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
-import com.sun.source.util.TreePathScanner;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.PackageSymbol;
 import java.lang.annotation.ElementType;
@@ -163,34 +160,10 @@ public class BadImport extends BugChecker implements ImportTreeMatcher {
     CompilationUnitTree compilationUnit = state.getPath().getCompilationUnit();
     TreePath path = TreePath.getPath(compilationUnit, compilationUnit);
     IdentifierTree firstFound =
-        new TreePathScanner<IdentifierTree, Void>() {
+        new SuppressibleTreePathScanner<IdentifierTree, Void>() {
           @Override
           public IdentifierTree reduce(IdentifierTree r1, IdentifierTree r2) {
             return (r2 != null) ? r2 : r1;
-          }
-
-          @Override
-          public IdentifierTree visitClass(ClassTree classTree, Void aVoid) {
-            if (isSuppressed(classTree)) {
-              return null;
-            }
-            return super.visitClass(classTree, aVoid);
-          }
-
-          @Override
-          public IdentifierTree visitMethod(MethodTree methodTree, Void aVoid) {
-            if (isSuppressed(methodTree)) {
-              return null;
-            }
-            return super.visitMethod(methodTree, aVoid);
-          }
-
-          @Override
-          public IdentifierTree visitVariable(VariableTree variableTree, Void aVoid) {
-            if (isSuppressed(variableTree)) {
-              return null;
-            }
-            return super.visitVariable(variableTree, aVoid);
           }
 
           @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeLocal.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeLocal.java
@@ -77,14 +77,13 @@ public final class FieldCanBeLocal extends BugChecker implements CompilationUnit
     Multimap<VarSymbol, TreePath> unconditionalAssignments = HashMultimap.create();
     Multimap<VarSymbol, Tree> uses = HashMultimap.create();
 
-    new TreePathScanner<Void, Void>() {
+    new SuppressibleTreePathScanner<Void, Void>() {
       @Override
       public Void visitVariable(VariableTree variableTree, Void unused) {
         VarSymbol symbol = getSymbol(variableTree);
         if (symbol != null
             && symbol.getKind() == ElementKind.FIELD
             && symbol.isPrivate()
-            && !isSuppressed(variableTree)
             && canBeLocal(variableTree)
         ) {
           potentialFields.put(symbol, getCurrentPath());

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MixedMutabilityReturnType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MixedMutabilityReturnType.java
@@ -42,7 +42,6 @@ import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.util.ASTHelpers;
-import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
@@ -187,7 +186,7 @@ public final class MixedMutabilityReturnType extends BugChecker
     }
   }
 
-  private final class ReturnTypesScanner extends TreePathScanner<Void, Void> {
+  private final class ReturnTypesScanner extends SuppressibleTreePathScanner<Void, Void> {
     private final VisitorState state;
 
     private final Set<VarSymbol> mutable;
@@ -201,14 +200,8 @@ public final class MixedMutabilityReturnType extends BugChecker
     }
 
     @Override
-    public Void visitClass(ClassTree classTree, Void unused) {
-      return isSuppressed(classTree) ? null : super.visitClass(classTree, null);
-    }
-
-    @Override
     public Void visitMethod(MethodTree methodTree, Void unused) {
-      if (isSuppressed(methodTree)
-          || !RETURNS_COLLECTION.matches(methodTree.getReturnType(), state)) {
+      if (!RETURNS_COLLECTION.matches(methodTree.getReturnType(), state)) {
         return super.visitMethod(methodTree, unused);
       }
       MethodScanner scanner = new MethodScanner();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SameNameButDifferent.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SameNameButDifferent.java
@@ -36,11 +36,8 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MemberSelectTree;
-import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
-import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
-import com.sun.source.util.TreePathScanner;
 import com.sun.tools.javac.code.Kinds.KindSelector;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
@@ -64,22 +61,7 @@ public final class SameNameButDifferent extends BugChecker implements Compilatio
   @Override
   public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {
     Table<String, TypeSymbol, List<TreePath>> table = HashBasedTable.create();
-    new TreePathScanner<Void, Void>() {
-      @Override
-      public Void visitClass(ClassTree classTree, Void unused) {
-        return isSuppressed(classTree) ? null : super.visitClass(classTree, null);
-      }
-
-      @Override
-      public Void visitMethod(MethodTree methodTree, Void unused) {
-        return isSuppressed(methodTree) ? null : super.visitMethod(methodTree, null);
-      }
-
-      @Override
-      public Void visitVariable(VariableTree variableTree, Void unused) {
-        return isSuppressed(variableTree) ? null : super.visitVariable(variableTree, null);
-      }
-
+    new SuppressibleTreePathScanner<Void, Void>() {
       @Override
       public Void visitMemberSelect(MemberSelectTree memberSelectTree, Void unused) {
         if (!shouldIgnore()) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/AlmostJavadoc.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/AlmostJavadoc.java
@@ -40,7 +40,6 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
-import com.sun.source.util.TreePathScanner;
 import com.sun.tools.javac.parser.Tokens.Comment;
 import com.sun.tools.javac.tree.JCTree;
 import java.util.regex.Pattern;
@@ -98,7 +97,7 @@ public final class AlmostJavadoc extends BugChecker implements CompilationUnitTr
   private ImmutableMap<Integer, Tree> getJavadocableTrees(
       CompilationUnitTree tree, VisitorState state) {
     ImmutableMap.Builder<Integer, Tree> javadoccablePositions = ImmutableMap.builder();
-    new TreePathScanner<Void, Void>() {
+    new SuppressibleTreePathScanner<Void, Void>() {
       @Override
       public Void visitClass(ClassTree classTree, Void unused) {
         if (!shouldMatch()) {
@@ -143,9 +142,6 @@ public final class AlmostJavadoc extends BugChecker implements CompilationUnitTr
       }
 
       private boolean shouldMatch() {
-        if (isSuppressed(getCurrentPath().getLeaf())) {
-          return false;
-        }
         // Check there isn't already a Javadoc for the element under question, otherwise we might
         // suggest double Javadoc.
         return Utils.getDocTreePath(state.withPath(getCurrentPath())) == null;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/StronglyTypeTime.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/StronglyTypeTime.java
@@ -37,13 +37,11 @@ import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.util.ASTHelpers;
-import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
-import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
@@ -204,17 +202,7 @@ public final class StronglyTypeTime extends BugChecker implements CompilationUni
   // TODO(b/147006492): Consider extracting a helper to find all fields that match a Matcher.
   private Map<VarSymbol, TreePath> findPathToPotentialFields(VisitorState state) {
     Map<VarSymbol, TreePath> fields = new HashMap<>();
-    new TreePathScanner<Void, Void>() {
-      @Override
-      public Void visitClass(ClassTree classTree, Void unused) {
-        return isSuppressed(classTree) ? null : super.visitClass(classTree, null);
-      }
-
-      @Override
-      public Void visitMethod(MethodTree methodTree, Void unused) {
-        return isSuppressed(methodTree) ? null : super.visitMethod(methodTree, null);
-      }
-
+    new SuppressibleTreePathScanner<Void, Void>() {
       @Override
       public Void visitVariable(VariableTree variableTree, Void unused) {
         VarSymbol symbol = getSymbol(variableTree);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a SuppressibleTreePathScanner to BugChecker to allow scanning a tree path obeying suppression.

For checkers that scan over an entire compilation unit, this is a pretty common pattern.

6f4009dff7f81e399e83ee97a6b38cfd8c86e832