### PR TITLE
MOE Sync 2020-03-11

### DIFF
--- a/annotations/src/main/java/com/google/errorprone/annotations/RestrictedApi.java
+++ b/annotations/src/main/java/com/google/errorprone/annotations/RestrictedApi.java
@@ -82,7 +82,12 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.CONSTRUCTOR, ElementType.METHOD})
 public @interface RestrictedApi {
-  /** Very short name for the diagnostic message. Used in error-prone. */
+  /**
+   * Very short name for the diagnostic message. Used in error-prone.
+   *
+   * @deprecated providing a different checker name is confusing; this field is ignored.
+   */
+  @Deprecated
   public String checkerName() default "RestrictedApi";
 
   /** Explanation why the API is restricted, to be inserted into the compiler output. */

--- a/check_api/src/main/java/com/google/errorprone/matchers/Description.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/Description.java
@@ -163,7 +163,7 @@ public class Description {
   public static class Builder {
     private final DiagnosticPosition position;
     private final String name;
-    private final String linkUrl;
+    private String linkUrl;
     private final SeverityLevel severity;
     private final ImmutableList.Builder<Fix> fixListBuilder = ImmutableList.builder();
     private String rawMessage;
@@ -230,10 +230,18 @@ public class Description {
      * @param message A custom error message without the check name ("[checkname]") or link
      */
     public Builder setMessage(String message) {
-      if (message == null) {
-        throw new IllegalArgumentException("message must not be null");
-      }
+      checkNotNull(message, "message must not be null");
       this.rawMessage = message;
+      return this;
+    }
+
+    /**
+     * Set a custom link URL. The custom URL will be used instead of the default one which forms
+     * part of the {@code @}BugPattern.
+     */
+    public Builder setLinkUrl(String linkUrl) {
+      checkNotNull(linkUrl, "linkUrl must not be null");
+      this.linkUrl = linkUrl;
       return this;
     }
 

--- a/check_api/src/test/java/com/google/errorprone/matchers/DescriptionTest.java
+++ b/check_api/src/test/java/com/google/errorprone/matchers/DescriptionTest.java
@@ -124,4 +124,15 @@ public class DescriptionTest {
     assertThat(description.getMessage())
         .isEqualTo("[CustomLinkChecker] custom message\n  (see https://www.google.com/)");
   }
+
+  @Test
+  public void testCustomLinkOverride() {
+    Description description =
+        BugChecker.buildDescriptionFromChecker(
+                (DiagnosticPosition) new MockTree(), new CustomLinkChecker())
+            .setMessage("custom message")
+            .setLinkUrl("http://foo")
+            .build();
+    assertThat(description.getMessage()).contains("http://foo");
+  }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RestrictedApiChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RestrictedApiChecker.java
@@ -47,7 +47,7 @@ import javax.lang.model.type.MirroredTypesException;
 /** Check for non-whitelisted callers to RestrictedApiChecker. */
 @BugPattern(
     name = "RestrictedApiChecker",
-    summary = " Check for non-whitelisted callers to RestrictedApiChecker.",
+    summary = "Check for non-whitelisted callers to RestrictedApiChecker.",
     severity = SeverityLevel.ERROR,
     suppressionAnnotations = {},
     disableable = false,
@@ -57,6 +57,12 @@ public class RestrictedApiChecker extends BugChecker
         NewClassTreeMatcher,
         AnnotationTreeMatcher,
         MemberReferenceTreeMatcher {
+  /**
+   * The name to use when reporting findings. It's important that this DOES NOT match {@link
+   * #canonicalName()}, because otherwise changing the severity won't work.
+   */
+  // TODO(b/151087021): rationalize this.
+  private static final String CHECK_NAME = "RestrictedApi";
 
   /**
    * Validates a {@code @RestrictedApi} annotation and that the declared restriction makes sense.
@@ -137,9 +143,7 @@ public class RestrictedApiChecker extends BugChecker
       // TODO(bangert): Clarify this message if possible.
       return buildDescription(where)
           .setMessage(
-              "The Restricted API (["
-                  + restriction.checkerName()
-                  + "]"
+              "The Restricted API ("
                   + restriction.explanation()
                   + ") call here is both whitelisted-as-warning and "
                   + "silently whitelisted. "
@@ -153,7 +157,7 @@ public class RestrictedApiChecker extends BugChecker
 
     Description.Builder description =
         Description.builder(
-            where, restriction.checkerName(), restriction.link(), level, restriction.explanation());
+            where, CHECK_NAME, restriction.link(), level, restriction.explanation());
     return description.build();
   }
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpression.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpression.java
@@ -61,6 +61,7 @@ public class StaticQualifiedUsingExpression extends BugChecker implements Member
           return NO_MATCH;
         }
         // fall through
+      case ENUM_CONSTANT:
       case METHOD:
         if (!sym.isStatic()) {
           return NO_MATCH;

--- a/core/src/test/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpressionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpressionTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,13 +26,10 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class StaticQualifiedUsingExpressionTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(StaticQualifiedUsingExpression.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(StaticQualifiedUsingExpression.class, getClass());
+  private final BugCheckerRefactoringTestHelper refactoringHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new StaticQualifiedUsingExpression(), getClass());
 
   @Test
   public void testPositiveCase1() {
@@ -52,7 +48,7 @@ public class StaticQualifiedUsingExpressionTest {
 
   @Test
   public void clash() {
-    BugCheckerRefactoringTestHelper.newInstance(new StaticQualifiedUsingExpression(), getClass())
+    refactoringHelper
         .addInputLines(
             "a/Lib.java", //
             "package a;",
@@ -84,7 +80,7 @@ public class StaticQualifiedUsingExpressionTest {
 
   @Test
   public void expr() {
-    BugCheckerRefactoringTestHelper.newInstance(new StaticQualifiedUsingExpression(), getClass())
+    refactoringHelper
         .addInputLines(
             "I.java", //
             "interface I {",
@@ -114,7 +110,7 @@ public class StaticQualifiedUsingExpressionTest {
 
   @Test
   public void superAccess() {
-    BugCheckerRefactoringTestHelper.newInstance(new StaticQualifiedUsingExpression(), getClass())
+    refactoringHelper
         .addInputLines(
             "I.java", //
             "interface I {",
@@ -134,6 +130,32 @@ public class StaticQualifiedUsingExpressionTest {
             "  }",
             "}")
         .expectUnchanged()
+        .doTest();
+  }
+
+  @Test
+  public void enumConstantAccessedViaInstance() {
+    refactoringHelper
+        .addInputLines(
+            "Enum.java", //
+            "enum Enum {",
+            "A, B;",
+            "}")
+        .expectUnchanged()
+        .addInputLines(
+            "Test.java", //
+            "class Test {",
+            "  Enum foo(Enum e) {",
+            "    return e.B;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java", //
+            "class Test {",
+            "  Enum foo(Enum e) {",
+            "    return Enum.B;",
+            "  }",
+            "}")
         .doTest();
   }
 }

--- a/docs/bugpattern/UnnecessaryDefaultInEnumSwitch.md
+++ b/docs/bugpattern/UnnecessaryDefaultInEnumSwitch.md
@@ -133,13 +133,16 @@ boolean isOn(State state) {
 
 ## Cases with UNRECOGNIZED
 
-In situations where a switch handles all values of a proto-generated enum except
-for UNRECOGNIZED, UNRECOGNIZED is explicitly handled and the default is removed.
-This is preferred practice because it will catch unexpected enum types at
-compiletime instead of runtime.
+When a switch statement handles all values of a proto-generated enum except for
+UNRECOGNIZED, the UNRECOGNIZED case should be explicitly handled and the default
+should be removed. This is preferred so that `MissingCasesInEnumSwitch` will
+catch unexpected enum types at compile-time instead of runtime.
 
-If the switch statement cannot complete normally, the default is deleted and its
-statements are moved after the switch statement. Case UNRECOGNIZED is added with
-a break.
+If the switch statement cannot [complete normally], the default should be
+deleted and its statements moved after the switch statement. The UNRECOGNIZED
+case should be added with a break.
 
-If it can complete, we merge the default with an added UNRECOGNIZED case.
+If it can complete normally, the default should be merged with an added
+UNRECOGNIZED case.
+
+[complete normally]: https://docs.oracle.com/javase/specs/jls/se10/html/jls-14.html#jls-14.1


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Reword section about UNRECOGNIZED to match the surrounding tone

This paragraph alone seems to be phrased like "the rule does X in its suggested fix" instead of "you should do X".

86b1f19efefa21de910c6a4def623dd7df7f2fa7

-------

<p> StaticQualifiedUsingExpression: handle enums

f45e7fd2b2ca5b799bb39556d018611f8ba899c2

-------

<p> RestrictedInheritance/RestrictedApi: ignore the checkerName in the annotations.

Excitingly, it's critical that this /does not/ match the #canonicalName defined by the BugPattern. These checks rely on being able to downgrade the check to a WARNING based on a value in the annotation. If the finding were reported under the canonical name, the severity would be overridden back to ERROR.

This is terrible, but I've left a TODO to clean this up.

637d0220503a2a588948e2fa95ee149de23c7cca

-------

<p> Add setLinkUrl to Description.Builder.

1a517a3b470fe4e8c5f21d0d6a47bfbf88d881cc