### PR TITLE
MOE Sync 2020-03-18

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/VisitorState.java
+++ b/check_api/src/main/java/com/google/errorprone/VisitorState.java
@@ -322,6 +322,11 @@ public class VisitorState {
   /**
    * Given the binary name of a class, returns the {@link Type}.
    *
+   * <p>Prefer not to use this method for constant strings, or strings otherwise known at compile
+   * time. Instead, save the result of {@link Suppliers#typeFromString} as a class constant, and use
+   * its {@link Supplier#get} method to look up the Type when needed. This lookup will be faster,
+   * improving Error Prone's analysis time.
+   *
    * <p>If this method returns null, the compiler doesn't have access to this type, which means that
    * if you are comparing other types to this for equality or the subtype relation, your result
    * would always be false even if it could create the type. Thus it might be best to bail out early

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StaticAssignmentInConstructor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StaticAssignmentInConstructor.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.AssignmentTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.util.TreeScanner;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+
+/** Checks for static fields being assigned within constructors. */
+@BugPattern(
+    name = "StaticAssignmentInConstructor",
+    severity = WARNING,
+    summary =
+        "This assignment is to a static field. Mutating static state from a constructor is highly"
+            + " error-prone.")
+public final class StaticAssignmentInConstructor extends BugChecker implements MethodTreeMatcher {
+  @Override
+  public Description matchMethod(MethodTree tree, VisitorState state) {
+    MethodSymbol methodSymbol = getSymbol(tree);
+    if (methodSymbol == null || !methodSymbol.isConstructor()) {
+      return NO_MATCH;
+    }
+    new TreeScanner<Void, Void>() {
+      @Override
+      public Void visitClass(ClassTree classTree, Void unused) {
+        return null;
+      }
+
+      @Override
+      public Void visitMethod(MethodTree methodTree, Void unused) {
+        return null;
+      }
+
+      @Override
+      public Void visitLambdaExpression(LambdaExpressionTree lambdaExpressionTree, Void unused) {
+        return null;
+      }
+
+      @Override
+      public Void visitAssignment(AssignmentTree assignmentTree, Void unused) {
+        Symbol symbol = getSymbol(assignmentTree.getVariable());
+        if (symbol != null && symbol.isStatic() && shouldEmitFinding(assignmentTree)) {
+          state.reportMatch(describeMatch(assignmentTree));
+        }
+        return super.visitAssignment(assignmentTree, null);
+      }
+
+      private boolean shouldEmitFinding(AssignmentTree assignmentTree) {
+        if (!(assignmentTree.getExpression() instanceof IdentifierTree)) {
+          return true;
+        }
+        IdentifierTree identifierTree = ((IdentifierTree) assignmentTree.getExpression());
+        return !identifierTree.getName().contentEquals("this");
+      }
+    }.scan(tree.getBody(), null);
+    return NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -265,6 +265,7 @@ import com.google.errorprone.bugpatterns.SelfEquals;
 import com.google.errorprone.bugpatterns.ShortCircuitBoolean;
 import com.google.errorprone.bugpatterns.ShouldHaveEvenArgs;
 import com.google.errorprone.bugpatterns.SizeGreaterThanOrEqualsZero;
+import com.google.errorprone.bugpatterns.StaticAssignmentInConstructor;
 import com.google.errorprone.bugpatterns.StaticQualifiedUsingExpression;
 import com.google.errorprone.bugpatterns.StreamResourceLeak;
 import com.google.errorprone.bugpatterns.StreamToString;
@@ -771,6 +772,7 @@ public class BuiltInCheckerSuppliers {
           SameNameButDifferent.class,
           ShortCircuitBoolean.class,
           StringSplitter.class,
+          StaticAssignmentInConstructor.class,
           StaticGuardedByInstance.class,
           StreamResourceLeak.class,
           SwigMemoryLeak.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/StaticAssignmentInConstructorTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/StaticAssignmentInConstructorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link StaticAssignmentInConstructor}. */
+@RunWith(JUnit4.class)
+public final class StaticAssignmentInConstructorTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(StaticAssignmentInConstructor.class, getClass());
+
+  @Test
+  public void positive() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  static int foo;",
+            "  public Test(int foo) {",
+            "    // BUG: Diagnostic contains:",
+            "    this.foo = foo;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void dubiousStorageOfLatestInstance_exempted() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  static Test latest;",
+            "  public Test() {",
+            "    latest = this;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void instanceField_noMatch() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  int foo;",
+            "  public Test(int foo) {",
+            "    this.foo = foo;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void assignedWithinLambda_noMatch() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  static int foo;",
+            "  public Test(int a) {",
+            "    java.util.Arrays.asList().stream().map(x -> { foo = 1; return a; }).count();",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/docs/bugpattern/StaticAssignmentInConstructor.md
+++ b/docs/bugpattern/StaticAssignmentInConstructor.md
@@ -1,0 +1,12 @@
+Assigning to a static variable from a constructor is highly indicative of a bug,
+or error-prone design.
+
+Common reasons are:
+
+1.  The field simply should be an instance field, and there's a bug.
+
+2.  An attempt is being made to lazily initialize a static field. In this case,
+    first consider whether lazy initialization is necessary: it often isn't. If
+    it is, doing it from a constructor is very hairy: the static field could be
+    accessed from a static method before the class is even initialized. Consider
+    using a memoized `Supplier`.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a note to VisitorState.getTypeFromString explaining when not to use it.

c968eeeeab25dac794d070bda92c7db9a98a7c5b

-------

<p> Flag assignment of static fields in constructors.

57f0a94022baa1db3fdd0ae7bf8f29b75b066174