### PR TITLE
MOE Sync 2020-03-04

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/InsecureCipherMode.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InsecureCipherMode.java
@@ -18,133 +18,73 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.method.MethodMatchers.constructor;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
-import com.sun.tools.javac.tree.JCTree;
+import com.sun.source.tree.NewClassTree;
 
 /** @author avenet@google.com (Arnaud J. Venet) */
 @BugPattern(
     name = "InsecureCryptoUsage",
     altNames = {"InsecureCipherMode"},
     summary =
-        "A standard cryptographic operation is used in a mode that is prone to vulnerabilities",
+        "Usage of the Java Cryptography API is insecure because it is prone to vulnerabilities.",
     documentSuppression = false,
     severity = ERROR)
-public class InsecureCipherMode extends BugChecker implements MethodInvocationTreeMatcher {
-  private static final String MESSAGE_BASE = "Insecure usage of a crypto API: ";
-
-  private static final Matcher<ExpressionTree> CIPHER_GETINSTANCE_MATCHER =
-      staticMethod().onClass("javax.crypto.Cipher").named("getInstance");
-
-  private static final Matcher<ExpressionTree> KEY_STRUCTURE_GETINSTANCE_MATCHER =
+public class InsecureCipherMode extends BugChecker
+    implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
+  private static final Matcher<ExpressionTree> BLOCKED_CRYPTO_EXPRESSIONS =
       anyOf(
+          staticMethod().onClass("javax.crypto.Cipher").named("getInstance"),
+          staticMethod().onClass("javax.crypto.KeyAgreement").named("getInstance"),
+          staticMethod().onClass("javax.crypto.Mac").named("getInstance"),
           staticMethod().onClass("java.security.KeyPairGenerator").named("getInstance"),
-          staticMethod().onClass("java.security.KeyFactory").named("getInstance"),
-          staticMethod().onClass("javax.crypto.KeyAgreement").named("getInstance"));
+          staticMethod().onClass("java.security.MessageDigest").named("getInstance"),
+          staticMethod().onClass("java.security.Signature").named("getInstance"));
+
+  private static final Matcher<NewClassTree> BLOCKED_CRYPTO_CLASSES =
+      anyOf(
+          constructor().forClass("javax.crypto.CipherInputStream"),
+          constructor().forClass("javax.crypto.CipherOutputStream"));
 
 
-  private Description buildErrorMessage(MethodInvocationTree tree, String explanation) {
-    Description.Builder description = buildDescription(tree);
-    String message = MESSAGE_BASE + explanation + ".";
-    description.setMessage(message);
-    return description.build();
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    Description description = checkMethodInvocation(tree, state);
+
+
+    return description;
   }
 
