### PR TITLE
Add SystemOut checker

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/SystemOut.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SystemOut.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.matchers.FieldMatchers.staticField;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.instanceMethod;
+import static com.google.errorprone.matchers.Matchers.staticMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.ProvidesFix;
+import com.google.errorprone.BugPattern.StandardTags;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MemberSelectTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodInvocationTree;
+
+/** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
+@BugPattern(
+    name = "SystemOut",
+    summary =
+        "Printing to standard output should only be used for debugging, not in production code",
+    severity = WARNING,
+    tags = StandardTags.LIKELY_ERROR,
+    providesFix = ProvidesFix.NO_FIX)
+public class SystemOut extends BugChecker
+    implements MethodInvocationTreeMatcher, MemberSelectTreeMatcher {
+
+  private static final Matcher<ExpressionTree> SYSTEM_OUT =
+      anyOf(
+          staticField(System.class.getName(), "out"), //
+          staticField(System.class.getName(), "err"));
+
+  private static final Matcher<ExpressionTree> PRINT_STACK_TRACE =
+      anyOf(
+          staticMethod().onClass(Thread.class.getName()).named("dumpStack").withParameters(),
+          instanceMethod()
+              .onDescendantOf(Throwable.class.getName())
+              .named("printStackTrace")
+              .withParameters());
+
+  @Override
+  public Description matchMemberSelect(MemberSelectTree tree, VisitorState state) {
+    if (SYSTEM_OUT.matches(tree, state)) {
+      return describeMatch(tree);
+    }
+    return NO_MATCH;
+  }
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (PRINT_STACK_TRACE.matches(tree, state)) {
+      return describeMatch(tree);
+    }
+    return NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -304,6 +304,7 @@ import com.google.errorprone.bugpatterns.SwigMemoryLeak;
 import com.google.errorprone.bugpatterns.SwitchDefault;
 import com.google.errorprone.bugpatterns.SymbolToString;
 import com.google.errorprone.bugpatterns.SystemExitOutsideMain;
+import com.google.errorprone.bugpatterns.SystemOut;
 import com.google.errorprone.bugpatterns.TestExceptionChecker;
 import com.google.errorprone.bugpatterns.TheoryButNoTheories;
 import com.google.errorprone.bugpatterns.ThreadJoinLoop;
@@ -1011,6 +1012,7 @@ public class BuiltInCheckerSuppliers {
           SwitchDefault.class,
           SymbolToString.class,
           SystemExitOutsideMain.class,
+          SystemOut.class,
           TestExceptionChecker.class,
           ThrowSpecificExceptions.class,
           ThrowsUncheckedException.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/SystemOutTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/SystemOutTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link SystemOut}. */
+@RunWith(JUnit4.class)
+public class SystemOutTest {
+
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(SystemOut.class, getClass());
+
+  @Test
+  public void positive() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.io.PrintStream;",
+            "",
+            "class Test {",
+            "  void f() {",
+            "    // BUG: Diagnostic contains: SystemOut",
+            "    System.out.println();",
+            "    // BUG: Diagnostic contains: SystemOut",
+            "    System.err.println();",
+            "    // BUG: Diagnostic contains: SystemOut",
+            "    p(System.out);",
+            "    // BUG: Diagnostic contains: SystemOut",
+            "    p(System.err);",
+            "    // BUG: Diagnostic contains: SystemOut",
+            "    Thread.dumpStack();",
+            "    // BUG: Diagnostic contains: SystemOut",
+            "    new Exception().printStackTrace();",
+            "  }",
+            "  private void p(PrintStream ps) {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.io.*;",
+            "",
+            "class Test {",
+            "  void f() {",
+            "    new Exception().printStackTrace(new PrintStream((OutputStream) null));",
+            "    new Exception().printStackTrace(new PrintWriter((OutputStream) null));",
+            "  }",
+            "}")
+        .doTest();
+  }
+}


### PR DESCRIPTION
This checker checks for uses of System.out and System.err as
possible logs used for debugging purpose.

Inspired by [Policeman's Forbidden API Checker](https://github.com/policeman-tools/forbidden-apis)'s `jdk-system-out` checks.

See also #1211 