### PR TITLE
MOE Sync 2020-03-30

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -630,7 +630,7 @@ public class SuggestedFixes {
     List<ErrorProneToken> methodTokens = state.getOffsetTokens(basePos, endPos);
     for (ErrorProneToken token : methodTokens) {
       if (token.kind() == TokenKind.IDENTIFIER && token.name().equals(tree.getName())) {
-        return SuggestedFix.builder().replace(token.pos(), token.endPos(), replacement).build();
+        return SuggestedFix.replace(token.pos(), token.endPos(), replacement);
       }
     }
     // Method name not found.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -298,7 +298,7 @@
       <!-- Apache 2.0 -->
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
-      <version>1.0-rc4</version>
+      <version>1.0-rc6</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ProtoFieldNullComparison.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ProtoFieldNullComparison.java
@@ -501,13 +501,11 @@ public class ProtoFieldNullComparison extends BugChecker implements CompilationU
             .map(
                 r -> {
                   MethodInvocationTree receiver = (MethodInvocationTree) getReceiver(tree);
-                  return SuggestedFix.builder()
-                      .replace(
-                          tree,
-                          String.format(
-                              "%s(%s).isTrue()",
-                              state.getSourceForNode(receiver.getMethodSelect()), r))
-                      .build();
+                  return SuggestedFix.replace(
+                      tree,
+                      String.format(
+                          "%s(%s).isTrue()",
+                          state.getSourceForNode(receiver.getMethodSelect()), r));
                 })
             .orElse(SuggestedFix.builder().build());
       }

--- a/core/src/main/java/com/google/errorprone/refaster/Inliner.java
+++ b/core/src/main/java/com/google/errorprone/refaster/Inliner.java
@@ -84,8 +84,7 @@ public final class Inliner {
       throws CouldNotResolveImportException {
     try {
       Symbol symbol =
-          JavaCompiler.instance(context)
-              .resolveIdent(symtab().java_base, qualifiedClass.toString());
+          JavaCompiler.instance(context).resolveBinaryNameOrIdent(qualifiedClass.toString());
       if (symbol.equals(symtab().errSymbol) || !(symbol instanceof ClassSymbol)) {
         throw new CouldNotResolveImportException(qualifiedClass);
       } else {

--- a/core/src/test/java/com/google/errorprone/refaster/AbstractUTreeTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/AbstractUTreeTest.java
@@ -20,11 +20,13 @@ import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.common.base.Joiner;
 import com.sun.tools.javac.file.JavacFileManager;
+import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.parser.Parser;
 import com.sun.tools.javac.parser.ParserFactory;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCIdent;
 import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.List;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
@@ -44,6 +46,8 @@ public abstract class AbstractUTreeTest {
   public void createContext() {
     context = new Context();
     JavacFileManager.preRegister(context);
+    JavaCompiler compiler = JavaCompiler.instance(context);
+    compiler.initModules(List.nil());
     unifier = new Unifier(context);
     inliner = unifier.createInliner();
   }

--- a/core/src/test/java/com/google/errorprone/refaster/DescriptionBasedDiffTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/DescriptionBasedDiffTest.java
@@ -145,20 +145,18 @@ public class DescriptionBasedDiffTest extends CompilerBasedTest {
                         .build())));
 
     DescriptionBasedDiff diff2 = createDescriptionBasedDiff();
-    diff2.onDescribed(dummyDescription(SuggestedFix.builder().replace(137, 140, "baz").build()));
+    diff2.onDescribed(dummyDescription(SuggestedFix.replace(137, 140, "baz")));
 
     assertThrows(
         IllegalArgumentException.class,
-        () ->
-            diff2.onDescribed(
-                dummyDescription(SuggestedFix.builder().replace(137, 140, "bar").build())));
+        () -> diff2.onDescribed(dummyDescription(SuggestedFix.replace(137, 140, "bar"))));
 
     DescriptionBasedDiff diff3 =
         DescriptionBasedDiff.createIgnoringOverlaps(
             compilationUnit, ImportOrganizer.STATIC_FIRST_ORGANIZER);
-    diff3.onDescribed(dummyDescription(SuggestedFix.builder().replace(137, 140, "baz").build()));
+    diff3.onDescribed(dummyDescription(SuggestedFix.replace(137, 140, "baz")));
     // No throw, since it's lenient. Refactors to the first "baz" replacement and ignores this.
-    diff3.onDescribed(dummyDescription(SuggestedFix.builder().replace(137, 140, "bar").build()));
+    diff3.onDescribed(dummyDescription(SuggestedFix.replace(137, 140, "bar")));
     diff3.applyDifferences(sourceFile);
 
     assertThat(sourceFile.getLines())

--- a/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
@@ -337,4 +337,9 @@ public class TemplateIntegrationTest extends CompilerBasedTest {
   public void unnecessaryLambdaParens() throws IOException {
     runTest("UnnecessaryLambdaParens");
   }
+
+  @Test
+  public void nonJdkType() throws IOException {
+    runTest("NonJdkTypeTemplate");
+  }
 }

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/input/NonJdkTypeTemplateExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/input/NonJdkTypeTemplateExample.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+import com.google.common.collect.ImmutableList;
+import java.util.stream.Stream;
+
+/** Test data for {@code NonJdkTypeTemplate}. */
+public class NonJdkTypeTemplateExample {
+  ImmutableList<Integer> example() {
+    return ImmutableList.copyOf(Stream.of(1).iterator());
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/output/NonJdkTypeTemplateExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/output/NonJdkTypeTemplateExample.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
+import java.util.stream.Stream;
+
+/** Test data for {@code NonJdkTypeTemplate}. */
+public class NonJdkTypeTemplateExample {
+  ImmutableList<Integer> example() {
+    return Stream.of(1).collect(toImmutableList());
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/template/NonJdkTypeTemplate.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/template/NonJdkTypeTemplate.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.errorprone.refaster.testdata.template;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.stream.Stream;
+
+/** Example template that uses a non-JDK type. */
+public class NonJdkTypeTemplate<T> {
+  @BeforeTemplate
+  public ImmutableList<T> before(Stream<T> stream) {
+    return ImmutableList.copyOf(stream.iterator());
+  }
+
+  @AfterTemplate
+  @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+  public ImmutableList<T> after(Stream<T> stream) {
+    return stream.collect(toImmutableList());
+  }
+}

--- a/docgen/pom.xml
+++ b/docgen/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
-      <version>1.0-rc2</version>
+      <version>1.0-rc6</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/docgen_processor/pom.xml
+++ b/docgen_processor/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
-      <version>1.0-rc2</version>
+      <version>1.0-rc6</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/refaster/pom.xml
+++ b/refaster/pom.xml
@@ -52,7 +52,7 @@
             <!-- Apache 2.0 -->
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>
-            <version>1.0-rc2</version>
+            <version>1.0-rc6</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Simplify SuggestedFix creation using the static factories.

2be87f55cc07ff6f74f6dd5bf86b0f17b25ec949

-------

<p> Have Refaster resolve classes against the appropriate modules

Looking up classes only in java.base seems to work fine on JDK 8, but fails on
JDK 9+. This causes Refaster templates that reference non-JDK types to silently
not match in places where they should. By resolving classes against the
appropriate modules the problem goes away.

Prior to this change the newly added test would pass when executed on JDK 8,

Fixes #1239

526440dbeb0ace53ad3a2c7f397ec939b71719b1

-------

<p> bump auto-service to 1.0-rc6, the newest version

Fixes #1531

6dcd0ce702729df0058391a0314f1440ef614e71