### PR TITLE
MOE Sync 2020-04-08

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/SideEffectAnalysis.java
+++ b/check_api/src/main/java/com/google/errorprone/util/SideEffectAnalysis.java
@@ -19,7 +19,6 @@ package com.google.errorprone.util;
 import com.sun.source.tree.CompoundAssignmentTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
-import com.sun.source.tree.NewArrayTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.UnaryTree;
 import com.sun.source.util.TreeScanner;
@@ -36,7 +35,6 @@ import com.sun.tools.javac.tree.JCTree.JCUnary;
  *   <li>Any function call: toString(), hashCode(), setX(value), etc.
  *   <li>Unary expression: i += 1, i++, --j
  *   <li>New expression: new SomeClass()
- *   <li>New array: new int[10]
  * </ul>
  *
  * <p>Everything besides the above examples is considered side-effect free.
@@ -71,12 +69,6 @@ public final class SideEffectAnalysis extends TreeScanner<Void, Void> {
 
   @Override
   public Void visitMethodInvocation(MethodInvocationTree tree, Void unused) {
-    hasSideEffect = true;
-    return null;
-  }
-
-  @Override
-  public Void visitNewArray(NewArrayTree tree, Void unused) {
     hasSideEffect = true;
     return null;
   }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ArrayHashCode.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ArrayHashCode.java
@@ -65,7 +65,6 @@ public class ArrayHashCode extends BugChecker implements MethodInvocationTreeMat
    * Matches calls to the JDK7 method {@link java.util.Objects#hashCode} with an argument of array
    * type. This method is not varargs, so we don't need to check the number of arguments.
    */
-  @SuppressWarnings({"unchecked"})
   private static final Matcher<MethodInvocationTree> jdk7HashCodeMethodMatcher =
       allOf(
           staticMethod().onClass("java.util.Objects").named("hashCode"),

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DefaultPackage.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DefaultPackage.java
@@ -33,6 +33,7 @@ import com.sun.source.tree.CompilationUnitTree;
 @BugPattern(
     name = "DefaultPackage",
     summary = "Java classes shouldn't use default package",
+    documentSuppression = false,
     severity = WARNING)
 public final class DefaultPackage extends BugChecker implements CompilationUnitTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JUnitAssertSameCheck.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JUnitAssertSameCheck.java
@@ -50,7 +50,6 @@ public class JUnitAssertSameCheck extends BugChecker implements MethodInvocation
    *   <li>junit.framework.Assert.assertSame("message", a, a);
    * </ol>
    */
-  @SuppressWarnings({"unchecked"})
   private static final Matcher<ExpressionTree> ASSERT_SAME_MATCHER =
       staticMethod().onClassAny("org.junit.Assert", "junit.framework.Assert").named("assertSame");
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SuppressWarningsDeprecated.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SuppressWarningsDeprecated.java
@@ -42,7 +42,7 @@ import java.util.List;
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
 public class SuppressWarningsDeprecated extends AbstractSuppressWarningsMatcher {
 
-  @SuppressWarnings({"varargs", "unchecked"})
+  @SuppressWarnings("varargs")
   private static final Matcher<AnnotationTree> matcher =
       allOf(
           isType("java.lang.SuppressWarnings"),

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MutablePublicArrayTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MutablePublicArrayTest.java
@@ -146,4 +146,17 @@ public class MutablePublicArrayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void negative_datapoints() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.junit.experimental.theories.DataPoints;",
+            "class Test {",
+            "  @DataPoints",
+            "  public static final int[] array = new int[10];",
+            "}")
+        .doTest();
+  }
 }

--- a/docs/bugpattern/DefaultPackage.md
+++ b/docs/bugpattern/DefaultPackage.md
@@ -1,0 +1,2 @@
+Declaring classes in the default package is discouraged.
+


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Disable MutablePublicArray for @DataPoints-annotated fields

d42b02834890631b88f3a34a0eaa0180ca69cb8e

-------

<p> Add a new utility function to remove a warning from SuppressWarning or remove the entire SuppressWarning annotation itself.

e3d6667f71c99867fa0b6cf537fe6d44d2dd2cb5

-------

<p> Document DefaultPackage suppression

5b0d6b679a17597670e4911fe4fa8ffde823a27f

-------

<p> Make hasSideEffect a little choosier.

Creating an array isn't itself a side effect. Instead, we just recurse
into the array initializers to see if any of them are side effectful.

4043e5b7e64f4e8c0a4c2445337042e74668c6d2

-------

<p> Remove unnecessarily suppressed warnings: unchecked

RELNOTES: Remove unnecessarily suppressed warnings: unchecked

0fd2467c504090deca0a7960392765408f0499e4