### PR TITLE
MOE Sync 2020-03-26

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/apidiff/AndroidJdkLibsChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/apidiff/AndroidJdkLibsChecker.java
@@ -36,9 +36,6 @@ import java.util.stream.Collectors;
     name = "AndroidJdkLibsChecker",
     altNames = {"Java7ApiChecker", "AndroidApiChecker"},
     summary = "Use of class, field, or method that is not compatible with legacy Android devices",
-    explanation =
-        "Code that needs to be compatible with Android cannot use types or members that "
-            + "only the latest or unreleased devices can handle",
     severity = ERROR)
 // TODO(b/32513850): Allow Android N+ APIs, e.g., by computing API diff using android.jar
 public class AndroidJdkLibsChecker extends ApiDiffChecker {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/UrlInSee.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/UrlInSee.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.javadoc;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.bugpatterns.javadoc.Utils.diagnosticPosition;
+import static com.google.errorprone.bugpatterns.javadoc.Utils.getDocTreePath;
+import static com.google.errorprone.bugpatterns.javadoc.Utils.replace;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.doctree.ErroneousTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.DocTreePath;
+import com.sun.source.util.DocTreePathScanner;
+
+/** Discourages using URLs in {@literal @}see tags. */
+@BugPattern(
+    name = "UrlInSee",
+    summary =
+        "URLs should not be used in @see tags; they are designed for Java elements which could be"
+            + " used with @link.",
+    severity = WARNING)
+public final class UrlInSee extends BugChecker
+    implements ClassTreeMatcher, MethodTreeMatcher, VariableTreeMatcher {
+  @Override
+  public Description matchClass(ClassTree classTree, VisitorState state) {
+    DocTreePath path = getDocTreePath(state);
+    if (path != null) {
+      new UrlInSeeChecker(state).scan(path, null);
+    }
+    return NO_MATCH;
+  }
+
+  @Override
+  public Description matchMethod(MethodTree methodTree, VisitorState state) {
+    DocTreePath path = getDocTreePath(state);
+    if (path != null) {
+      new UrlInSeeChecker(state).scan(path, null);
+    }
+    return NO_MATCH;
+  }
+
+  @Override
+  public Description matchVariable(VariableTree variableTree, VisitorState state) {
+    DocTreePath path = getDocTreePath(state);
+    if (path != null) {
+      new UrlInSeeChecker(state).scan(path, null);
+    }
+    return NO_MATCH;
+  }
+
+  private final class UrlInSeeChecker extends DocTreePathScanner<Void, Void> {
+    private final VisitorState state;
+
+    private UrlInSeeChecker(VisitorState state) {
+      this.state = state;
+    }
+
+    @Override
+    public Void visitErroneous(ErroneousTree erroneousTree, Void aVoid) {
+      if (erroneousTree.getBody().startsWith("@see http")) {
+        state.reportMatch(
+            describeMatch(
+                diagnosticPosition(getCurrentPath(), state),
+                replace(
+                    erroneousTree, erroneousTree.getBody().replaceFirst("@see", "See"), state)));
+      }
+      return super.visitErroneous(erroneousTree, aVoid);
+    }
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -398,6 +398,7 @@ import com.google.errorprone.bugpatterns.javadoc.InvalidThrows;
 import com.google.errorprone.bugpatterns.javadoc.MissingSummary;
 import com.google.errorprone.bugpatterns.javadoc.ReturnFromVoid;
 import com.google.errorprone.bugpatterns.javadoc.UnescapedEntity;
+import com.google.errorprone.bugpatterns.javadoc.UrlInSee;
 import com.google.errorprone.bugpatterns.nullness.EqualsBrokenForNull;
 import com.google.errorprone.bugpatterns.nullness.FieldMissingNullable;
 import com.google.errorprone.bugpatterns.nullness.NullableDereference;
@@ -930,6 +931,7 @@ public class BuiltInCheckerSuppliers {
           UnnecessarySetDefault.class,
           UnnecessaryStaticImport.class,
           UnusedException.class,
+          UrlInSee.class,
           VarChecker.class,
           WildcardImport.class,
           WrongParameterPackage.class

--- a/docs/bugpattern/AndroidJdkLibsChecker.md
+++ b/docs/bugpattern/AndroidJdkLibsChecker.md
@@ -1,0 +1,18 @@
+Code that needs to be compatible with Android cannot use types or members that
+only the latest or unreleased devices can handle
+
+## Suppression
+
+WARNING: We _strongly_ recommend checking your code with Android Lint if
+suppressing or disabling this check.
+
+The check can be suppressed in code that deliberately only targets newer Android
+SDK versions.
+
+To suppress for a particular statement, method, or class, use
+`@SuppressWarnings`:
+
+```
+@SuppressWarnings("AndroidJdkLibsChecker") // TODO({{USERNAME}}): document suppression
+```
+


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> UrlInSee: flag uses of `@see http...`.

@see is meant for Java element links, not HTTP links.

e46f6bb4d4ad56941badd00a1813d612632cb5a7

-------

<p> Document how to suppress AndroidJdkLibsChecker

(and suggest checking suppressed code with Android Lint)

920aa11eab4e73a4386a081a743e2e73d9b60076