-  private Description identifyEcbVulnerability(MethodInvocationTree tree) {
-    // We analyze the first argument of all the overloads of Cipher.getInstance().
-    Object argument = ASTHelpers.constValue((JCTree) tree.getArguments().get(0));
-    if (argument == null) {
-      // We flag call sites where the transformation string is dynamically computed.
-      return buildErrorMessage(
-          tree, "the transformation is not a compile-time constant expression");
-    }
-    // Otherwise, we know that the transformation is specified by a string literal.
-    String transformation = (String) argument;
-
-    // We exclude stream ciphers (this check only makes sense for block ciphers), i.e., the RC4
-    // cipher. The name of this algorithm is "ARCFOUR" in the SunJce and "ARC4" in Conscrypt.
-    // Some other providers like JCraft also seem to use the name "RC4".
-    if (transformation.matches("ARCFOUR.*")
-        || transformation.matches("ARC4.*")
-        || transformation.matches("RC4.*")) {
-      return Description.NO_MATCH;
-    }
-
-    if (!transformation.matches(".*/.*/.*")) {
-      // The mode and padding shall be explicitly specified. We don't allow default settings to be
-      // used, regardless of the algorithm and provider.
-      return buildErrorMessage(tree, "the mode and padding must be explicitly specified");
-    }
-
-    if (transformation.matches(".*/ECB/.*")
-        && !transformation.matches("RSA/.*")
-        && !transformation.matches("AESWrap/.*")) {
-      // Otherwise, ECB mode should be explicitly specified in order to trigger the check. RSA
-      // is an exception, as this transformation doesn't actually implement a block cipher
-      // encryption mode (the input is limited by the size of the key). AESWrap is another
-      // exception, because this algorithm is only used to encrypt encryption keys.
-      return buildErrorMessage(tree, "ECB mode must not be used");
-    }
-
-    if (transformation.matches("ECIES.*") || transformation.matches("DHIES.*")) {
-      // Existing implementations of IES-based algorithms use ECB under the hood and must also be
-      // flagged as vulnerable. See b/30424901 for a more detailed rationale.
-      return buildErrorMessage(tree, "IES-based algorithms use ECB mode and are insecure");
-    }
-
-    return Description.NO_MATCH;
-  }
-
-  private Description identifyDiffieHellmanAndDsaVulnerabilities(MethodInvocationTree tree) {
-    // The first argument holds a string specifying the algorithm used for the operation
-    // considered.
-    Object argument = ASTHelpers.constValue((JCTree) tree.getArguments().get(0));
-    if (argument == null) {
-      // We flag call sites where the algorithm specification string is dynamically computed.
-      return buildErrorMessage(
-          tree, "the algorithm specification is not a compile-time constant expression");
-    }
-    // Otherwise, we know that the algorithm is specified by a string literal.
-    String algorithm = (String) argument;
-
-    if (algorithm.matches("DH")) {
-      // Most implementations of Diffie-Hellman on prime fields have vulnerabilities. See b/31574444
-      // for a more detailed rationale.
-      return buildErrorMessage(tree, "using Diffie-Hellman on prime fields is insecure");
-    }
-
-    if (algorithm.matches("DSA")) {
-      // Some crypto libraries may accept invalid DSA signatures in specific configurations (see
-      // b/30262692 for details).
-      return buildErrorMessage(tree, "using DSA is insecure");
+  Description checkMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (BLOCKED_CRYPTO_EXPRESSIONS.matches(tree, state)) {
+      String message = "Use of these APIs is considered insecure";
+      state.reportMatch(buildDescription(tree).setMessage(message).build());
     }
 
     return Description.NO_MATCH;
   }
 
   @Override
-  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-    Description description = checkInvocation(tree, state);
+  public Description matchNewClass(NewClassTree tree, VisitorState state) {
+    Description description = checkClassInvocation(tree, state);
 
 
     return description;
   }
 
-  Description checkInvocation(MethodInvocationTree tree, VisitorState state) {
-    if (CIPHER_GETINSTANCE_MATCHER.matches(tree, state)) {
-      return identifyEcbVulnerability(tree);
-    }
-
-    if (KEY_STRUCTURE_GETINSTANCE_MATCHER.matches(tree, state)) {
-      return identifyDiffieHellmanAndDsaVulnerabilities(tree);
+  Description checkClassInvocation(NewClassTree tree, VisitorState state) {
+    if (BLOCKED_CRYPTO_CLASSES.matches(tree, state)) {
+      String message = "Use of these APIs is considered insecure";
+      state.reportMatch(buildDescription(tree).setMessage(message).build());
     }
 
     return Description.NO_MATCH;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MutablePublicArray.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MutablePublicArray.java
@@ -37,7 +37,7 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "MutablePublicArray",
     summary =
-        "Nonzero-length arrays are mutable, so this `public static final` array is not a constant"
+        "Non-empty arrays are mutable, so this `public static final` array is not a constant"
             + " and can be modified by clients of this class.  Prefer an ImmutableList, or provide"
             + " an accessor method that returns a defensive copy.",
     severity = WARNING,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/InsecureCipherModeNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/InsecureCipherModeNegativeCases.java
@@ -16,146 +16,19 @@
 
 package com.google.errorprone.bugpatterns.testdata;
 
-import java.security.KeyFactory;
-import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import javax.crypto.Cipher;
-import javax.crypto.KeyAgreement;
-import javax.crypto.NoSuchPaddingException;
 
 /**
  * @author avenet@google.com (Arnaud J. Venet)
  */
 public class InsecureCipherModeNegativeCases {
-  static Cipher aesCipher;
-
   static {
     // We don't handle any exception as this code is not meant to be executed.
     try {
-      aesCipher = Cipher.getInstance("AES/CBC/NoPadding");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static final String AES_STRING = "AES/CBC/NoPadding";
-  static Cipher aesCipherWithConstantString;
-
-  static {
-    try {
-      aesCipherWithConstantString = Cipher.getInstance(AES_STRING);
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher aesCipherWithProvider;
-
-  static {
-    try {
-      aesCipherWithProvider = Cipher.getInstance("AES/CBC/NoPadding", "My Provider");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchProviderException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher arc4CipherConscrypt;
-
-  static {
-    try {
-      arc4CipherConscrypt = Cipher.getInstance("ARC4", "Conscrypt");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchProviderException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher rc4CipherJsch;
-
-  static {
-    try {
-      rc4CipherJsch = Cipher.getInstance("RC4", "JSch");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchProviderException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher arcfourCipherSunJce;
-
-  static {
-    try {
-      arcfourCipherSunJce = Cipher.getInstance("ARCFOUR/ECB/NoPadding");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher desCipher;
-
-  static {
-    try {
-      desCipher = Cipher.getInstance("DES/CBC/NoPadding");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher rsaCipher;
-
-  static {
-    try {
-      rsaCipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher aesWrapCipher;
-
-  static {
-    try {
-      aesWrapCipher = Cipher.getInstance("AESWrap/ECB/NoPadding");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  public void ellipticCurveDiffieHellman() {
-    KeyFactory keyFactory;
-    KeyAgreement keyAgreement;
-    KeyPairGenerator keyPairGenerator;
-    final String ecdh = "ECDH";
-    try {
-      keyFactory = KeyFactory.getInstance(ecdh);
-      keyAgreement = KeyAgreement.getInstance("ECDH");
-      keyPairGenerator = KeyPairGenerator.getInstance("EC" + "DH");
+      int keyLength = Cipher.getMaxAllowedKeyLength("AES");
     } catch (NoSuchAlgorithmException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
-
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/InsecureCipherModePositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/InsecureCipherModePositiveCases.java
@@ -16,12 +16,20 @@
 
 package com.google.errorprone.bugpatterns.testdata;
 
-import java.security.KeyFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.security.Signature;
 import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.CipherOutputStream;
 import javax.crypto.KeyAgreement;
+import javax.crypto.Mac;
 import javax.crypto.NoSuchPaddingException;
 
 /** @author avenet@google.com (Arnaud J. Venet) */
@@ -30,24 +38,9 @@ public class InsecureCipherModePositiveCases {
 
   static {
     try {
-      // BUG: Diagnostic contains: the mode and padding must be explicitly specified
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
       defaultAesCipher = Cipher.getInstance("AES");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher defaultRsaCipher;
-
-  static {
-    try {
-      // BUG: Diagnostic contains: the mode and padding must be explicitly specified
-      defaultRsaCipher = Cipher.getInstance("RSA");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
@@ -57,37 +50,9 @@ public class InsecureCipherModePositiveCases {
 
   static {
     try {
-      // BUG: Diagnostic contains: the mode and padding must be explicitly specified
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
       defaultAesCipherWithConstantString = Cipher.getInstance(AES_STRING);
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher explicitAesCipher;
-
-  static {
-    try {
-      // BUG: Diagnostic contains: ECB mode must not be used
-      explicitAesCipher = Cipher.getInstance("AES/ECB/NoPadding");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static Cipher explicitDesCipher;
-
-  static {
-    try {
-      // BUG: Diagnostic contains: ECB mode must not be used
-      explicitDesCipher = Cipher.getInstance("DES/ECB/NoPadding");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
@@ -96,38 +61,9 @@ public class InsecureCipherModePositiveCases {
 
   static {
     try {
-      // BUG: Diagnostic contains: ECB mode must not be used
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
       explicitDesCipherWithProvider = Cipher.getInstance("DES/ECB/NoPadding", "My Provider");
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchProviderException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static String transformation;
-
-  static {
-    try {
-      transformation = "DES/CBC/NoPadding";
-      // BUG: Diagnostic contains: the transformation is not a compile-time constant
-      Cipher cipher = Cipher.getInstance(transformation);
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    }
-  }
-
-  static void transformationAsParameter(String transformation) {
-    try {
-      // BUG: Diagnostic contains: the transformation is not a compile-time constant
-      Cipher cipher = Cipher.getInstance(transformation);
-    } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException | NoSuchProviderException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
@@ -138,7 +74,7 @@ public class InsecureCipherModePositiveCases {
     // Make sure that the checker is enabled inside constructors.
     public CipherWrapper() {
       try {
-        // BUG: Diagnostic contains: the mode and padding must be explicitly specified
+        // BUG: Diagnostic contains: Use of these APIs is considered insecure
         cipher = Cipher.getInstance("AES");
       } catch (NoSuchAlgorithmException e) {
         // We don't handle any exception as this code is not meant to be executed.
@@ -148,90 +84,91 @@ public class InsecureCipherModePositiveCases {
     }
   }
 
-  static Cipher complexCipher1;
+  static Mac mac;
 
   static {
     try {
-      String algorithm = "AES";
-      // BUG: Diagnostic contains: the transformation is not a compile-time constant
-      complexCipher1 = Cipher.getInstance(algorithm);
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      mac = Mac.getInstance("HmacSHA1");
+
     } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
 
-  static Cipher complexCipher2;
+  static MessageDigest messageDigest;
 
   static {
     try {
-      String transformation = "AES";
-      transformation += "/ECB";
-      transformation += "/NoPadding";
-      // BUG: Diagnostic contains: the transformation is not a compile-time constant
-      complexCipher2 = Cipher.getInstance(transformation);
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      messageDigest = MessageDigest.getInstance("SHA");
+
     } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
 
-  static Cipher IesCipher;
+  static Signature sig;
 
   static {
     try {
-      // BUG: Diagnostic contains: the mode and padding must be explicitly specified
-      IesCipher = Cipher.getInstance("ECIES");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("ECIES/DHAES/NoPadding");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("ECIESWITHAES/NONE/PKCS5Padding");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("DHIESWITHAES/DHAES/PKCS7Padding");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("ECIESWITHDESEDE/NONE/NOPADDING");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("DHIESWITHDESEDE/DHAES/PKCS5PADDING");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("ECIESWITHAES/CBC/PKCS7PADDING");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("ECIESWITHAES-CBC/NONE/PKCS5PADDING");
-      // BUG: Diagnostic contains: IES
-      IesCipher = Cipher.getInstance("ECIESwithDESEDE-CBC/DHAES/NOPADDING");
-
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      sig = Signature.getInstance("SHA1withRSA");
     } catch (NoSuchAlgorithmException e) {
-      // We don't handle any exception as this code is not meant to be executed.
-    } catch (NoSuchPaddingException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
 
-  interface StringProvider {
-    String get();
-  }
+  static KeyAgreement keyAgreement;
 
-  public void keyOperations(StringProvider provider) {
-    KeyFactory keyFactory;
-    KeyAgreement keyAgreement;
-    KeyPairGenerator keyPairGenerator;
-    final String dh = "DH";
+  static {
     try {
-      // BUG: Diagnostic contains: compile-time constant
-      keyFactory = KeyFactory.getInstance(provider.get());
-      // BUG: Diagnostic contains: Diffie-Hellman on prime fields
-      keyFactory = KeyFactory.getInstance(dh);
-      // BUG: Diagnostic contains: DSA
-      keyAgreement = KeyAgreement.getInstance("DSA");
-      // BUG: Diagnostic contains: compile-time constant
-      keyAgreement = KeyAgreement.getInstance(provider.get());
-      // BUG: Diagnostic contains: Diffie-Hellman on prime fields
-      keyPairGenerator = KeyPairGenerator.getInstance(dh);
-      // BUG: Diagnostic contains: compile-time constant
-      keyPairGenerator = KeyPairGenerator.getInstance(provider.get());
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      keyAgreement = KeyAgreement.getInstance("ECDH");
     } catch (NoSuchAlgorithmException e) {
       // We don't handle any exception as this code is not meant to be executed.
     }
   }
+
+  static KeyPairGenerator keyPairGenerator;
+
+  static {
+    try {
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      keyPairGenerator = KeyPairGenerator.getInstance("EC" + "DH");
+    } catch (NoSuchAlgorithmException e) {
+      // We don't handle any exception as this code is not meant to be executed.
+    }
+  }
+
+  static CipherInputStream inputStream;
+
+  static {
+    try {
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      Cipher cipher = Cipher.getInstance("AES");
+      File file = new File("ok");
+      FileInputStream in = new FileInputStream(file);
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      inputStream = new CipherInputStream(in, cipher);
+    } catch (FileNotFoundException | NoSuchAlgorithmException | NoSuchPaddingException e) {
+      // We don't handle any exception as this code is not meant to be executed.
+    }
+  }
+
+  static CipherOutputStream outputStream;
+
+  static {
+    try {
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      Cipher cipher = Cipher.getInstance("AES");
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      // BUG: Diagnostic contains: Use of these APIs is considered insecure
+      outputStream = new CipherOutputStream(os, cipher);
+    } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+      // We don't handle any exception as this code is not meant to be executed.
+    }
+  }
+
+
 }

--- a/docs/bugpattern/InsecureCryptoUsage.md
+++ b/docs/bugpattern/InsecureCryptoUsage.md
@@ -1,25 +1,15 @@
 This checker looks for usages of standard cryptographic algorithms in
-configurations that are prone to vulnerabilities. There are currently three
+configurations that are prone to vulnerabilities. There are currently a few
 classes of problems that are covered by this checker:
 
-*   Creating an instance of `javax.crypto.Cipher` using either the default
-    settings or the notoriously insecure ECB mode. In particular, Java's default
-    `Cipher.getInstance(AES)` returns a cipher object that operates in ECB mode.
-    Dynamically constructed transformation strings are also flagged, as they may
-    conceal an instance of ECB mode. The problem with ECB mode is that
-    encrypting the same block of plaintext always yields the same block of
-    ciphertext. Hence, repetitions in the plaintext translate into repetitions
-    in the ciphertext, which can be readily used to conduct cryptanalysis. The
-    use of IES-based cipher algorithms also raises an error, as all currently
-    available implementations use ECB mode under the hood.
+*   Creating an instance of any of the following is considered insecure:
 
-*   Using the Diffie-Hellmann protocol on prime fields. Most library
-    implementations of Diffie-Hellman on prime fields have serious issues that
-    can be exploited by an attacker. Any operation that may involve this
-    protocol will be flagged by the checker. Implementations of the protocol
-    based on elliptic curves (ECDH) are secure and should be used instead.
-
-*   Using DSA for digital signatures. Some widely used crypto libraries accept
-    invalid DSA signatures in specific configurations. The checker will flag all
-    cryptographic operations that may involve DSA.
+    *   `javax.crypto.Cipher`
+    *   `javax.crypto.KeyAgreement`
+    *   `javax.crypto.Mac`
+    *   `javax.crypto.CipherInputStream`
+    *   `javax.crypto.CipherOutputStream`
+    *   `java.security.KeyPairGenerator`
+    *   `java.security.MessageDigest`
+    *   `java.security.Signature`
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update InsecureCipherMode check to ban a number of cryptography API's
entirely as opposed to just when certain cryptography modes were
selected:

javax.crypto.Cipher
javax.crypto.KeyAgreement
javax.crypto.Mac
javax.crypto.CipherInputStream
javax.crypto.CipherOutputStream
java.security.KeyPairGenerator
java.security.MessageDigest
java.security.Signature

f32c7fcba601dba7abc22ff8578831d025227016

-------

<p> Nit: Nonzero-length -> Non-empty.

I think the latter reads a little more nicely.

a8bccd94823d0145432bf4e899d86d18253cfe6e