### PR TITLE
skip unnecessary boxing

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/BigDecimalLiteralDouble.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BigDecimalLiteralDouble.java
@@ -88,7 +88,7 @@ public class BigDecimalLiteralDouble extends BugChecker implements NewClassTreeM
     if (literalNumber == null) {
       return Description.NO_MATCH;
     }
-    Double literal = literalNumber.doubleValue();
+    double literal = literalNumber.doubleValue();
 
     // Strip off 'd', 'f' suffixes and _ separators from the source.
     String literalString = state.getSourceForNode(arg).replaceAll("[_dDfF]", "");


### PR DESCRIPTION
Fixes this warning:

https://lgtm.com/projects/g/google/error-prone/snapshot/51e13bbcddc1364f574728a1d1ab9b341a18ff70/files/core/src/main/java/com/google/errorprone/bugpatterns/BigDecimalLiteralDouble.java?sort=name&dir=ASC&mode=heatmap