### PR TITLE
MOE Sync 2020-04-09

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/Matchers.java
@@ -1256,7 +1256,11 @@ public class Matchers {
     return stream(state.getPath())
         // Find the nearest definitional context for this method invocation
         // (i.e.: the nearest surrounding class or lambda)
-        .filter(t -> t.getKind() == Kind.LAMBDA_EXPRESSION || t.getKind() == Kind.CLASS)
+        .filter(
+            t ->
+                t.getKind() == Kind.LAMBDA_EXPRESSION
+                    || t.getKind() == Kind.CLASS
+                    || t.getKind() == Kind.ENUM)
         .findFirst()
         .map(t -> isThrowingFunctionalInterface(getType(t), state))
         .orElseThrow(VerifyException::new);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AnnotateFormatMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AnnotateFormatMethod.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.MoreCollectors.toOptional;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.BugPattern.StandardTags.FRAGILE_CODE;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
@@ -52,9 +51,8 @@ import javax.annotation.Nullable;
         "This method passes a pair of parameters through to String.format, but the enclosing"
             + " method wasn't annotated @FormatMethod. Doing so gives compile-time rather than"
             + " run-time protection against malformed format strings.",
-    severity = WARNING,
     tags = FRAGILE_CODE,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class AnnotateFormatMethod extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final String REORDER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AnnotationPosition.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AnnotationPosition.java
@@ -31,7 +31,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -74,8 +73,8 @@ import javax.lang.model.element.Name;
     severity = WARNING,
     tags = STYLE,
     linkType = CUSTOM,
-    link = "https://google.github.io/styleguide/javaguide.html#s4.8.5-annotations",
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    link = "https://google.github.io/styleguide/javaguide.html#s4.8.5-annotations"
+    )
 public final class AnnotationPosition extends BugChecker
     implements ClassTreeMatcher, MethodTreeMatcher, VariableTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ArrayEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ArrayEquals.java
@@ -26,7 +26,6 @@ import static com.google.errorprone.matchers.Matchers.staticEqualsInvocation;
 import static com.google.errorprone.predicates.TypePredicates.isArray;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -40,8 +39,7 @@ import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 @BugPattern(
     name = "ArrayEquals",
     summary = "Reference equality used to compare arrays",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class ArrayEquals extends BugChecker implements MethodInvocationTreeMatcher {
   /** Matches when the equals instance method is used to compare two arrays. */
   private static final Matcher<MethodInvocationTree> instanceEqualsMatcher =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ArrayHashCode.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ArrayHashCode.java
@@ -26,7 +26,6 @@ import static com.google.errorprone.predicates.TypePredicates.isArray;
 
 import com.google.common.base.Preconditions;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -46,8 +45,7 @@ import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
     name = "ArrayHashCode",
     summary = "hashcode method on array does not hash array contents",
     severity = ERROR,
-    generateExamplesFromTestCases = false,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    generateExamplesFromTestCases = false)
 public class ArrayHashCode extends BugChecker implements MethodInvocationTreeMatcher {
 
   /**

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ArraysAsListPrimitiveArray.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ArraysAsListPrimitiveArray.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.matchers.Matchers.staticMethod;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -44,8 +43,7 @@ import javax.lang.model.type.TypeKind;
 @BugPattern(
     name = "ArraysAsListPrimitiveArray",
     summary = "Arrays.asList does not autobox primitive arrays, as one might expect.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class ArraysAsListPrimitiveArray extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<MethodInvocationTree> ARRAYS_AS_LIST_SINGLE_ARRAY =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AssertFalse.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AssertFalse.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.matchers.Matchers.assertionWithCondition;
 import static com.google.errorprone.matchers.Matchers.booleanLiteral;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.AssertTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -35,8 +34,7 @@ import com.sun.source.tree.AssertTree;
     summary =
         "Assertions may be disabled at runtime and do not guarantee that execution will "
             + "halt here; consider throwing an exception instead",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class AssertFalse extends BugChecker implements AssertTreeMatcher {
 
   private static final Matcher<AssertTree> ASSERT_FALSE_MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AssertThrowsMultipleStatements.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AssertThrowsMultipleStatements.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -42,8 +41,7 @@ import java.util.List;
 @BugPattern(
     name = "AssertThrowsMultipleStatements",
     summary = "The lambda passed to assertThrows should contain exactly one statement",
-    severity = SeverityLevel.WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SeverityLevel.WARNING)
 public class AssertThrowsMultipleStatements extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AssignmentToMock.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AssignmentToMock.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.ChildMultiMatcher.MatchType.AT_LEAST_ONE;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -57,8 +56,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @BugPattern(
     name = "AssignmentToMock",
     summary = "Fields annotated with @Mock should not be manually assigned to.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class AssignmentToMock extends BugChecker
     implements AssignmentTreeMatcher, VariableTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AutoValueFinalMethods.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AutoValueFinalMethods.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.matchers.Matchers.not;
 
 import com.google.common.base.Joiner;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -51,8 +50,7 @@ import javax.lang.model.element.Modifier;
     summary =
         "Make toString(), hashCode() and equals() final in AutoValue classes"
             + ", so it is clear to readers that AutoValue is not overriding them",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class AutoValueFinalMethods extends BugChecker implements ClassTreeMatcher {
 
   private static final String MEMOIZED = "com.google.auto.value.extension.memoized.Memoized";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/AutoValueImmutableFields.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AutoValueImmutableFields.java
@@ -25,7 +25,6 @@ import static com.google.errorprone.suppliers.Suppliers.typeFromString;
 
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.matchers.Description;
@@ -47,7 +46,6 @@ import javax.lang.model.element.Modifier;
     altNames = "mutable",
     summary = "AutoValue recommends using immutable collections",
     severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
     documentSuppression = false)
 public class AutoValueImmutableFields extends BugChecker implements ClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadComparable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadComparable.java
@@ -27,7 +27,6 @@ import static com.google.errorprone.matchers.MethodVisibility.Visibility.PUBLIC;
 import static com.google.errorprone.suppliers.Suppliers.INT_TYPE;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.TypeCastTreeMatcher;
@@ -50,8 +49,7 @@ import com.sun.tools.javac.code.TypeTag;
     name = "BadComparable",
     summary = "Possible sign flip from narrowing conversion",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public class BadComparable extends BugChecker implements TypeCastTreeMatcher {
   /** Matcher for the overriding method of 'int java.lang.Comparable.compareTo(T other)' */
   private static final Matcher<MethodTree> COMPARABLE_METHOD_MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.matchers.Matchers.annotations;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ImportTreeMatcher;
 import com.google.errorprone.bugpatterns.StaticImports.StaticImportInfo;
@@ -55,8 +54,7 @@ import javax.lang.model.element.Name;
             + "code harder to read, because it may not be clear from the context exactly which "
             + "type is being referred to. Qualifying the name with that of the containing class "
             + "can make the code clearer.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class BadImport extends BugChecker implements ImportTreeMatcher {
 
   private static final ImmutableSet<String> BAD_NESTED_CLASSES =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadInstanceof.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadInstanceof.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.BugPattern.StandardTags.SIMPLIFICATION;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -43,8 +42,7 @@ import com.sun.source.tree.Tree.Kind;
     name = "BadInstanceof",
     summary = "instanceof used in a way that is equivalent to a null check.",
     severity = WARNING,
-    tags = SIMPLIFICATION,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    tags = SIMPLIFICATION)
 public final class BadInstanceof extends BugChecker implements InstanceOfTreeMatcher {
 
   private static final String NON_NULL =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadShiftAmount.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadShiftAmount.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.kindIs;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -45,8 +44,7 @@ import com.sun.tools.javac.code.Types;
 @BugPattern(
     name = "BadShiftAmount",
     summary = "Shift by an amount that is out of range",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class BadShiftAmount extends BugChecker implements BinaryTreeMatcher {
 
   /**

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BigDecimalEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BigDecimalEquals.java
@@ -27,7 +27,6 @@ import static com.google.errorprone.util.ASTHelpers.getType;
 import static com.google.errorprone.util.ASTHelpers.isSameType;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
@@ -47,8 +46,7 @@ import java.util.List;
 @BugPattern(
     name = "BigDecimalEquals",
     summary = "BigDecimal#equals has surprising behavior: it also compares scale.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class BigDecimalEquals extends BugChecker implements MethodInvocationTreeMatcher {
   private static final String BIG_DECIMAL = "java.math.BigDecimal";
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BigDecimalLiteralDouble.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BigDecimalLiteralDouble.java
@@ -20,7 +20,6 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -44,8 +43,7 @@ import java.util.Optional;
 @BugPattern(
     name = "BigDecimalLiteralDouble",
     summary = "new BigDecimal(double) loses precision in this case.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class BigDecimalLiteralDouble extends BugChecker implements NewClassTreeMatcher {
 
   private static final String ACTUAL_VALUE = " The exact value here is `new BigDecimal(\"%s\")`.";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BooleanParameter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BooleanParameter.java
@@ -26,7 +26,6 @@ import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
@@ -54,8 +53,7 @@ import java.util.List;
 @BugPattern(
     name = "BooleanParameter",
     summary = "Use parameter comments to document ambiguous literals",
-    severity = SUGGESTION,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public class BooleanParameter extends BugChecker
     implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BoxedPrimitiveConstructor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BoxedPrimitiveConstructor.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.util.ASTHelpers.getType;
 import static com.google.errorprone.util.ASTHelpers.isSameType;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
@@ -52,8 +51,7 @@ import com.sun.tools.javac.util.Context;
     name = "BoxedPrimitiveConstructor",
     summary = "valueOf or autoboxing provides better time and space performance",
     severity = SeverityLevel.WARNING,
-    tags = StandardTags.PERFORMANCE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.PERFORMANCE)
 public class BoxedPrimitiveConstructor extends BugChecker implements NewClassTreeMatcher {
 
   private static final Matcher<Tree> TO_STRING =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CanonicalDuration.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CanonicalDuration.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
@@ -57,8 +56,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @BugPattern(
     name = "CanonicalDuration",
     summary = "Duration can be expressed more clearly with different units",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class CanonicalDuration extends BugChecker implements MethodInvocationTreeMatcher {
 
   enum Api {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CatchFail.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CatchFail.java
@@ -28,7 +28,6 @@ import static java.util.stream.Collectors.joining;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.TryTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -67,8 +66,7 @@ import java.util.stream.Stream;
     name = "CatchFail",
     summary =
         "Ignoring exceptions and calling fail() is unnecessary, and makes test output less useful",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class CatchFail extends BugChecker implements TryTreeMatcher {
 
   public static final Matcher<ExpressionTree> ASSERT_WITH_MESSAGE =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ChainedAssertionLosesContext.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ChainedAssertionLosesContext.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.bugpatterns.ImplementAssertionWithChaining.makeCheckDescription;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -72,8 +71,7 @@ import javax.annotation.Nullable;
     summary =
         "Inside a Subject, use check(...) instead of assert*() to preserve user-supplied messages"
             + " and other settings.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class ChainedAssertionLosesContext extends BugChecker
     implements MethodInvocationTreeMatcher {
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ChainingConstructorIgnoresParameter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ChainingConstructorIgnoresParameter.java
@@ -29,7 +29,6 @@ import static java.util.Collections.unmodifiableList;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -71,8 +70,7 @@ import java.util.Map;
     summary =
         "The called constructor accepts a parameter with the same name and type as one of "
             + "its caller's parameters, but its caller doesn't pass that parameter to it.  It's "
-            + "likely that it was intended to.",
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+            + "likely that it was intended to.")
 public final class ChainingConstructorIgnoresParameter extends BugChecker
     implements CompilationUnitTreeMatcher, MethodInvocationTreeMatcher, MethodTreeMatcher {
   private final Map<MethodSymbol, List<VariableTree>> paramTypesForMethod = newHashMap();

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CheckNotNullMultipleTimes.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CheckNotNullMultipleTimes.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
@@ -52,8 +51,7 @@ import java.util.Map;
 @BugPattern(
     name = "CheckNotNullMultipleTimes",
     severity = ERROR,
-    summary = "A variable was checkNotNulled multiple times. Did you mean to check something else?",
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    summary = "A variable was checkNotNulled multiple times. Did you mean to check something else?")
 public final class CheckNotNullMultipleTimes extends BugChecker implements MethodTreeMatcher {
 
   private static final Matcher<ExpressionTree> CHECK_NOT_NULL =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassCanBeStatic.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassCanBeStatic.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
@@ -40,8 +39,7 @@ import javax.lang.model.element.NestingKind;
     name = "ClassCanBeStatic",
     summary = "Inner class is non-static but does not reference enclosing class",
     severity = WARNING,
-    tags = {StandardTags.STYLE, StandardTags.PERFORMANCE},
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = {StandardTags.STYLE, StandardTags.PERFORMANCE})
 public class ClassCanBeStatic extends BugChecker implements ClassTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassNewInstance.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassNewInstance.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -62,8 +61,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
         "Class.newInstance() bypasses exception checking; prefer"
             + " getDeclaredConstructor().newInstance()",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public class ClassNewInstance extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> NEW_INSTANCE =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CompareToZero.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CompareToZero.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -48,7 +47,6 @@ import com.sun.source.util.TreePath;
         "The result of #compareTo or #compare should only be compared to 0. It is an "
             + "implementation detail whether a given type returns strictly the values {-1, 0, +1} "
             + "or others.",
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     severity = WARNING)
 public final class CompareToZero extends BugChecker implements MethodInvocationTreeMatcher {
   private static final String SUGGEST_IMPROVEMENT =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ComparingThisWithNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ComparingThisWithNull.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
 import com.google.errorprone.matchers.Description;
@@ -37,8 +36,7 @@ import com.sun.source.tree.Tree.Kind;
     explanation =
         "The boolean expression this != null always returns true"
             + " and similarly this == null always returns false.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class ComparingThisWithNull extends BugChecker implements BinaryTreeMatcher {
 
   private static final Matcher<BinaryTree> EQUAL_OR_NOT_EQUAL =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ComparisonContractViolated.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ComparisonContractViolated.java
@@ -26,7 +26,6 @@ import static com.google.errorprone.matchers.MethodVisibility.Visibility.PUBLIC;
 import static com.google.errorprone.suppliers.Suppliers.INT_TYPE;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -60,8 +59,7 @@ import java.util.Set;
 @BugPattern(
     name = "ComparisonContractViolated",
     summary = "This comparison method violates the contract",
-    severity = SeverityLevel.ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SeverityLevel.ERROR)
 public class ComparisonContractViolated extends BugChecker implements MethodTreeMatcher {
   /** Matcher for the overriding method of 'int java.lang.Comparable.compareTo(T other)' */
   private static final Matcher<MethodTree> COMPARABLE_METHOD_MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ComparisonOutOfRange.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ComparisonOutOfRange.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -58,8 +57,7 @@ import java.util.List;
             + "outside that range will always evaluate to false and usually indicates an error in "
             + "the code.\n\n"
             + "This checker currently supports checking for bad byte and character comparisons.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class ComparisonOutOfRange extends BugChecker implements BinaryTreeMatcher {
 
   private static final String MESSAGE_TEMPLATE =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ComplexBooleanConstant.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ComplexBooleanConstant.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
@@ -35,8 +34,7 @@ import java.util.Objects;
 @BugPattern(
     name = "ComplexBooleanConstant",
     summary = "Non-trivial compile time constant boolean expressions shouldn't be used.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class ComplexBooleanConstant extends BugChecker implements BinaryTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ConditionalExpressionNumericPromotion.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ConditionalExpressionNumericPromotion.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ConditionalExpressionTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -40,8 +39,7 @@ import com.sun.tools.javac.code.Type;
         "A conditional expression with numeric operands of differing types will perform binary "
             + "numeric promotion of the operands; when these operands are of reference types, "
             + "the expression's result may not be of the expected type.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class ConditionalExpressionNumericPromotion extends BugChecker
     implements ConditionalExpressionTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ConstantField.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ConstantField.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import com.google.common.base.Ascii;
 import com.google.common.base.CaseFormat;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -39,9 +38,7 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "ConstantField",
     summary = "Field name is CONSTANT_CASE, but field is not static and final",
-    severity = SUGGESTION,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION
-    )
+    severity = SUGGESTION)
 public class ConstantField extends BugChecker implements VariableTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ConstantOverflow.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ConstantOverflow.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.util.ASTHelpers.isSameType;
 import com.google.common.math.IntMath;
 import com.google.common.math.LongMath;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -53,8 +52,7 @@ import javax.lang.model.type.TypeKind;
 @BugPattern(
     name = "ConstantOverflow",
     summary = "Compile-time constant expression overflows",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class ConstantOverflow extends BugChecker implements BinaryTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ConstantPatternCompile.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ConstantPatternCompile.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
@@ -57,8 +56,7 @@ import javax.lang.model.element.NestingKind;
 @BugPattern(
     name = "ConstantPatternCompile",
     summary = "Variables initialized with Pattern#compile calls on constants can be constants",
-    severity = SUGGESTION,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public final class ConstantPatternCompile extends BugChecker implements VariableTreeMatcher {
 
   private static final String PATTERN_CLASS = "java.util.regex.Pattern";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DateFormatConstant.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DateFormatConstant.java
@@ -25,7 +25,6 @@ import static com.google.errorprone.util.ASTHelpers.isSubtype;
 import com.google.common.base.Ascii;
 import com.google.common.base.CaseFormat;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
@@ -47,8 +46,7 @@ import javax.lang.model.element.Modifier;
     name = "DateFormatConstant",
     summary = "DateFormat is not thread-safe, and should not be used as a constant field.",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public class DateFormatConstant extends BugChecker implements VariableTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DeadException.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DeadException.java
@@ -30,7 +30,6 @@ import static com.sun.source.tree.Tree.Kind.IF;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -52,8 +51,7 @@ import com.sun.source.tree.Tree;
     name = "DeadException",
     altNames = "ThrowableInstanceNeverThrown",
     summary = "Exception created but not thrown",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class DeadException extends BugChecker implements NewClassTreeMatcher {
 
   public static final Matcher<Tree> MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DeadThread.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DeadThread.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.method.MethodMatchers.constructor;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -32,11 +31,7 @@ import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree.Kind;
 
 /** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
-@BugPattern(
-    name = "DeadThread",
-    summary = "Thread created but not started",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+@BugPattern(name = "DeadThread", summary = "Thread created but not started", severity = ERROR)
 public class DeadThread extends BugChecker implements NewClassTreeMatcher {
 
   private static final Matcher<ExpressionTree> NEW_THREAD =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DeduplicateConstants.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DeduplicateConstants.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.util.ASTHelpers.isConsideredFinal;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -52,8 +51,7 @@ import java.util.Set;
     summary =
         "This expression was previously declared as a constant;"
             + " consider replacing this occurrence.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class DeduplicateConstants extends BugChecker implements CompilationUnitTreeMatcher {
 
   /** A lexical scope for constant declarations. */

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DefaultCharset.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DefaultCharset.java
@@ -28,7 +28,6 @@ import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -77,8 +76,7 @@ import java.util.Scanner;
             + " between JVM executions or incorrect behavior if the encoding of the data source"
             + " doesn't match expectations.",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public class DefaultCharset extends BugChecker
     implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DepAnn.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DepAnn.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.sun.tools.javac.code.Flags.DEPRECATED;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -43,8 +42,7 @@ import com.sun.tools.javac.code.Symbol;
     name = "DepAnn",
     altNames = "dep-ann",
     summary = "Item documented with a @deprecated javadoc note is not annotated with @Deprecated",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class DepAnn extends BugChecker
     implements MethodTreeMatcher, ClassTreeMatcher, VariableTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DescribeMatch.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DescribeMatch.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.matchers.method.MethodMatchers.instanceMetho
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -41,8 +40,7 @@ import com.sun.source.tree.MethodInvocationTree;
     summary =
         "`describeMatch(tree, fix)` is equivalent to and simpler than"
             + " `buildDescription(tree).addFix(fix).build()`",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class DescribeMatch extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> BUILD_DESCRIPTION =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DiscardedPostfixExpression.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DiscardedPostfixExpression.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.UnaryTreeMatcher;
@@ -36,8 +35,7 @@ import com.sun.tools.javac.tree.JCTree.JCLambda;
 @BugPattern(
     name = "DiscardedPostfixExpression",
     summary = "The result of this unary operation on a lambda parameter is discarded",
-    severity = SeverityLevel.ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SeverityLevel.ERROR)
 public class DiscardedPostfixExpression extends BugChecker implements UnaryTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DivZero.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DivZero.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.kindIs;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.CompoundAssignmentTreeMatcher;
@@ -45,8 +44,7 @@ import com.sun.source.tree.Tree.Kind;
     name = "DivZero",
     altNames = "divzero",
     summary = "Division by integer literal zero",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class DivZero extends BugChecker
     implements BinaryTreeMatcher, CompoundAssignmentTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DoNotCallChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DoNotCallChecker.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.util.ASTHelpers.hasAnnotation;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MemberReferenceTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -48,11 +47,7 @@ import javax.lang.model.element.Modifier;
 
 /** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 // TODO(cushon): this should subsume ImmutableModification and LocalizableWrongToString
-@BugPattern(
-    name = "DoNotCall",
-    summary = "This method should not be called.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+@BugPattern(name = "DoNotCall", summary = "This method should not be called.", severity = ERROR)
 public class DoNotCallChecker extends BugChecker
     implements MethodTreeMatcher, MethodInvocationTreeMatcher, MemberReferenceTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DuplicateMapKeys.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DuplicateMapKeys.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
@@ -40,8 +39,7 @@ import java.util.Set;
     name = "DuplicateMapKeys",
     summary =
         "Map#ofEntries will throw an IllegalArgumentException if there are any duplicate keys",
-    severity = ERROR,
-    providesFix = ProvidesFix.NO_FIX)
+    severity = ERROR)
 public class DuplicateMapKeys extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> METHOD_MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EmptyIfStatement.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EmptyIfStatement.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.isLastStatementInBlock;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.EmptyStatementTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -44,8 +43,7 @@ import com.sun.source.util.TreePath;
     name = "EmptyIf",
     altNames = {"empty"},
     summary = "Empty statement after if",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class EmptyIfStatement extends BugChecker implements EmptyStatementTreeMatcher {
 
   /**

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EmptyTopLevelDeclaration.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EmptyTopLevelDeclaration.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -33,8 +32,7 @@ import java.util.List;
 @BugPattern(
     name = "EmptyTopLevelDeclaration",
     summary = "Empty top-level type declaration",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class EmptyTopLevelDeclaration extends BugChecker implements CompilationUnitTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EqualsGetClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EqualsGetClass.java
@@ -26,7 +26,6 @@ import static com.google.errorprone.util.ASTHelpers.getReceiver;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -67,8 +66,7 @@ import javax.lang.model.element.Modifier;
         "Overriding Object#equals in a non-final class by using getClass rather than instanceof "
             + "breaks substitutability of subclasses.",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public final class EqualsGetClass extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> GET_CLASS =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EqualsNaN.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EqualsNaN.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -36,8 +35,7 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "EqualsNaN",
     summary = "== NaN always returns false; use the isNaN methods instead",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class EqualsNaN extends BugChecker implements BinaryTreeMatcher {
   @Override
   public Description matchBinary(BinaryTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EqualsUnsafeCast.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EqualsUnsafeCast.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.equalsMethodDeclaration;
@@ -54,7 +53,6 @@ import java.util.List;
     summary =
         "The contract of #equals states that it should return false for incompatible types, "
             + "while this implementation may throw ClassCastException.",
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     severity = WARNING)
 public final class EqualsUnsafeCast extends BugChecker implements MethodTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EqualsUsingHashCode.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EqualsUsingHashCode.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.matchers.Matchers.equalsMethodDeclaration;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -48,8 +47,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
         "Implementing #equals by just comparing hashCodes is fragile. Hashes collide "
             + "frequently, and this will lead to false positives in #equals.",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public final class EqualsUsingHashCode extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EqualsWrongThing.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EqualsWrongThing.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -60,7 +59,6 @@ import javax.lang.model.element.ElementKind;
     summary =
         "Comparing different pairs of fields/getters in an equals implementation is probably "
             + "a mistake.",
-    providesFix = NO_FIX,
     severity = ERROR)
 public final class EqualsWrongThing extends BugChecker implements MethodTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ExtendingJUnitAssert.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ExtendingJUnitAssert.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -43,8 +42,7 @@ import java.util.List;
     summary =
         "When only using JUnit Assert's static methods, "
             + "you should import statically instead of extending.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class ExtendingJUnitAssert extends BugChecker implements ClassTreeMatcher {
 
   private static final Matcher<ExpressionTree> STATIC_ASSERT =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeFinal.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeFinal.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.util.ASTHelpers.hasAnnotation;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFixes;
@@ -56,8 +55,7 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "FieldCanBeFinal",
     summary = "This field is only assigned during initialization; consider making it final",
-    severity = SUGGESTION,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public class FieldCanBeFinal extends BugChecker implements CompilationUnitTreeMatcher {
 
   /** Annotations that imply a field is non-constant. */

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeLocal.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FieldCanBeLocal.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.util.ASTHelpers.getAnnotation;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
@@ -65,7 +64,6 @@ import javax.lang.model.element.ElementKind;
     altNames = {"unused", "Unused"},
     summary = "This field can be replaced with a local variable in the methods that use it.",
     severity = SUGGESTION,
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     documentSuppression = false)
 public final class FieldCanBeLocal extends BugChecker implements CompilationUnitTreeMatcher {
   private static final ImmutableSet<ElementType> VALID_ON_LOCAL_VARIABLES =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FloatCast.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FloatCast.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 import static com.google.errorprone.util.ASTHelpers.isSameType;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.TypeCastTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -46,8 +45,7 @@ import javax.lang.model.type.TypeKind;
 @BugPattern(
     name = "FloatCast",
     summary = "Use parentheses to make the precedence explicit",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class FloatCast extends BugChecker implements TypeCastTreeMatcher {
 
   static final Set<TypeKind> FLOATING_POINT = EnumSet.of(TypeKind.FLOAT, TypeKind.DOUBLE);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FloatingPointAssertionWithinEpsilon.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FloatingPointAssertionWithinEpsilon.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.matchers.method.MethodMatchers.instanceMetho
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -54,8 +53,7 @@ import java.util.Optional;
         "This fuzzy equality check is using a tolerance less than the gap to the next number. "
             + "You may want a less restrictive tolerance, or to assert equality.",
     severity = WARNING,
-    tags = StandardTags.SIMPLIFICATION,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.SIMPLIFICATION)
 public final class FloatingPointAssertionWithinEpsilon extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FloatingPointLiteralPrecision.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FloatingPointLiteralPrecision.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.util.ASTHelpers.constValue;
 
 import com.google.common.base.CharMatcher;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.LiteralTreeMatcher;
@@ -38,8 +37,7 @@ import java.math.BigDecimal;
     name = "FloatingPointLiteralPrecision",
     summary = "Floating point literal loses precision",
     severity = WARNING,
-    tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.STYLE)
 public class FloatingPointLiteralPrecision extends BugChecker implements LiteralTreeMatcher {
 
   /*

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FuturesGetCheckedIllegalExceptionType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FuturesGetCheckedIllegalExceptionType.java
@@ -30,7 +30,6 @@ import static javax.lang.model.element.Modifier.PUBLIC;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Futures;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -56,8 +55,7 @@ import java.util.List;
 @BugPattern(
     name = "FuturesGetCheckedIllegalExceptionType",
     summary = "Futures.getChecked requires a checked exception type with a standard constructor.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public final class FuturesGetCheckedIllegalExceptionType extends BugChecker
     implements MethodInvocationTreeMatcher {
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnAnnotation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnAnnotation.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
@@ -34,8 +33,7 @@ import java.lang.annotation.Annotation;
 @BugPattern(
     name = "GetClassOnAnnotation",
     summary = "Calling getClass() on an annotation may return a proxy class",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class GetClassOnAnnotation extends BugChecker
     implements BugChecker.MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnClass.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -40,8 +39,7 @@ import com.sun.source.tree.MethodInvocationTree;
     summary =
         "Calling getClass() on an object of type Class returns the Class object for "
             + "java.lang.Class; you probably meant to operate on the object directly",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class GetClassOnClass extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> getClassMethodMatcher =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnEnum.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/GetClassOnEnum.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -35,8 +34,7 @@ import com.sun.source.tree.MethodInvocationTree;
     name = "GetClassOnEnum",
     summary = "Calling getClass() on an enum may return a subclass of the enum type",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public class GetClassOnEnum extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> ENUM_CLASS =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/HashtableContains.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/HashtableContains.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.method.MethodMatchers.instanceMetho
 
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -43,8 +42,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @BugPattern(
     name = "HashtableContains",
     summary = "contains() is a legacy method that is equivalent to containsValue()",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class HashtableContains extends BugChecker implements MethodInvocationTreeMatcher {
 
   static final Matcher<ExpressionTree> CONTAINS_MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ImplementAssertionWithChaining.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ImplementAssertionWithChaining.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.fixes.SuggestedFix.replace;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -74,8 +73,7 @@ import java.util.regex.Pattern;
 @BugPattern(
     name = "ImplementAssertionWithChaining",
     summary = "Prefer check(...), which usually generates more readable failure messages.",
-    severity = SUGGESTION,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public final class ImplementAssertionWithChaining extends BugChecker implements IfTreeMatcher {
   @Override
   public Description matchIf(IfTree ifTree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IncompatibleModifiersChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IncompatibleModifiersChecker.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.annotations.IncompatibleModifiers;
@@ -48,8 +47,7 @@ import javax.lang.model.element.TypeElement;
             + "@IncompatibleModifiers annotation",
     linkType = NONE,
     severity = ERROR,
-    tags = StandardTags.LIKELY_ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.LIKELY_ERROR)
 
 // TODO(cushon): merge the implementation with RequiredModifiersChecker
 public class IncompatibleModifiersChecker extends BugChecker implements AnnotationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InconsistentCapitalization.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InconsistentCapitalization.java
@@ -23,7 +23,6 @@ import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -49,8 +48,7 @@ import javax.lang.model.element.ElementKind;
         "It is confusing to have a field and a parameter under the same scope that differ only in "
             + "capitalization.",
     severity = WARNING,
-    generateExamplesFromTestCases = false,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    generateExamplesFromTestCases = false)
 public class InconsistentCapitalization extends BugChecker implements ClassTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InconsistentHashCode.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InconsistentHashCode.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
@@ -66,8 +65,7 @@ import javax.lang.model.element.ElementKind;
         "Including fields in hashCode which are not compared in equals violates "
             + "the contract of hashCode.",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public final class InconsistentHashCode extends BugChecker implements ClassTreeMatcher {
 
   public static final String MESSAGE =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IndexOfChar.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IndexOfChar.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getType;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -42,8 +41,7 @@ import java.util.List;
     summary =
         "The first argument to indexOf is a Unicode code point, and the second is the index to"
             + " start the search from",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class IndexOfChar extends BugChecker implements MethodInvocationTreeMatcher {
   private static final Matcher<ExpressionTree> MATCHER =
       MethodMatchers.instanceMethod()

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InexactVarargsConditional.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InexactVarargsConditional.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getType;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -39,8 +38,7 @@ import com.sun.tools.javac.code.Types;
 @BugPattern(
     name = "InexactVarargsConditional",
     summary = "Conditional expression in varargs call contains array and non-array arguments",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class InexactVarargsConditional extends BugChecker implements MethodInvocationTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InstanceOfAndCastMatchWrongType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InstanceOfAndCastMatchWrongType.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.TypeCastTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -53,8 +52,7 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "InstanceOfAndCastMatchWrongType",
     summary = "Casting inside an if block should be plausibly consistent with the instanceof type",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class InstanceOfAndCastMatchWrongType extends BugChecker implements TypeCastTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IntLongMath.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IntLongMath.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.BugPattern.StandardTags.FRAGILE_CODE;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.AssignmentTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.ReturnTreeMatcher;
@@ -45,8 +44,7 @@ import javax.lang.model.type.TypeKind;
     name = "IntLongMath",
     summary = "Expression of type int may overflow before being assigned to a long",
     severity = WARNING,
-    tags = FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = FRAGILE_CODE)
 public class IntLongMath extends BugChecker
     implements VariableTreeMatcher, AssignmentTreeMatcher, ReturnTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InterfaceWithOnlyStatics.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InterfaceWithOnlyStatics.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.bugpatterns.inject.dagger.DaggerAnnotations.
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
@@ -50,8 +49,7 @@ import javax.lang.model.element.Modifier;
     summary =
         "This interface only contains static fields and methods; consider making it a final class "
             + "instead to prevent subclassing.",
-    severity = SeverityLevel.WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SeverityLevel.WARNING)
 public final class InterfaceWithOnlyStatics extends BugChecker implements ClassTreeMatcher {
   @Override
   public Description matchClass(ClassTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InterruptedExceptionSwallowed.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InterruptedExceptionSwallowed.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -90,7 +89,6 @@ import javax.annotation.Nullable;
         "This catch block appears to be catching an explicitly declared InterruptedException as an"
             + " Exception/Throwable and not handling the interruption separately.",
     severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     documentSuppression = false)
 public final class InterruptedExceptionSwallowed extends BugChecker
     implements MethodTreeMatcher, TryTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InvalidPatternSyntax.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InvalidPatternSyntax.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.matchers.method.MethodMatchers.instanceMetho
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -40,8 +39,7 @@ import java.util.regex.PatternSyntaxException;
 @BugPattern(
     name = "InvalidPatternSyntax",
     summary = "Invalid syntax used for a regular expression",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class InvalidPatternSyntax extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final String MESSAGE_BASE = "Invalid syntax used for a regular expression: ";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InvalidTimeZoneID.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InvalidTimeZoneID.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -39,8 +38,7 @@ import java.util.regex.Pattern;
     summary =
         "Invalid time zone identifier. TimeZone.getTimeZone(String) will silently return GMT"
             + " instead of the time zone you intended.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class InvalidTimeZoneID extends BugChecker implements MethodInvocationTreeMatcher {
   private static final ImmutableSet<String> AVAILABLE_IDS =
       ImmutableSet.copyOf(TimeZone.getAvailableIDs());

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InvalidZoneId.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InvalidZoneId.java
@@ -20,7 +20,6 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
@@ -40,8 +39,7 @@ import java.time.ZoneId;
 @BugPattern(
     name = "InvalidZoneId",
     summary = "Invalid zone identifier. ZoneId.of(String) will throw exception at runtime.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class InvalidZoneId extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> METHOD_MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IsInstanceOfClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IsInstanceOfClass.java
@@ -23,7 +23,6 @@ import static com.google.errorprone.matchers.Matchers.instanceMethod;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -42,8 +41,7 @@ import com.sun.tools.javac.tree.JCTree;
 @BugPattern(
     name = "IsInstanceOfClass",
     summary = "The argument to Class#isInstance(Object) should not be a Class",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class IsInstanceOfClass extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<MethodInvocationTree> INSTANCE_OF_CLASS =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/IterablePathParameter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IterablePathParameter.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.isSameType;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -44,8 +43,7 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "IterablePathParameter",
     summary = "Path implements Iterable<Path>; prefer Collection<Path> for clarity",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class IterablePathParameter extends BugChecker implements VariableTreeMatcher {
   @Override
   public Description matchVariable(VariableTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JUnit3FloatingPointComparisonWithoutDelta.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JUnit3FloatingPointComparisonWithoutDelta.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -50,8 +49,7 @@ import javax.lang.model.type.TypeKind;
     summary = "Floating-point comparison without error tolerance",
     // First sentence copied directly from JUnit 4.
 
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class JUnit3FloatingPointComparisonWithoutDelta extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JUnit3TestNotRun.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JUnit3TestNotRun.java
@@ -34,7 +34,6 @@ import static com.google.errorprone.suppliers.Suppliers.VOID_TYPE;
 
 import com.google.common.base.Ascii;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -53,8 +52,7 @@ import javax.lang.model.element.Modifier;
     summary =
         "Test method will not be run; please correct method signature "
             + "(Should be public, non-static, and method name should begin with \"test\").",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class JUnit3TestNotRun extends BugChecker implements MethodTreeMatcher {
 
   /*

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4ClassAnnotationNonStatic.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4ClassAnnotationNonStatic.java
@@ -26,7 +26,6 @@ import static com.google.errorprone.matchers.Matchers.isStatic;
 import static com.google.errorprone.matchers.Matchers.isType;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFixes;
@@ -45,8 +44,7 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "JUnit4ClassAnnotationNonStatic",
     summary = "This method should be static",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class JUnit4ClassAnnotationNonStatic extends BugChecker implements MethodTreeMatcher {
 
   private static final MultiMatcher<MethodTree, AnnotationTree> CLASS_INIT_ANNOTATION =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4TestNotRun.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4TestNotRun.java
@@ -32,7 +32,6 @@ import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -59,8 +58,7 @@ import javax.lang.model.element.Modifier;
     summary =
         "This looks like a test method but is not run; please add @Test and @Ignore, or, if this"
             + " is a helper method, reduce its visibility.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class JUnit4TestNotRun extends BugChecker implements ClassTreeMatcher {
 
   private static final String TEST_CLASS = "org.junit.Test";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LambdaFunctionalInterface.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LambdaFunctionalInterface.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Streams;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -51,8 +50,7 @@ import javax.lang.model.element.Modifier;
     name = "LambdaFunctionalInterface",
     summary =
         "Use Java's utility functional interfaces instead of Function<A, B> for primitive types.",
-    severity = SUGGESTION,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public class LambdaFunctionalInterface extends BugChecker implements MethodTreeMatcher {
   private static final String JAVA_UTIL_FUNCTION_FUNCTION = "java.util.function.Function";
   private static final String JAVA_LANG_NUMBER = "java.lang.Number";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LiteProtoToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LiteProtoToString.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Streams.stream;
-import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.predicates.TypePredicates.allOf;
 import static com.google.errorprone.predicates.TypePredicates.isDescendantOf;
@@ -44,8 +43,7 @@ import java.util.Optional;
         "toString() on lite protos will not generate a useful representation of the proto from"
             + " optimized builds. Consider whether using some subset of fields instead would"
             + " provide useful information.",
-    severity = WARNING,
-    providesFix = NO_FIX)
+    severity = WARNING)
 public final class LiteProtoToString extends AbstractToString {
   private static final String LITE_ENUM_MESSAGE =
       "toString() on lite proto enums will generate different representations of the value from"

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LockNotBeforeTry.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LockNotBeforeTry.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.BugPattern.StandardTags.FRAGILE_CODE;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -51,8 +50,7 @@ import com.sun.source.util.TreeScanner;
     summary =
         "Calls to Lock#lock should be immediately followed by a try block which releases the lock.",
     severity = WARNING,
-    tags = FRAGILE_CODE,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    tags = FRAGILE_CODE)
 public final class LockNotBeforeTry extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> LOCK =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LockOnBoxedPrimitive.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LockOnBoxedPrimitive.java
@@ -28,7 +28,6 @@ import static com.google.errorprone.matchers.Matchers.variableInitializer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
@@ -59,8 +58,7 @@ import java.util.Optional;
             + " method. This method is used for autoboxing. This means that using a boxed"
             + " primitive as a lock can result in unintentionally sharing a lock with another"
             + " piece of code.",
-    severity = SeverityLevel.WARNING,
-    providesFix = ProvidesFix.NO_FIX)
+    severity = SeverityLevel.WARNING)
 public class LockOnBoxedPrimitive extends BugChecker
     implements CompilationUnitTreeMatcher, SynchronizedTreeMatcher, MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LogicalAssignment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LogicalAssignment.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.DoWhileLoopTreeMatcher;
@@ -45,8 +44,7 @@ import com.sun.tools.javac.tree.JCTree;
         "Assignment where a boolean expression was expected;"
             + " use == if this assignment wasn't expected or add parentheses for clarity.",
     severity = WARNING,
-    tags = StandardTags.LIKELY_ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.LIKELY_ERROR)
 public class LogicalAssignment extends BugChecker
     implements IfTreeMatcher, WhileLoopTreeMatcher, DoWhileLoopTreeMatcher, ForLoopTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LongLiteralLowerCaseSuffix.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LongLiteralLowerCaseSuffix.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.LiteralTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -40,8 +39,7 @@ import java.util.regex.Pattern;
 @BugPattern(
     name = "LongLiteralLowerCaseSuffix",
     summary = "Prefer 'L' to 'l' for the suffix to long literals",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class LongLiteralLowerCaseSuffix extends BugChecker implements LiteralTreeMatcher {
 
   private static final Matcher<LiteralTree> matcher =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LossyPrimitiveCompare.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LossyPrimitiveCompare.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
@@ -49,8 +48,7 @@ import java.util.function.Predicate;
             + " Float.compare can lead to lossy comparison. For example,"
             + " `Float.compare(Integer.MAX_VALUE, Integer.MAX_VALUE - 1) == 0`. Use a compare"
             + " method with non-lossy conversion, or ideally no conversion if possible.",
-    severity = ERROR,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class LossyPrimitiveCompare extends BugChecker implements MethodInvocationTreeMatcher {
   private static final Matcher<ExpressionTree> COMPARE_MATCHER =
       staticMethod().onClassAny("java.lang.Float", "java.lang.Double").named("compare");

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MathRoundIntLong.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MathRoundIntLong.java
@@ -25,7 +25,6 @@ import static com.google.errorprone.matchers.Matchers.staticMethod;
 
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -47,8 +46,7 @@ import com.sun.source.tree.MethodInvocationTree;
         "Math.round() called with an integer or long type results in truncation"
             + " because Math.round only accepts floats or doubles and some integers and longs can't"
             + " be represented with float.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public final class MathRoundIntLong extends BugChecker implements MethodInvocationTreeMatcher {
   private static final Matcher<ExpressionTree> MATH_ROUND_CALLS =
       staticMethod().onClass("java.lang.Math").named("round");

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MethodCanBeStatic.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MethodCanBeStatic.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.matchers.Matchers.SERIALIZATION_METHODS;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
@@ -56,8 +55,7 @@ import javax.lang.model.element.Modifier;
     name = "MethodCanBeStatic",
     altNames = "static-method",
     summary = "A private method that does not reference the enclosing instance can be static",
-    severity = SUGGESTION,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public class MethodCanBeStatic extends BugChecker implements CompilationUnitTreeMatcher {
   private final FindingOutputStyle findingOutputStyle;
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingDefault.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingDefault.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.SwitchTreeMatcher;
@@ -44,8 +43,7 @@ import javax.lang.model.element.ElementKind;
             + " statement group, even if it contains no code. (This requirement is lifted for any"
             + " switch statement that covers all values of an enum.)",
     severity = WARNING,
-    tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.STYLE)
 public class MissingDefault extends BugChecker implements SwitchTreeMatcher {
   @Override
   public Description matchSwitch(SwitchTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingFail.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingFail.java
@@ -41,7 +41,6 @@ import static com.google.errorprone.matchers.method.MethodMatchers.anyMethod;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.TryTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -84,8 +83,7 @@ import javax.lang.model.element.Name;
     name = "MissingFail",
     altNames = "missing-fail",
     summary = "Not calling fail() when expecting an exception masks bugs",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class MissingFail extends BugChecker implements TryTreeMatcher {
 
   // Many test writers don't seem to know about `fail()`. They instead use synonyms of varying

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingOverride.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingOverride.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
@@ -40,8 +39,7 @@ import javax.lang.model.element.Modifier;
     name = "MissingOverride",
     summary = "method overrides method in supertype; expected @Override",
     severity = WARNING,
-    tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.STYLE)
 public class MissingOverride extends BugChecker implements MethodTreeMatcher {
 
   /** if true, don't warn on missing {@code @Override} annotations inside interfaces */

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingSuperCall.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingSuperCall.java
@@ -23,7 +23,6 @@ import static com.google.errorprone.matchers.Matchers.isType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.AnnotationTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -49,8 +48,7 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "MissingSuperCall",
     summary = "Overriding method is missing a call to overridden super method",
-    severity = ERROR,
-    providesFix = ProvidesFix.NO_FIX)
+    severity = ERROR)
 // TODO(eaftan): Add support for JDK methods that cannot be annotated, such as
 // java.lang.Object#finalize and java.lang.Object#clone.
 public class MissingSuperCall extends BugChecker

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingTestCall.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingTestCall.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
@@ -58,8 +57,7 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "MissingTestCall",
     summary = "A terminating method call is required for a test helper to have any effect.",
-    severity = ERROR,
-    providesFix = NO_FIX)
+    severity = ERROR)
 public final class MissingTestCall extends BugChecker implements MethodTreeMatcher {
 
   private static final MethodClassMatcher EQUALS_TESTER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MisusedWeekYear.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MisusedWeekYear.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import java.util.Optional;
 
 /**
@@ -34,8 +33,7 @@ import java.util.Optional;
     summary =
         "Use of \"YYYY\" (week year) in a date pattern without \"ww\" (week in year). "
             + "You probably meant to use \"yyyy\" (year) instead.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public final class MisusedWeekYear extends MisusedDateFormat {
   @Override
   Optional<String> rewriteTo(String pattern) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MixedDescriptors.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MixedDescriptors.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
@@ -55,8 +54,7 @@ import java.util.Optional;
     summary =
         "The field number passed into #getFieldByNumber belongs to a different proto"
             + " to the Descriptor.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class MixedDescriptors extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> GET_DESCRIPTOR =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MixedMutabilityReturnType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MixedMutabilityReturnType.java
@@ -34,7 +34,6 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
@@ -80,8 +79,7 @@ import javax.lang.model.type.TypeKind;
     summary =
         "This method returns both mutable and immutable collections or maps from different "
             + "paths. This may be confusing for users of the method.",
-    severity = SeverityLevel.WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SeverityLevel.WARNING)
 public final class MixedMutabilityReturnType extends BugChecker
     implements CompilationUnitTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MockitoCast.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MockitoCast.java
@@ -23,7 +23,6 @@ import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -57,8 +56,7 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "MockitoCast",
     summary = "A bug in Mockito will cause this test to fail at runtime with a ClassCastException",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class MockitoCast extends BugChecker implements CompilationUnitTreeMatcher {
 
   private static final String MOCKITO_CLASS = "org.mockito.Mockito";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MockitoUsage.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MockitoUsage.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -38,8 +37,7 @@ import java.util.List;
 @BugPattern(
     name = "MockitoUsage",
     summary = "Missing method call for verify(mock) here",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class MockitoUsage extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final String MESSAGE_FORMAT = "Missing method call for %s here";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ModifiedButNotUsed.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ModifiedButNotUsed.java
@@ -17,7 +17,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -78,7 +77,6 @@ import java.util.stream.Stream;
 @BugPattern(
     name = "ModifiedButNotUsed",
     summary = "A collection or proto builder was created, but its values were never accessed.",
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     severity = WARNING)
 public class ModifiedButNotUsed extends BugChecker
     implements ExpressionStatementTreeMatcher, VariableTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ModifyingCollectionWithItself.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ModifyingCollectionWithItself.java
@@ -31,7 +31,6 @@ import static com.sun.source.tree.Tree.Kind.MEMBER_SELECT;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -52,8 +51,7 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "ModifyingCollectionWithItself",
     summary = "Using a collection function with itself as the argument.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class ModifyingCollectionWithItself extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MultipleParallelOrSequentialCalls.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MultipleParallelOrSequentialCalls.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -37,8 +36,7 @@ import com.sun.source.util.TreePath;
     name = "MultipleParallelOrSequentialCalls",
     summary =
         "Multiple calls to either parallel or sequential are unnecessary and cause confusion.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class MultipleParallelOrSequentialCalls extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MustBeClosedChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MustBeClosedChecker.java
@@ -27,7 +27,6 @@ import static com.google.errorprone.matchers.Matchers.not;
 import static com.google.errorprone.matchers.method.MethodMatchers.constructor;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
@@ -58,8 +57,7 @@ import java.util.List;
     name = "MustBeClosedChecker",
     summary = "The result of this method must be closed.",
     severity = ERROR,
-    generateExamplesFromTestCases = false,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    generateExamplesFromTestCases = false)
 public class MustBeClosedChecker extends AbstractMustBeClosedChecker
     implements MethodTreeMatcher,
         MethodInvocationTreeMatcher,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MutableConstantField.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MutableConstantField.java
@@ -23,7 +23,6 @@ import static com.google.errorprone.matchers.Matchers.isSameType;
 
 import com.google.common.base.Ascii;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -46,8 +45,7 @@ import javax.lang.model.element.Modifier;
     summary =
         "Constant field declarations should use the immutable type (such as ImmutableList) instead"
             + " of the general collection interface type (such as List)",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class MutableConstantField extends BugChecker implements VariableTreeMatcher {
 
   private static final String BIND = "com.google.inject.testing.fieldbinder.Bind";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MutableMethodReturnType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MutableMethodReturnType.java
@@ -23,7 +23,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -50,8 +49,7 @@ import java.util.function.Predicate;
     summary =
         "Method return type should use the immutable type (such as ImmutableList) instead of"
             + " the general collection interface type (such as List)",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class MutableMethodReturnType extends BugChecker implements MethodTreeMatcher {
 
   private static final Matcher<MethodTree> ANNOTATED_WITH_PRODUCES_OR_PROVIDES =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MutablePublicArray.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MutablePublicArray.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.matchers.Matchers.isArrayType;
 import static com.google.errorprone.util.ASTHelpers.hasAnnotation;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.matchers.Description;
@@ -42,8 +41,7 @@ import javax.lang.model.element.Modifier;
         "Non-empty arrays are mutable, so this `public static final` array is not a constant"
             + " and can be modified by clients of this class.  Prefer an ImmutableList, or provide"
             + " an accessor method that returns a defensive copy.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class MutablePublicArray extends BugChecker implements VariableTreeMatcher {
 
   private static final Matcher<VariableTree> MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NCopiesOfChar.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NCopiesOfChar.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 import static com.google.errorprone.util.ASTHelpers.getType;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -39,8 +38,7 @@ import java.util.List;
     name = "NCopiesOfChar",
     summary =
         "The first argument to nCopies is the number of copies, and the second is the item to copy",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class NCopiesOfChar extends BugChecker implements MethodInvocationTreeMatcher {
   private static final Matcher<ExpressionTree> MATCHER =
       staticMethod().onClass("java.util.Collections").named("nCopies");

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NarrowingCompoundAssignment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NarrowingCompoundAssignment.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.util.Signatures.prettyType;
 
 import com.google.common.base.Optional;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompoundAssignmentTreeMatcher;
@@ -43,8 +42,7 @@ import com.sun.tools.javac.tree.JCTree.JCBinary;
     name = "NarrowingCompoundAssignment",
     summary = "Compound assignments may hide dangerous casts",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public class NarrowingCompoundAssignment extends BugChecker
     implements CompoundAssignmentTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NoAllocationChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NoAllocationChecker.java
@@ -57,7 +57,6 @@ import static com.sun.source.tree.Tree.Kind.UNSIGNED_RIGHT_SHIFT_ASSIGNMENT;
 import static com.sun.source.tree.Tree.Kind.XOR_ASSIGNMENT;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.annotations.NoAllocation;
 import com.google.errorprone.bugpatterns.BugChecker.AssignmentTreeMatcher;
@@ -125,8 +124,7 @@ import java.util.Set;
     summary =
         "@NoAllocation was specified on this method, but something was found that would"
             + " trigger an allocation",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class NoAllocationChecker extends BugChecker
     implements AssignmentTreeMatcher,
         BinaryTreeMatcher,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NonCanonicalStaticImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NonCanonicalStaticImport.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ImportTreeMatcher;
 import com.google.errorprone.bugpatterns.StaticImports.StaticImportInfo;
@@ -36,8 +35,7 @@ import com.sun.source.tree.ImportTree;
     name = "NonCanonicalStaticImport",
     summary = "Static import of type uses non-canonical name",
     severity = ERROR,
-    documentSuppression = false,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    documentSuppression = false)
 public class NonCanonicalStaticImport extends BugChecker implements ImportTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NonCanonicalStaticMemberImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NonCanonicalStaticMemberImport.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ImportTreeMatcher;
 import com.google.errorprone.bugpatterns.StaticImports.StaticImportInfo;
@@ -36,8 +35,7 @@ import com.sun.source.tree.ImportTree;
     name = "NonCanonicalStaticMemberImport",
     summary = "Static import of member uses non-canonical name",
     severity = WARNING,
-    documentSuppression = false,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    documentSuppression = false)
 public class NonCanonicalStaticMemberImport extends BugChecker implements ImportTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NonOverridingEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NonOverridingEquals.java
@@ -35,7 +35,6 @@ import static com.google.errorprone.suppliers.Suppliers.OBJECT_TYPE;
 import static com.sun.tools.javac.code.Flags.ENUM;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -58,8 +57,7 @@ import com.sun.tools.javac.util.Name;
     name = "NonOverridingEquals",
     summary = "equals method doesn't override Object.equals",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public class NonOverridingEquals extends BugChecker implements MethodTreeMatcher {
 
   private static final String MESSAGE_BASE = "equals method doesn't override Object.equals";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NullableConstructor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NullableConstructor.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -36,8 +35,7 @@ import com.sun.tools.javac.code.Symbol;
     name = "NullableConstructor",
     summary = "Constructors should not be annotated with @Nullable since they cannot return null",
     severity = WARNING,
-    tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.STYLE)
 public class NullableConstructor extends BugChecker implements MethodTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NullablePrimitive.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NullablePrimitive.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.AnnotatedTypeTreeMatcher;
@@ -43,8 +42,7 @@ import java.util.List;
     name = "NullablePrimitive",
     summary = "@Nullable should not be used for primitive types since they cannot be null",
     severity = WARNING,
-    tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.STYLE)
 public class NullablePrimitive extends BugChecker
     implements AnnotatedTypeTreeMatcher, VariableTreeMatcher, MethodTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NullableVoid.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NullableVoid.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -39,8 +38,7 @@ import javax.lang.model.type.TypeKind;
         "void-returning methods should not be annotated with @Nullable,"
             + " since they cannot return null",
     severity = WARNING,
-    tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.STYLE)
 public class NullableVoid extends BugChecker implements MethodTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ObjectToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ObjectToString.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.fixes.Fix;
 import com.google.errorprone.fixes.SuggestedFixes;
@@ -44,8 +43,7 @@ import java.util.Optional;
     summary =
         "Calling toString on Objects that don't override toString() doesn't"
             + " provide useful information",
-    severity = WARNING,
-    providesFix = ProvidesFix.NO_FIX)
+    severity = WARNING)
 public class ObjectToString extends AbstractToString {
 
   private static boolean finalNoOverrides(Type type, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ObjectsHashCodePrimitive.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ObjectsHashCodePrimitive.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.matchers.Matchers.isPrimitiveType;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -40,8 +39,7 @@ import java.util.Objects;
 @BugPattern(
     name = "ObjectsHashCodePrimitive",
     summary = "Objects.hashCode(Object o) should not be passed a primitive value",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class ObjectsHashCodePrimitive extends BugChecker
     implements MethodInvocationTreeMatcher {
   private static final Matcher<MethodInvocationTree> OBJECTS_HASHCODE_CALLS =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OperatorPrecedence.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OperatorPrecedence.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
@@ -41,8 +40,7 @@ import java.util.EnumSet;
     name = "OperatorPrecedence",
     summary = "Use grouping parenthesis to make the operator precedence explicit",
     severity = WARNING,
-    tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.STYLE)
 public class OperatorPrecedence extends BugChecker implements BinaryTreeMatcher {
 
   private static final EnumSet<Kind> CONDITIONAL =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OptionalMapToOptional.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OptionalMapToOptional.java
@@ -14,7 +14,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -43,8 +42,7 @@ import com.sun.tools.javac.util.List;
 @BugPattern(
     name = "OptionalMapToOptional",
     summary = "Mapping to another Optional will yield a nested Optional. Did you mean flatMap?",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class OptionalMapToOptional extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> MAP =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OutlineNone.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OutlineNone.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.constValue;
@@ -42,8 +41,7 @@ import java.util.regex.Pattern;
     summary =
         "Setting CSS outline style to none or 0 (while not otherwise providing visual focus "
             + "indicators) is inaccessible for users navigating a web page without a mouse.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class OutlineNone extends BugChecker
     implements MethodInvocationTreeMatcher, AnnotationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/OverrideThrowableToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OverrideThrowableToString.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFixes;
@@ -41,8 +40,7 @@ import com.sun.source.tree.MethodTree;
     summary =
         "To return a custom message with a Throwable class, one should "
             + "override getMessage() instead of toString().",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class OverrideThrowableToString extends BugChecker implements ClassTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/Overrides.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Overrides.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -42,8 +41,7 @@ import java.util.Set;
     name = "Overrides",
     altNames = "overrides",
     summary = "Varargs doesn't agree for overridden method",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class Overrides extends BugChecker implements MethodTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ParameterComment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ParameterComment.java
@@ -23,7 +23,6 @@ import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -47,8 +46,7 @@ import java.util.stream.Stream;
     name = "ParameterComment",
     summary = "Non-standard parameter comment; prefer `/* paramName= */ arg`",
     severity = SUGGESTION,
-    tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.STYLE)
 public class ParameterComment extends BugChecker
     implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ParameterName.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ParameterName.java
@@ -26,7 +26,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Range;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
@@ -58,8 +57,7 @@ import java.util.regex.Matcher;
     summary =
         "Detects `/* name= */`-style comments on actual parameters where the name doesn't match the"
             + " formal parameter",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class ParameterName extends BugChecker
     implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullRepeated.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsCheckNotNullRepeated.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
@@ -42,8 +41,7 @@ import java.util.List;
     summary =
         "Including the first argument of checkNotNull in the failure message is not useful, "
             + "as it will always be `null`.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class PreconditionsCheckNotNullRepeated extends BugChecker
     implements MethodInvocationTreeMatcher {
   private static final String MESSAGE =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsInvalidPlaceholder.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsInvalidPlaceholder.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -39,8 +38,7 @@ import java.util.regex.Pattern;
     name = "PreconditionsInvalidPlaceholder",
     summary = "Preconditions only accepts the %s placeholder in error message strings",
     severity = WARNING,
-    tags = StandardTags.LIKELY_ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.LIKELY_ERROR)
 public class PreconditionsInvalidPlaceholder extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PrimitiveAtomicReference.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PrimitiveAtomicReference.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
@@ -41,7 +40,6 @@ import javax.lang.model.type.TypeKind;
         "Using compareAndSet with boxed primitives is dangerous, as reference rather than value"
             + " equality is used. Consider using AtomicInteger, AtomicLong, or AtomicBoolean"
             + " instead.",
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     severity = WARNING)
 public final class PrimitiveAtomicReference extends BugChecker
     implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PrivateConstructorForUtilityClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PrivateConstructorForUtilityClass.java
@@ -30,7 +30,6 @@ import static javax.lang.model.element.Modifier.STATIC;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.matchers.Description;
@@ -47,8 +46,7 @@ import com.sun.source.tree.VariableTree;
         "Classes which are not intended to be instantiated should be made non-instantiable with a"
             + " private constructor. This includes utility classes (classes with only static"
             + " members), and the main class.",
-    severity = SUGGESTION,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public final class PrivateConstructorForUtilityClass extends BugChecker
     implements ClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ProtectedMembersInFinalClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ProtectedMembersInFinalClass.java
@@ -26,7 +26,6 @@ import static javax.lang.model.element.Modifier.PROTECTED;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -48,8 +47,7 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "ProtectedMembersInFinalClass",
     summary = "Protected members in final classes can be package-private",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class ProtectedMembersInFinalClass extends BugChecker implements ClassTreeMatcher {
 
   private static final Matcher<ClassTree> HAS_FINAL = hasModifier(FINAL);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ProtoFieldNullComparison.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ProtoFieldNullComparison.java
@@ -32,7 +32,6 @@ import static com.google.errorprone.util.ASTHelpers.isSameType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
@@ -73,8 +72,7 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "ProtoFieldNullComparison",
     summary = "Protobuf fields cannot be null.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class ProtoFieldNullComparison extends BugChecker implements CompilationUnitTreeMatcher {
 
   private static final String PROTO_SUPER_CLASS = "com.google.protobuf.GeneratedMessage";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ProtoRedundantSet.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ProtoRedundantSet.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -52,8 +51,7 @@ import java.util.regex.Pattern;
     name = "ProtoRedundantSet",
     summary = "A field on a protocol buffer was set twice in the same chained expression.",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public final class ProtoRedundantSet extends BugChecker implements MethodInvocationTreeMatcher {
 
   /** Matches a chainable proto builder method. */

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ProtoStringFieldReferenceEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ProtoStringFieldReferenceEquality.java
@@ -23,7 +23,6 @@ import static com.google.errorprone.matchers.Matchers.instanceMethod;
 import static com.google.errorprone.matchers.Matchers.isSameType;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -37,8 +36,7 @@ import com.sun.source.tree.Tree.Kind;
 @BugPattern(
     name = "ProtoStringFieldReferenceEquality",
     severity = ERROR,
-    summary = "Comparing protobuf fields of type String using reference equality",
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    summary = "Comparing protobuf fields of type String using reference equality")
 public class ProtoStringFieldReferenceEquality extends BugChecker implements BinaryTreeMatcher {
 
   private static final String PROTO_SUPER_CLASS = "com.google.protobuf.GeneratedMessage";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ProtoTruthMixedDescriptors.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ProtoTruthMixedDescriptors.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
@@ -54,8 +53,7 @@ import java.util.Optional;
     summary =
         "The arguments passed to `ignoringFields` are inconsistent with the proto which is "
             + "the subject of the assertion.",
-    severity = ERROR,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public final class ProtoTruthMixedDescriptors extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RandomModInteger.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RandomModInteger.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
@@ -35,8 +34,7 @@ import com.sun.source.tree.Tree.Kind;
 @BugPattern(
     name = "RandomModInteger",
     summary = "Use Random.nextInt(int).  Random.nextInt() % n can have negative results",
-    severity = SeverityLevel.ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SeverityLevel.ERROR)
 public class RandomModInteger extends BugChecker implements BinaryTreeMatcher {
 
   private static final Matcher<ExpressionTree> RANDOM_NEXT_INT =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RedundantCondition.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RedundantCondition.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.AssignmentTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.ConditionalExpressionTreeMatcher;
@@ -57,8 +56,7 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "RedundantCondition",
     summary = "Redundant usage of a boolean variable with known value",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class RedundantCondition extends BugChecker
     implements IfTreeMatcher,
         AssignmentTreeMatcher,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RedundantOverride.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RedundantOverride.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.findSuperMethod;
@@ -52,8 +51,7 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "RedundantOverride",
     summary = "This overriding method is redundant, and can be removed.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class RedundantOverride extends BugChecker implements MethodTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RedundantThrows.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RedundantThrows.java
@@ -28,7 +28,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.SetMultimap;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFixes;
@@ -46,8 +45,7 @@ import java.util.Set;
 @BugPattern(
     name = "RedundantThrows",
     summary = "Thrown exception is a subtype of another",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class RedundantThrows extends BugChecker implements MethodTreeMatcher {
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RemoveUnusedImports.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RemoveUnusedImports.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.util.ASTHelpers.getSymbol;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
@@ -54,8 +53,7 @@ import javax.annotation.Nullable;
     summary = "Unused imports",
     severity = SUGGESTION,
     documentSuppression = false,
-    tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.STYLE)
 public final class RemoveUnusedImports extends BugChecker implements CompilationUnitTreeMatcher {
   @Override
   public Description matchCompilationUnit(

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RequiredModifiersChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RequiredModifiersChecker.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.annotations.RequiredModifiers;
@@ -44,8 +43,7 @@ import javax.lang.model.element.Modifier;
             + "@RequiredModifiers annotation",
     linkType = NONE,
     severity = WARNING,
-    tags = StandardTags.LIKELY_ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.LIKELY_ERROR)
 public class RequiredModifiersChecker extends BugChecker implements AnnotationTreeMatcher {
 
   private static final String MESSAGE_TEMPLATE =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/RestrictedApiChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/RestrictedApiChecker.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.annotations.RestrictedApi;
@@ -50,8 +49,7 @@ import javax.lang.model.type.MirroredTypesException;
     summary = "Check for non-whitelisted callers to RestrictedApiChecker.",
     severity = SeverityLevel.ERROR,
     suppressionAnnotations = {},
-    disableable = false,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    disableable = false)
 public class RestrictedApiChecker extends BugChecker
     implements MethodInvocationTreeMatcher,
         NewClassTreeMatcher,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SameNameButDifferent.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SameNameButDifferent.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.findPathFromEnclosingNodeToTopLevel;
@@ -55,7 +54,6 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "SameNameButDifferent",
     summary = "This type name shadows another in a way that may be confusing.",
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     severity = WARNING)
 public final class SameNameButDifferent extends BugChecker implements CompilationUnitTreeMatcher {
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SelfAssignment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SelfAssignment.java
@@ -28,7 +28,6 @@ import static javax.lang.model.element.Modifier.STATIC;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.AssignmentTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
@@ -56,11 +55,7 @@ import com.sun.tools.javac.code.Type;
  * @author eaftan@google.com (Eddie Aftandilian)
  * @author scottjohnson@google.com (Scott Johnson)
  */
-@BugPattern(
-    name = "SelfAssignment",
-    summary = "Variable assigned to itself",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+@BugPattern(name = "SelfAssignment", summary = "Variable assigned to itself", severity = ERROR)
 public class SelfAssignment extends BugChecker
     implements AssignmentTreeMatcher, VariableTreeMatcher {
   private static final Matcher<MethodInvocationTree> NON_NULL_MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SelfEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SelfEquals.java
@@ -27,7 +27,6 @@ import static com.google.errorprone.matchers.Matchers.toType;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -53,8 +52,7 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "SelfEquals",
     summary = "Testing an object for equality with itself will always be true.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class SelfEquals extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<Tree> ASSERTION =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ShortCircuitBoolean.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ShortCircuitBoolean.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.util.ASTHelpers.getType;
 import static com.google.errorprone.util.ASTHelpers.isSameType;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
@@ -44,8 +43,7 @@ import java.util.Iterator;
     name = "ShortCircuitBoolean",
     summary = "Prefer the short-circuiting boolean operators && and || to & and |.",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public class ShortCircuitBoolean extends BugChecker implements BinaryTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SizeGreaterThanOrEqualsZero.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SizeGreaterThanOrEqualsZero.java
@@ -31,7 +31,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import com.google.common.collect.Table.Cell;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -61,8 +60,7 @@ import java.util.regex.Pattern;
     name = "SizeGreaterThanOrEqualsZero",
     summary =
         "Comparison of a size >= 0 is always true, did you intend to check for " + "non-emptiness?",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class SizeGreaterThanOrEqualsZero extends BugChecker implements BinaryTreeMatcher {
 
   private enum MethodName {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpression.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpression.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MemberSelectTreeMatcher;
@@ -44,8 +43,7 @@ import java.util.Objects;
     severity = WARNING,
     altNames = {"static", "static-access", "StaticAccessedFromInstance"},
     generateExamplesFromTestCases = false,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public class StaticQualifiedUsingExpression extends BugChecker implements MemberSelectTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StreamResourceLeak.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StreamResourceLeak.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -52,8 +51,7 @@ import java.util.Objects;
     summary =
         "Streams that encapsulate a closeable resource should be closed using"
             + " try-with-resources",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class StreamResourceLeak extends AbstractMustBeClosedChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StringBuilderInitWithChar.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StringBuilderInitWithChar.java
@@ -17,7 +17,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -36,8 +35,7 @@ import javax.lang.model.type.TypeKind;
 @BugPattern(
     name = "StringBuilderInitWithChar",
     severity = ERROR,
-    summary = "StringBuilder does not have a char constructor; this invokes the int constructor.",
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    summary = "StringBuilder does not have a char constructor; this invokes the int constructor.")
 public class StringBuilderInitWithChar extends BugChecker implements NewClassTreeMatcher {
   @Override
   public Description matchNewClass(NewClassTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StringSplitter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StringSplitter.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.matchers.method.MethodMatchers.instanceMetho
 import static com.google.errorprone.util.Regexes.convertRegexToLiteral;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -55,8 +54,7 @@ import java.util.Optional;
 @BugPattern(
     name = "StringSplitter",
     summary = "String.split(String) has surprising behavior",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class StringSplitter extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SubstringOfZero.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SubstringOfZero.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -39,8 +38,7 @@ import java.util.Objects;
     explanation =
         "String.substring(int) gives you the substring from the index to the end, inclusive."
             + "Calling that method with an index of 0 will return the same String.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public final class SubstringOfZero extends BugChecker implements MethodInvocationTreeMatcher {
   private static final Matcher<ExpressionTree> SUBSTRING_CALLS =
       Matchers.instanceMethod()

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SuppressWarningsDeprecated.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SuppressWarningsDeprecated.java
@@ -23,7 +23,6 @@ import static com.google.errorprone.matchers.Matchers.isType;
 import static com.google.errorprone.matchers.Matchers.stringLiteral;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
@@ -38,8 +37,7 @@ import java.util.List;
 @BugPattern(
     name = "SuppressWarningsDeprecated",
     summary = "Suppressing \"deprecated\" is probably a typo for \"deprecation\"",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class SuppressWarningsDeprecated extends AbstractSuppressWarningsMatcher {
 
   @SuppressWarnings("varargs")

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SwitchDefault.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SwitchDefault.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.SwitchTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -39,8 +38,7 @@ import java.util.Optional;
 @BugPattern(
     name = "SwitchDefault",
     summary = "The default case of a switch should appear at the end of the last statement group",
-    severity = SUGGESTION,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public class SwitchDefault extends BugChecker implements SwitchTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SystemExitOutsideMain.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SystemExitOutsideMain.java
@@ -31,7 +31,6 @@ import static com.google.errorprone.matchers.MethodVisibility.Visibility.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
@@ -53,8 +52,7 @@ import java.util.Optional;
 @BugPattern(
     name = "SystemExitOutsideMain",
     summary = "Code that contains System.exit() is untestable.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class SystemExitOutsideMain extends BugChecker implements MethodInvocationTreeMatcher {
   private static final Matcher<ExpressionTree> CALLS_TO_SYSTEM_EXIT =
       staticMethod().onClass("java.lang.System").named("exit");

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThreadJoinLoop.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThreadJoinLoop.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.util.ASTHelpers.getType;
 import static com.google.errorprone.util.ASTHelpers.isSubtype;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -50,8 +49,7 @@ import java.util.concurrent.atomic.AtomicInteger;
     summary =
         "Thread.join needs to be surrounded by a loop until it succeeds, "
             + "as in Uninterruptibles.joinUninterruptibly.",
-    severity = SeverityLevel.WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SeverityLevel.WARNING)
 public class ThreadJoinLoop extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> MATCH_THREAD_JOIN =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThreadLocalUsage.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThreadLocalUsage.java
@@ -29,7 +29,6 @@ import static com.google.errorprone.util.ASTHelpers.isSubtype;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
 import com.google.errorprone.matchers.Description;
@@ -46,8 +45,7 @@ import com.sun.tools.javac.code.Type;
 @BugPattern(
     name = "ThreadLocalUsage",
     summary = "ThreadLocals should be stored in static fields",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class ThreadLocalUsage extends BugChecker implements NewClassTreeMatcher {
 
   private static final Matcher<ExpressionTree> NEW_THREAD_LOCAL =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThreeLetterTimeZoneID.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThreeLetterTimeZoneID.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -40,8 +39,7 @@ import java.util.TimeZone;
 @BugPattern(
     name = "ThreeLetterTimeZoneID",
     summary = ThreeLetterTimeZoneID.SUMMARY,
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class ThreeLetterTimeZoneID extends BugChecker implements MethodInvocationTreeMatcher {
   static final String SUMMARY =
       "Three-letter time zone identifiers are deprecated, may be ambiguous, and might not do what "

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThrowIfUncheckedKnownChecked.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThrowIfUncheckedKnownChecked.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.matchers.Matchers.argumentCount;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
@@ -42,8 +41,7 @@ import javax.lang.model.type.UnionType;
 @BugPattern(
     name = "ThrowIfUncheckedKnownChecked",
     summary = "throwIfUnchecked(knownCheckedException) is a no-op.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class ThrowIfUncheckedKnownChecked extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThrowNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThrowNull.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.sun.source.tree.Tree.Kind.NULL_LITERAL;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ThrowTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -32,8 +31,7 @@ import com.sun.source.tree.ThrowTree;
 @BugPattern(
     name = "ThrowNull",
     summary = "Throwing 'null' always results in a NullPointerException being thrown.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class ThrowNull extends BugChecker implements ThrowTreeMatcher {
   @Override
   public Description matchThrow(ThrowTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThrowSpecificExceptions.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThrowSpecificExceptions.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.auto.value.AutoValue;
@@ -40,7 +39,6 @@ import com.sun.source.tree.ThrowTree;
         "Consider throwing more specific exceptions rather than (e.g.) RuntimeException. Throwing"
             + " generic exceptions forces any users of the API that wish to handle the failure"
             + " mode to catch very non-specific exceptions that convey little information.",
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     severity = WARNING)
 public final class ThrowSpecificExceptions extends BugChecker implements NewClassTreeMatcher {
   private static final ImmutableList<AbstractLikeException> ABSTRACT_LIKE_EXCEPTIONS =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ThrowsUncheckedException.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ThrowsUncheckedException.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.util.ASTHelpers.getType;
 import static com.google.errorprone.util.ASTHelpers.isSubtype;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFixes;
@@ -42,8 +41,7 @@ import java.util.List;
     name = "ThrowsUncheckedException",
     summary = "Unchecked exceptions do not need to be declared in the method signature.",
     severity = SUGGESTION,
-    generateExamplesFromTestCases = false,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    generateExamplesFromTestCases = false)
 public class ThrowsUncheckedException extends BugChecker implements MethodTreeMatcher {
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TransientMisuse.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TransientMisuse.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFixes;
@@ -36,8 +35,7 @@ import javax.lang.model.element.Modifier;
     name = "TransientMisuse",
     summary = "Static fields are implicitly transient, so the explicit modifier is unnecessary",
     linkType = NONE,
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class TransientMisuse extends BugChecker implements VariableTreeMatcher {
   @Override
   public Description matchVariable(VariableTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TreeToString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TreeToString.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.util.ASTHelpers.getReceiver;
 import static com.google.errorprone.util.ASTHelpers.isSubtype;
@@ -48,8 +47,7 @@ import java.util.Optional;
     summary =
         "Tree#toString shouldn't be used for Trees deriving from the code being compiled, as it"
             + " discards whitespace and comments.",
-    severity = WARNING,
-    providesFix = NO_FIX)
+    severity = WARNING)
 public class TreeToString extends AbstractToString {
 
   private static final Matcher<ClassTree> IS_BUGCHECKER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TruthAssertExpected.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TruthAssertExpected.java
@@ -25,7 +25,6 @@ import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.common.base.Ascii;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -57,8 +56,7 @@ import javax.annotation.Nullable;
         "The actual and expected values appear to be swapped, which results in poor assertion "
             + "failure messages. The actual value should come first.",
     severity = WARNING,
-    tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.STYLE)
 public final class TruthAssertExpected extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final String TRUTH = "com.google.common.truth.Truth";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TruthConstantAsserts.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TruthConstantAsserts.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.method.MethodMatchers.instanceMetho
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -43,8 +42,7 @@ import java.util.regex.Pattern;
     name = "TruthConstantAsserts",
     summary = "Truth Library assert is called on a constant.",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public class TruthConstantAsserts extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> ASSERT_THAT =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TruthSelfEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TruthSelfEquals.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.matchers.method.MethodMatchers.instanceMetho
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -46,8 +45,7 @@ import java.util.regex.Pattern;
     summary =
         "isEqualTo should not be used to test an object for equality with itself; the"
             + " assertion will never fail.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class TruthSelfEquals extends BugChecker implements MethodInvocationTreeMatcher {
 
   /**

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TryFailRefactoring.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TryFailRefactoring.java
@@ -27,7 +27,6 @@ import static com.sun.source.tree.Tree.Kind.UNION_TYPE;
 
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.TryTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -50,8 +49,7 @@ import java.util.Optional;
     name = "TryFailRefactoring",
     summary = "Prefer assertThrows to try/fail",
     severity = SUGGESTION,
-    tags = REFACTORING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = REFACTORING)
 public class TryFailRefactoring extends BugChecker implements TryTreeMatcher {
 
   private static final Matcher<StatementTree> FAIL_METHOD =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TryFailThrowable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TryFailThrowable.java
@@ -36,7 +36,6 @@ import static com.sun.source.tree.Tree.Kind.METHOD_INVOCATION;
 import static java.lang.String.format;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.TryTreeMatcher;
 import com.google.errorprone.fixes.Fix;
@@ -93,8 +92,7 @@ import java.util.List;
 @BugPattern(
     name = "TryFailThrowable",
     summary = "Catching Throwable/Error masks failures from fail() or assert*() in the try block",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class TryFailThrowable extends BugChecker implements TryTreeMatcher {
 
   private static final Matcher<VariableTree> javaLangThrowable = isSameType("java.lang.Throwable");

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeEqualsChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeEqualsChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -46,8 +45,7 @@ import com.sun.source.tree.MethodInvocationTree;
         "com.sun.tools.javac.code.Type doesn't override Object.equals and instances are not"
             + " interned by javac, so testing types for equality should be done with"
             + " Types#isSameType instead",
-    severity = WARNING,
-    providesFix = NO_FIX)
+    severity = WARNING)
 public class TypeEqualsChecker extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final TypePredicate TYPE_MIRROR =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeNameShadowing.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeNameShadowing.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
@@ -61,8 +60,7 @@ import java.util.stream.Collectors;
     name = "TypeNameShadowing",
     summary = "Type parameter declaration shadows another named type",
     severity = WARNING,
-    tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.STYLE)
 public class TypeNameShadowing extends BugChecker implements MethodTreeMatcher, ClassTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterNaming.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterNaming.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.LinkType;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.TypeParameterTreeMatcher;
@@ -63,7 +62,6 @@ import javax.lang.model.element.Name;
     severity = SUGGESTION,
     tags = StandardTags.STYLE,
     linkType = LinkType.CUSTOM,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
     link = "https://google.github.io/styleguide/javaguide.html#s5.2.8-type-variable-names"
     )
 public class TypeParameterNaming extends BugChecker implements TypeParameterTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MemberSelectTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -35,8 +34,7 @@ import javax.lang.model.element.ElementKind;
     name = "TypeParameterQualifier",
     summary = "Type parameter used as type qualifier",
     severity = ERROR,
-    suppressionAnnotations = {},
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    suppressionAnnotations = {})
 public class TypeParameterQualifier extends BugChecker implements MemberSelectTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterShadowing.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterShadowing.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import com.google.common.collect.MoreCollectors;
 import com.google.common.collect.Streams;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
@@ -49,8 +48,7 @@ import javax.lang.model.element.Name;
     name = "TypeParameterShadowing",
     summary = "Type parameter declaration overrides another type parameter already declared",
     severity = WARNING,
-    tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.STYLE)
 public class TypeParameterShadowing extends BugChecker
     implements MethodTreeMatcher, ClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UndefinedEquals.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UndefinedEquals.java
@@ -35,7 +35,6 @@ import static com.google.errorprone.util.ASTHelpers.isSubtype;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -58,8 +57,7 @@ import java.util.function.BiFunction;
 @BugPattern(
     name = "UndefinedEquals",
     summary = "This type is not guaranteed to implement a useful #equals method.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class UndefinedEquals extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> IS_EQUAL_TO =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryAnonymousClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryAnonymousClass.java
@@ -20,7 +20,6 @@ import static com.google.common.base.CaseFormat.LOWER_CAMEL;
 import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getReceiver;
@@ -65,8 +64,7 @@ import javax.lang.model.element.Modifier;
     summary =
         "Implementing a functional interface is unnecessary; prefer to implement the functional"
             + " interface method directly and use a method reference instead.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class UnnecessaryAnonymousClass extends BugChecker implements VariableTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryBoxedAssignment.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryBoxedAssignment.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.AssignmentTreeMatcher;
@@ -47,7 +46,6 @@ import com.sun.tools.javac.code.TypeTag;
     summary = "This expression can be implicitly boxed.",
     explanation =
         "It is unnecessary for this assignment or return expression to be boxed explicitly.",
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
     severity = SeverityLevel.SUGGESTION)
 public class UnnecessaryBoxedAssignment extends BugChecker
     implements AssignmentTreeMatcher, ReturnTreeMatcher, VariableTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryBoxedVariable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryBoxedVariable.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.method.MethodMatchers.instanceMetho
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
@@ -71,7 +70,6 @@ import javax.lang.model.element.ElementKind;
         "This variable is of boxed type, but equivalent semantics can be achieved using the"
             + " corresponding primitive type, which avoids the cost of constructing an unnecessary"
             + " object.",
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
     severity = SeverityLevel.SUGGESTION)
 public class UnnecessaryBoxedVariable extends BugChecker implements VariableTreeMatcher {
   private static final Matcher<ExpressionTree> VALUE_OF_MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryDefaultInEnumSwitch.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryDefaultInEnumSwitch.java
@@ -27,7 +27,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.SwitchTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -52,8 +51,7 @@ import javax.lang.model.element.ElementKind;
     summary =
         "Switch handles all enum values: an explicit default case is unnecessary and defeats error"
             + " checking for non-exhaustive switches.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class UnnecessaryDefaultInEnumSwitch extends BugChecker implements SwitchTreeMatcher {
 
   private static final String DESCRIPTION_MOVED_DEFAULT =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryLambda.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryLambda.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.common.base.CaseFormat.LOWER_CAMEL;
 import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.fixes.SuggestedFixes.prettyType;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -70,8 +69,7 @@ import javax.lang.model.element.Modifier;
         "Returning a lambda from a helper method or saving it in a constant is unnecessary; prefer"
             + " to implement the functional interface method directly and use a method reference"
             + " instead.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class UnnecessaryLambda extends BugChecker
     implements MethodTreeMatcher, VariableTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryMethodInvocationMatcher.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryMethodInvocationMatcher.java
@@ -14,7 +14,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
@@ -43,7 +42,6 @@ import java.util.List;
 @BugPattern(
     name = "UnnecessaryMethodInvocationMatcher",
     summary = "It is not necessary to wrap a MethodMatcher with methodInvocation().",
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     severity = WARNING)
 public class UnnecessaryMethodInvocationMatcher extends BugChecker
     implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryParentheses.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryParentheses.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.BugPattern.StandardTags.STYLE;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -39,7 +38,6 @@ import com.sun.tools.javac.tree.JCTree;
         "These grouping parentheses are unnecessary; it is unlikely the code will"
             + " be misinterpreted without them",
     severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     tags = STYLE)
 public class UnnecessaryParentheses extends BugChecker implements ParenthesizedTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarySetDefault.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarySetDefault.java
@@ -46,7 +46,6 @@ import com.google.common.collect.Range;
 import com.google.common.io.ByteSource;
 import com.google.common.io.CharSource;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -66,8 +65,7 @@ import java.util.OptionalLong;
 @BugPattern(
     name = "UnnecessarySetDefault",
     summary = "Unnecessary call to NullPointerTester#setDefault",
-    severity = SUGGESTION,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public class UnnecessarySetDefault extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> SET_DEFAULT =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryStaticImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryStaticImport.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.ImportTreeMatcher;
@@ -35,8 +34,7 @@ import com.sun.source.tree.ImportTree;
 
     severity = SUGGESTION,
     documentSuppression = false,
-    tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.STYLE)
 public class UnnecessaryStaticImport extends BugChecker implements ImportTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryTypeArgument.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryTypeArgument.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Verify.verify;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
@@ -40,8 +39,7 @@ import java.util.List;
 @BugPattern(
     name = "UnnecessaryTypeArgument",
     summary = "Non-generic methods should not be invoked with type arguments",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class UnnecessaryTypeArgument extends BugChecker
     implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnsafeReflectiveConstructionCast.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnsafeReflectiveConstructionCast.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.matchers.method.MethodMatchers.instanceMetho
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.TypeCastTreeMatcher;
@@ -51,8 +50,7 @@ import java.lang.reflect.Constructor;
             + "This way, if the class is of the incorrect type,"
             + "it will throw an exception before invoking its constructor.",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public class UnsafeReflectiveConstructionCast extends BugChecker implements TypeCastTreeMatcher {
 
   private static final Matcher<ExpressionTree> CLASS_FOR_NAME =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnsynchronizedOverridesSynchronized.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnsynchronizedOverridesSynchronized.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.isSameType;
@@ -48,8 +47,7 @@ import javax.lang.model.element.Modifier;
     name = "UnsynchronizedOverridesSynchronized",
     summary = "Unsynchronized method overrides a synchronized method.",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public class UnsynchronizedOverridesSynchronized extends BugChecker implements MethodTreeMatcher {
   @Override
   public Description matchMethod(MethodTree methodTree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedException.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedException.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.BugPattern.StandardTags.STYLE;
 import static com.google.errorprone.util.ASTHelpers.isSameType;
@@ -66,7 +65,6 @@ import javax.lang.model.element.Modifier;
             + " exception rather than setting it as a cause. This can make debugging harder.",
     severity = WARNING,
     tags = STYLE,
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     documentSuppression = false)
 public final class UnusedException extends BugChecker implements CatchTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedMethod.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.common.collect.Iterables.getLast;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.SERIALIZATION_METHODS;
 import static com.google.errorprone.suppliers.Suppliers.typeFromString;
@@ -66,7 +65,6 @@ import javax.lang.model.element.Name;
     name = "UnusedMethod",
     altNames = {"Unused", "unused", "UnusedParameters"},
     summary = "Unused.",
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     severity = WARNING,
     documentSuppression = false)
 public final class UnusedMethod extends BugChecker implements CompilationUnitTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedNestedClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedNestedClass.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.enclosingClass;
@@ -46,7 +45,6 @@ import java.util.Set;
     name = "UnusedNestedClass",
     altNames = "unused",
     summary = "This nested class is unused, and can be removed.",
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     severity = WARNING,
     documentSuppression = false)
 public final class UnusedNestedClass extends BugChecker implements CompilationUnitTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.SERIALIZATION_METHODS;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
@@ -113,7 +112,6 @@ import javax.lang.model.type.NullType;
     name = "UnusedVariable",
     altNames = {"unused", "UnusedParameters"},
     summary = "Unused.",
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     severity = WARNING,
     documentSuppression = false)
 public final class UnusedVariable extends BugChecker implements CompilationUnitTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UseCorrectAssertInTests.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UseCorrectAssertInTests.java
@@ -22,7 +22,6 @@ import static com.sun.source.tree.Tree.Kind.NULL_LITERAL;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -48,8 +47,7 @@ import com.sun.tools.javac.tree.TreeInfo;
 @BugPattern(
     name = "UseCorrectAssertInTests",
     summary = "Java assert is used in test. For testing purposes Assert.* matchers should be used.",
-    severity = SeverityLevel.WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SeverityLevel.WARNING)
 public class UseCorrectAssertInTests extends BugChecker implements MethodTreeMatcher {
   private static final String STATIC_ASSERT_THAT_IMPORT =
       "static com.google.common.truth.Truth.assertThat";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/VarChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/VarChecker.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.util.ASTHelpers.isConsideredFinal;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.annotations.Var;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
@@ -46,8 +45,7 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "Var",
     summary = "Non-constant variable missing @Var annotation",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class VarChecker extends BugChecker implements VariableTreeMatcher {
 
   private static final String UNNECESSARY_FINAL = "Unnecessary 'final' modifier.";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/WaitNotInLoop.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/WaitNotInLoop.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.matchers.WaitMatchers.waitMethod;
 import static com.google.errorprone.matchers.WaitMatchers.waitMethodWithTimeout;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -44,8 +43,7 @@ import com.sun.tools.javac.tree.JCTree.JCIf;
         "Because of spurious wakeups, Object.wait() and Condition.await() must always be "
             + "called in a loop",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public class WaitNotInLoop extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final String MESSAGE_TEMPLATE =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/WithSignatureDiscouraged.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/WithSignatureDiscouraged.java
@@ -14,7 +14,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
@@ -45,7 +44,6 @@ import java.util.stream.Collectors;
 @BugPattern(
     name = "WithSignatureDiscouraged",
     summary = "withSignature is discouraged. Prefer .named and/or .withParameters where possible.",
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     severity = WARNING)
 public class WithSignatureDiscouraged extends BugChecker implements MethodInvocationTreeMatcher {
   private static final Matcher<ExpressionTree> WITH_SIGNATURE =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/WrongParameterPackage.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/WrongParameterPackage.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
@@ -39,8 +38,7 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "ParameterPackage",
     summary = "Method parameter has wrong package",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class WrongParameterPackage extends BugChecker implements MethodTreeMatcher {
 
   private MethodSymbol supermethod;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/XorPower.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/XorPower.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
@@ -34,8 +33,7 @@ import com.sun.source.tree.Tree;
 @BugPattern(
     name = "XorPower",
     summary = "The `^` operator is binary XOR, not a power operator.",
-    severity = ERROR,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class XorPower extends BugChecker implements BinaryTreeMatcher {
   @Override
   public Description matchBinary(BinaryTree tree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/BinderIdentityRestoredDangerously.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/BinderIdentityRestoredDangerously.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.findEnclosingNode;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
@@ -41,8 +40,7 @@ import com.sun.source.tree.TryTree;
         "A call to Binder.clearCallingIdentity() should be followed by "
             + "Binder.restoreCallingIdentity() in a finally block. Otherwise the wrong Binder "
             + "identity may be used by subsequent code.",
-    severity = SeverityLevel.WARNING,
-    providesFix = ProvidesFix.NO_FIX)
+    severity = SeverityLevel.WARNING)
 public class BinderIdentityRestoredDangerously extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/HardCodedSdCardPath.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/HardCodedSdCardPath.java
@@ -21,7 +21,6 @@ import static com.sun.source.tree.Tree.Kind.STRING_LITERAL;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.LiteralTreeMatcher;
@@ -41,8 +40,7 @@ import java.util.Map;
     name = "HardCodedSdCardPath",
     altNames = {"SdCardPath"},
     summary = "Hardcoded reference to /sdcard",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class HardCodedSdCardPath extends BugChecker implements LiteralTreeMatcher {
   // The proper ways of retrieving the "/sdcard" and "/data/data" directories.
   static final String SDCARD = "Environment.getExternalStorageDirectory().getPath()";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/MislabeledAndroidString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/MislabeledAndroidString.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MemberSelectTreeMatcher;
@@ -42,8 +41,7 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "MislabeledAndroidString",
     summary = "Certain resources in `android.R.string` have names that do not match their content",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class MislabeledAndroidString extends BugChecker implements MemberSelectTreeMatcher {
 
   private static final String R_STRING_CLASSNAME = "android.R.string";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/ParcelableCreator.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/ParcelableCreator.java
@@ -23,7 +23,6 @@ import static com.google.errorprone.matchers.Matchers.not;
 
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -52,8 +51,7 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "ParcelableCreator",
     summary = "Detects classes which implement Parcelable but don't have CREATOR",
-    severity = SeverityLevel.ERROR,
-    providesFix = ProvidesFix.NO_FIX)
+    severity = SeverityLevel.ERROR)
 public class ParcelableCreator extends BugChecker implements ClassTreeMatcher {
 
   /** Matches if a non-public non-abstract class/interface is subtype of android.os.Parcelable */

--- a/core/src/main/java/com/google/errorprone/bugpatterns/android/WakelockReleasedDangerously.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/android/WakelockReleasedDangerously.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableMultimap.Builder;
 import com.google.common.collect.Streams;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
@@ -64,8 +63,7 @@ import com.sun.tools.javac.code.Types;
         "A wakelock acquired with a timeout may be released by the system before calling"
             + " `release`, even after checking `isHeld()`. If so, it will throw a RuntimeException."
             + " Please wrap in a try/catch block.",
-    severity = SeverityLevel.WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SeverityLevel.WARNING)
 public class WakelockReleasedDangerously extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final String WAKELOCK_CLASS_NAME = "android.os.PowerManager.WakeLock";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/ArgumentSelectionDefectChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/ArgumentSelectionDefectChecker.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -55,8 +54,7 @@ import java.util.function.Function;
 @BugPattern(
     name = "ArgumentSelectionDefectChecker",
     summary = "Arguments are in the wrong order or could be commented for clarity.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class ArgumentSelectionDefectChecker extends BugChecker
     implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/AssertEqualsArgumentOrderChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/AssertEqualsArgumentOrderChecker.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns.argumentselectiondefects;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -46,8 +45,7 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "AssertEqualsArgumentOrderChecker",
     summary = "Arguments are swapped in assertEquals-like call",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class AssertEqualsArgumentOrderChecker extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/AutoValueConstructorOrderChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/AutoValueConstructorOrderChecker.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns.argumentselectiondefects;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.NewClassTreeMatcher;
@@ -44,8 +43,7 @@ import java.util.function.Function;
 @BugPattern(
     name = "AutoValueConstructorOrderChecker",
     summary = "Arguments to AutoValue constructor are in the wrong order",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class AutoValueConstructorOrderChecker extends BugChecker implements NewClassTreeMatcher {
 
   private final ArgumentChangeFinder argumentChangeFinder =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionIncompatibleType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionIncompatibleType.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.util.ASTHelpers.getType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -68,8 +67,7 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "CollectionIncompatibleType",
     summary = "Incompatible type as argument to Object-accepting Java collections method",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class CollectionIncompatibleType extends BugChecker
     implements MethodInvocationTreeMatcher, MemberReferenceTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/AssistedInjectAndInjectOnSameConstructor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/AssistedInjectAndInjectOnSameConstructor.java
@@ -26,7 +26,6 @@ import static com.google.errorprone.matchers.Matchers.hasAnnotation;
 import static com.google.errorprone.matchers.Matchers.isType;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.AnnotationTreeMatcher;
@@ -42,8 +41,7 @@ import com.sun.source.tree.Tree;
 @BugPattern(
     name = "AssistedInjectAndInjectOnSameConstructor",
     summary = "@AssistedInject and @Inject cannot be used on the same constructor.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class AssistedInjectAndInjectOnSameConstructor extends BugChecker
     implements AnnotationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/AutoFactoryAtInject.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/AutoFactoryAtInject.java
@@ -27,7 +27,6 @@ import static com.sun.source.tree.Tree.Kind.METHOD;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.AnnotationTreeMatcher;
@@ -43,8 +42,7 @@ import com.sun.source.tree.Tree;
 @BugPattern(
     name = "AutoFactoryAtInject",
     summary = "@AutoFactory and @Inject should not be used in the same type.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class AutoFactoryAtInject extends BugChecker implements AnnotationTreeMatcher {
 
   private static final Matcher<Tree> HAS_AUTO_FACTORY_ANNOTATION =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/CloseableProvides.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/CloseableProvides.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.Matchers.methodReturns;
 import static com.google.errorprone.matchers.Matchers.not;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -36,8 +35,7 @@ import com.sun.source.tree.MethodTree;
 @BugPattern(
     name = "CloseableProvides",
     summary = "Providing Closeable resources makes their lifecycle unclear",
-    severity = WARNING,
-    providesFix = ProvidesFix.NO_FIX)
+    severity = WARNING)
 public class CloseableProvides extends BugChecker implements MethodTreeMatcher {
 
   private static final Matcher<MethodTree> CLOSEABLE_PROVIDES_MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectOnConstructorOfAbstractClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectOnConstructorOfAbstractClass.java
@@ -30,7 +30,6 @@ import static com.google.errorprone.matchers.Matchers.methodIsConstructor;
 import static javax.lang.model.element.Modifier.ABSTRACT;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -48,8 +47,7 @@ import com.sun.source.tree.MethodTree;
     summary =
         "Constructors on abstract classes are never directly @Injected, only the constructors"
             + " of their subclasses can be @Inject'ed.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class InjectOnConstructorOfAbstractClass extends BugChecker implements MethodTreeMatcher {
 
   private static final MultiMatcher<MethodTree, AnnotationTree> INJECT_FINDER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectOnMemberAndConstructor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectOnMemberAndConstructor.java
@@ -26,7 +26,6 @@ import static com.google.errorprone.matchers.Matchers.constructor;
 import static com.google.errorprone.matchers.Matchers.isField;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
@@ -59,8 +58,7 @@ import javax.lang.model.element.ElementKind;
     name = "InjectOnMemberAndConstructor",
     summary =
         "Members shouldn't be annotated with @Inject if constructor is already annotated @Inject",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class InjectOnMemberAndConstructor extends BugChecker implements ClassTreeMatcher {
 
   private static final Matcher<ClassTree> HAS_CONSTRUCTORS_WITH_INJECT =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectedConstructorAnnotations.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectedConstructorAnnotations.java
@@ -28,7 +28,6 @@ import static com.google.errorprone.matchers.Matchers.methodIsConstructor;
 import static com.google.errorprone.matchers.Matchers.symbolHasAnnotation;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -42,8 +41,7 @@ import com.sun.source.tree.MethodTree;
 @BugPattern(
     name = "InjectedConstructorAnnotations",
     summary = "Injected constructors cannot be optional nor have binding annotations",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class InjectedConstructorAnnotations extends BugChecker implements MethodTreeMatcher {
 
   // A matcher of @Inject{optional=true}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/InvalidTargetingOnScopingAnnotation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/InvalidTargetingOnScopingAnnotation.java
@@ -33,7 +33,6 @@ import static java.lang.annotation.ElementType.TYPE;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
@@ -56,8 +55,7 @@ import java.util.Set;
 @BugPattern(
     name = "InjectInvalidTargetingOnScopingAnnotation",
     summary = "A scoping annotation's Target should include TYPE and METHOD.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class InvalidTargetingOnScopingAnnotation extends BugChecker implements ClassTreeMatcher {
 
   private static final String TARGET_ANNOTATION = "java.lang.annotation.Target";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/JavaxInjectOnAbstractMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/JavaxInjectOnAbstractMethod.java
@@ -28,7 +28,6 @@ import static javax.lang.model.element.Modifier.ABSTRACT;
 import static javax.lang.model.element.Modifier.DEFAULT;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -43,8 +42,7 @@ import com.sun.source.tree.MethodTree;
 @BugPattern(
     name = "JavaxInjectOnAbstractMethod",
     summary = "Abstract and default methods are not injectable with javax.inject.Inject",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class JavaxInjectOnAbstractMethod extends BugChecker implements MethodTreeMatcher {
   private static final MultiMatcher<MethodTree, AnnotationTree> INJECT_FINDER =
       annotations(AT_LEAST_ONE, IS_APPLICATION_OF_JAVAX_INJECT);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/JavaxInjectOnFinalField.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/JavaxInjectOnFinalField.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.InjectMatchers.IS_APPLICATION_OF_JA
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.AnnotationTreeMatcher;
@@ -34,8 +33,7 @@ import com.sun.source.tree.AnnotationTree;
 @BugPattern(
     name = "JavaxInjectOnFinalField",
     summary = "@javax.inject.Inject cannot be put on a final field.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class JavaxInjectOnFinalField extends BugChecker implements AnnotationTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/MoreThanOneQualifier.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/MoreThanOneQualifier.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.InjectMatchers.JAVAX_QUALIFIER_ANNO
 import static com.google.errorprone.matchers.Matchers.hasAnnotation;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.AnnotationTreeMatcher;
@@ -38,8 +37,7 @@ import java.util.List;
 @BugPattern(
     name = "InjectMoreThanOneQualifier",
     summary = "Using more than one qualifier annotation on the same element is not allowed.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class MoreThanOneQualifier extends BugChecker implements AnnotationTreeMatcher {
 
   private static final Matcher<AnnotationTree> QUALIFIER_ANNOTATION_MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/QualifierOrScopeOnInjectMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/QualifierOrScopeOnInjectMethod.java
@@ -25,7 +25,6 @@ import static com.google.errorprone.matchers.Matchers.annotations;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
@@ -51,8 +50,7 @@ import java.util.List;
         "Qualifiers/Scope annotations on @Inject methods don't have any effect."
             + " Move the qualifier annotation to the binding location.",
     severity = SeverityLevel.WARNING,
-    tags = StandardTags.LIKELY_ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.LIKELY_ERROR)
 public class QualifierOrScopeOnInjectMethod extends BugChecker implements MethodTreeMatcher {
 
   private static final MultiMatcher<MethodTree, AnnotationTree> QUALIFIER_ANNOTATION_FINDER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/QualifierWithTypeUse.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/QualifierWithTypeUse.java
@@ -28,7 +28,6 @@ import static com.sun.source.tree.Tree.Kind.ANNOTATION_TYPE;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -57,8 +56,7 @@ import java.util.Set;
         "Injection frameworks currently don't understand Qualifiers in TYPE_PARAMETER or"
             + " TYPE_USE contexts.",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public class QualifierWithTypeUse extends BugChecker implements ClassTreeMatcher {
 
   private static final MultiMatcher<ClassTree, AnnotationTree> HAS_TARGET_ANNOTATION =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/ScopeAnnotationOnInterfaceOrAbstractClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/ScopeAnnotationOnInterfaceOrAbstractClass.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.matchers.Matchers.hasAnnotation;
 import static javax.lang.model.element.Modifier.ABSTRACT;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.AnnotationTreeMatcher;
@@ -42,8 +41,7 @@ import com.sun.tools.javac.code.Flags;
 @BugPattern(
     name = "InjectScopeAnnotationOnInterfaceOrAbstractClass",
     summary = "Scope annotation on an interface or abstract class is not allowed",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class ScopeAnnotationOnInterfaceOrAbstractClass extends BugChecker
     implements AnnotationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/ScopeOrQualifierAnnotationRetention.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/ScopeOrQualifierAnnotationRetention.java
@@ -28,7 +28,6 @@ import static com.google.errorprone.matchers.Matchers.kindIs;
 import static com.sun.source.tree.Tree.Kind.ANNOTATION_TYPE;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
@@ -47,8 +46,7 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "InjectScopeOrQualifierAnnotationRetention",
     summary = "Scoping and qualifier annotations must have runtime retention.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class ScopeOrQualifierAnnotationRetention extends BugChecker implements ClassTreeMatcher {
 
   private static final String RETENTION_ANNOTATION = "java.lang.annotation.Retention";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/EmptySetMultibindingContributions.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/EmptySetMultibindingContributions.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -69,8 +68,7 @@ import java.util.TreeSet;
     summary =
         "@Multibinds is a more efficient and declarative mechanism for ensuring that a set"
             + " multibinding is present in the graph.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class EmptySetMultibindingContributions extends BugChecker
     implements MethodTreeMatcher {
   private static final Matcher<AnnotationTree> HAS_DAGGER_ONE_MODULE_ARGUMENT =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/PrivateConstructorForNoninstantiableModule.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/PrivateConstructorForNoninstantiableModule.java
@@ -28,7 +28,6 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.FluentIterable;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
@@ -44,8 +43,7 @@ import com.sun.source.tree.Tree;
 @BugPattern(
     name = "PrivateConstructorForNoninstantiableModule",
     summary = "Add a private constructor to modules that will not be instantiated by Dagger.",
-    severity = SUGGESTION,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public class PrivateConstructorForNoninstantiableModule extends BugChecker
     implements ClassTreeMatcher {
   private static final Predicate<Tree> IS_CONSTRUCTOR =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/ProvidesNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/ProvidesNull.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns.inject.dagger;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.ReturnTreeMatcher;
@@ -43,8 +42,7 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
 @BugPattern(
     name = "DaggerProvidesNull",
     summary = "Dagger @Provides methods may not return null unless annotated with @Nullable",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class ProvidesNull extends BugChecker implements ReturnTreeMatcher {
 
   /**

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/ScopeOnModule.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/ScopeOnModule.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.util.ASTHelpers.getSymbol;
 import static com.google.errorprone.util.ASTHelpers.hasAnnotation;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
@@ -37,8 +36,7 @@ import java.util.List;
 @BugPattern(
     name = "ScopeOnModule",
     summary = "Scopes on modules have no function and will soon be an error.",
-    severity = SUGGESTION,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public final class ScopeOnModule extends BugChecker implements ClassTreeMatcher {
   @Override
   public Description matchClass(ClassTree classTree, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/UseBinds.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/UseBinds.java
@@ -35,7 +35,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -67,8 +66,7 @@ import javax.lang.model.element.Modifier;
 @BugPattern(
     name = "UseBinds",
     summary = "@Binds is a more efficient and declarative mechanism for delegating a binding.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class UseBinds extends BugChecker implements MethodTreeMatcher {
   private static final Matcher<MethodTree> SIMPLE_METHOD =
       new Matcher<MethodTree>() {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/AssistedInjectScoping.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/AssistedInjectScoping.java
@@ -30,7 +30,6 @@ import static com.google.errorprone.matchers.Matchers.hasAnnotation;
 import static com.google.errorprone.matchers.Matchers.methodHasParameters;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
@@ -55,8 +54,7 @@ import com.sun.source.tree.MethodTree;
 @BugPattern(
     name = "GuiceAssistedInjectScoping",
     summary = "Scope annotation on implementation class of AssistedInject factory is not allowed",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class AssistedInjectScoping extends BugChecker implements ClassTreeMatcher {
 
   /** Matches classes that have an annotation that itself is annotated with @ScopeAnnotation. */

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/InjectOnFinalField.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/InjectOnFinalField.java
@@ -23,7 +23,6 @@ import static com.google.errorprone.matchers.Matchers.isField;
 import static javax.lang.model.element.Modifier.FINAL;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
@@ -38,8 +37,7 @@ import com.sun.source.tree.VariableTree;
     summary =
         "Although Guice allows injecting final fields, doing so is disallowed because the injected "
             + "value may not be visible to other threads.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class InjectOnFinalField extends BugChecker implements VariableTreeMatcher {
 
   private static final Matcher<VariableTree> FINAL_FIELD_WITH_GUICE_INJECT =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/OverridesGuiceInjectableMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/OverridesGuiceInjectableMethod.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.InjectMatchers.JAVAX_INJECT_ANNOTAT
 import static com.google.errorprone.matchers.InjectMatchers.hasInjectAnnotation;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -45,8 +44,7 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
         "This method is not annotated with @Inject, but it overrides a "
             + "method that is annotated with @com.google.inject.Inject. Guice will inject this "
             + "method, and it is recommended to annotate it explicitly.",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class OverridesGuiceInjectableMethod extends BugChecker implements MethodTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/OverridesJavaxInjectableMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/OverridesJavaxInjectableMethod.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.InjectMatchers.JAVAX_INJECT_ANNOTAT
 import static com.google.errorprone.matchers.InjectMatchers.hasInjectAnnotation;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
@@ -44,8 +43,7 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
     summary =
         "This method is not annotated with @Inject, but it overrides a method that is "
             + " annotated with @javax.inject.Inject. The method will not be Injected.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class OverridesJavaxInjectableMethod extends BugChecker implements MethodTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/ProvidesMethodOutsideOfModule.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/guice/ProvidesMethodOutsideOfModule.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.matchers.Matchers.isType;
 import static com.google.errorprone.matchers.Matchers.not;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.AnnotationTreeMatcher;
@@ -35,8 +34,7 @@ import com.sun.source.tree.AnnotationTree;
 @BugPattern(
     name = "ProvidesMethodOutsideOfModule",
     summary = "@Provides methods need to be declared in a Module to have any effect.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public class ProvidesMethodOutsideOfModule extends BugChecker implements AnnotationTreeMatcher {
 
   private static final Matcher<AnnotationTree> PROVIDES_ANNOTATION_ON_METHOD_OUTSIDE_OF_MODULE =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/AlmostJavadoc.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/AlmostJavadoc.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.javadoc;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.BugPattern.StandardTags.STYLE;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
@@ -56,7 +55,6 @@ import javax.lang.model.element.ElementKind;
             + " (/**); is it meant to be Javadoc?",
     severity = WARNING,
     tags = STYLE,
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     documentSuppression = false)
 public final class AlmostJavadoc extends BugChecker implements CompilationUnitTreeMatcher {
   private static final Pattern HAS_TAG =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/EmptyBlockTag.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/EmptyBlockTag.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.bugpatterns.javadoc.Utils.diagnosticPosition;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -58,7 +57,6 @@ import java.util.List;
     linkType = CUSTOM,
     link = "http://google.github.io/styleguide/javaguide.html#s7.1.3-javadoc-block-tags",
     tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
     documentSuppression = false)
 public final class EmptyBlockTag extends BugChecker
     implements ClassTreeMatcher, MethodTreeMatcher, VariableTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/EscapedEntity.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/EscapedEntity.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.javadoc;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.BugPattern.StandardTags.STYLE;
 import static com.google.errorprone.bugpatterns.javadoc.Utils.diagnosticPosition;
@@ -50,7 +49,6 @@ import javax.annotation.Nullable;
     summary = "HTML entities in @code/@literal tags will appear literally in the rendered javadoc.",
     severity = WARNING,
     tags = STYLE,
-    providesFix = NO_FIX,
     documentSuppression = false)
 public final class EscapedEntity extends BugChecker
     implements ClassTreeMatcher, MethodTreeMatcher, VariableTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/InheritDoc.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/InheritDoc.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.util.ASTHelpers.findSuperMethods;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -49,7 +48,6 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
     summary = "Invalid use of @inheritDoc.",
     severity = WARNING,
     tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
     documentSuppression = false)
 public final class InheritDoc extends BugChecker
     implements ClassTreeMatcher, MethodTreeMatcher, VariableTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/InvalidBlockTag.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/InvalidBlockTag.java
@@ -25,7 +25,6 @@ import static com.google.errorprone.bugpatterns.javadoc.Utils.replace;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -62,7 +61,6 @@ import java.util.Set;
     summary = "This tag is invalid.",
     severity = WARNING,
     tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
     documentSuppression = false)
 public final class InvalidBlockTag extends BugChecker
     implements ClassTreeMatcher, MethodTreeMatcher, VariableTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/InvalidInlineTag.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/InvalidInlineTag.java
@@ -25,7 +25,6 @@ import static java.util.stream.Collectors.joining;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -68,7 +67,6 @@ import java.util.regex.Pattern;
     summary = "This tag is invalid.",
     severity = WARNING,
     tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
     documentSuppression = false)
 public final class InvalidInlineTag extends BugChecker
     implements ClassTreeMatcher, MethodTreeMatcher, VariableTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/InvalidParam.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/InvalidParam.java
@@ -28,7 +28,6 @@ import static com.google.errorprone.names.LevenshteinEditDistance.getEditDistanc
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -59,7 +58,6 @@ import java.util.regex.Pattern;
     summary = "This @param tag doesn't refer to a parameter of the method.",
     severity = WARNING,
     tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
     documentSuppression = false)
 public final class InvalidParam extends BugChecker implements ClassTreeMatcher, MethodTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/InvalidThrows.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/InvalidThrows.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.util.ASTHelpers.getType;
 import static com.google.errorprone.util.ASTHelpers.isSubtype;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -47,7 +46,6 @@ import javax.lang.model.element.Element;
     summary = "The documented method doesn't actually throw this checked exception.",
     severity = WARNING,
     tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
     documentSuppression = false)
 public final class InvalidThrows extends BugChecker implements MethodTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/MissingSummary.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/MissingSummary.java
@@ -28,7 +28,6 @@ import static com.google.errorprone.util.ASTHelpers.hasAnnotation;
 import static java.util.stream.Collectors.joining;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
@@ -65,7 +64,6 @@ import javax.lang.model.element.Modifier;
     tags = STYLE,
     linkType = CUSTOM,
     link = "http://google.github.io/styleguide/javaguide.html#s7.2-summary-fragment",
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
     documentSuppression = false)
 public final class MissingSummary extends BugChecker
     implements ClassTreeMatcher, MethodTreeMatcher, VariableTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/ReturnFromVoid.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/ReturnFromVoid.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.util.ASTHelpers.getType;
 import static com.google.errorprone.util.ASTHelpers.isSameType;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -43,7 +42,6 @@ import com.sun.source.util.DocTreePathScanner;
     summary = "Void methods should not have a @return tag.",
     severity = WARNING,
     tags = StandardTags.STYLE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION,
     documentSuppression = false)
 public final class ReturnFromVoid extends BugChecker implements MethodTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/UnescapedEntity.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/UnescapedEntity.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.javadoc;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.BugPattern.StandardTags.STYLE;
 import static com.google.errorprone.bugpatterns.javadoc.Utils.diagnosticPosition;
@@ -70,7 +69,6 @@ import javax.annotation.Nullable;
     summary = "Javadoc is interpreted as HTML, so HTML entities such as &, <, > must be escaped.",
     severity = WARNING,
     tags = STYLE,
-    providesFix = REQUIRES_HUMAN_ATTENTION,
     documentSuppression = false)
 public final class UnescapedEntity extends BugChecker
     implements ClassTreeMatcher, MethodTreeMatcher, VariableTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/EqualsBrokenForNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/EqualsBrokenForNull.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.util.ASTHelpers.getSymbol;
 import static com.google.errorprone.util.ASTHelpers.isConsideredFinal;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -61,8 +60,7 @@ import javax.annotation.Nullable;
 @BugPattern(
     name = "EqualsBrokenForNull",
     summary = "equals() implementation may throw NullPointerException when given null",
-    severity = SeverityLevel.WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SeverityLevel.WARNING)
 public class EqualsBrokenForNull extends BugChecker implements MethodTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/FieldMissingNullable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/FieldMissingNullable.java
@@ -16,7 +16,6 @@
 
 package com.google.errorprone.bugpatterns.nullness;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 
 import com.google.errorprone.BugPattern;
@@ -51,8 +50,7 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "FieldMissingNullable",
     summary = "Fields that can be null should be annotated @Nullable",
-    severity = SUGGESTION,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public class FieldMissingNullable extends BugChecker
     implements AssignmentTreeMatcher, VariableTreeMatcher {
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/NullableDereference.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/NullableDereference.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MemberSelectTreeMatcher;
@@ -58,8 +57,7 @@ import javax.lang.model.type.TypeVariable;
 @BugPattern(
     name = "NullableDereference",
     summary = "Dereference of possibly-null value",
-    severity = WARNING,
-    providesFix = ProvidesFix.NO_FIX)
+    severity = WARNING)
 public class NullableDereference extends BugChecker
     implements MemberSelectTreeMatcher, MethodInvocationTreeMatcher, NewClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/ParameterNotNullable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/ParameterNotNullable.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns.nullness;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.ArrayAccessTreeMatcher;
@@ -46,8 +45,7 @@ import javax.lang.model.element.ElementKind;
 @BugPattern(
     name = "ParameterNotNullable",
     summary = "Method parameters that aren't checked for null shouldn't be annotated @Nullable",
-    severity = SUGGESTION,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public class ParameterNotNullable extends BugChecker
     implements MemberSelectTreeMatcher, ArrayAccessTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/UnnecessaryCheckNotNull.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/UnnecessaryCheckNotNull.java
@@ -23,7 +23,6 @@ import static com.sun.source.tree.Tree.Kind.STRING_LITERAL;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -62,8 +61,7 @@ import java.util.Set;
     name = "UnnecessaryCheckNotNull",
     summary = "This null check is unnecessary; the expression can never be null",
     severity = ERROR,
-    altNames = {"PreconditionsCheckNotNull", "PreconditionsCheckNotNullPrimitive"},
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    altNames = {"PreconditionsCheckNotNull", "PreconditionsCheckNotNullPrimitive"})
 public class UnnecessaryCheckNotNull extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<MethodInvocationTree> CHECK_NOT_NULL_MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/DoubleCheckedLocking.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/DoubleCheckedLocking.java
@@ -22,7 +22,6 @@ import static com.google.errorprone.util.ASTHelpers.stripParentheses;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -59,8 +58,7 @@ import javax.lang.model.element.Modifier;
     name = "DoubleCheckedLocking",
     summary = "Double-checked locking on non-volatile fields is unsafe",
     severity = WARNING,
-    tags = StandardTags.FRAGILE_CODE,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.FRAGILE_CODE)
 public class DoubleCheckedLocking extends BugChecker implements IfTreeMatcher {
   @Override
   public Description matchIf(IfTree outerIf, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableAnnotationChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableAnnotationChecker.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.util.ASTHelpers.getType;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
@@ -48,8 +47,7 @@ import java.util.Optional;
     altNames = "Immutable",
     summary = "Annotations should always be immutable",
     severity = WARNING,
-    tags = StandardTags.LIKELY_ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    tags = StandardTags.LIKELY_ERROR)
 public class ImmutableAnnotationChecker extends BugChecker implements ClassTreeMatcher {
 
   public static final String ANNOTATED_ANNOTATION_MESSAGE =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableChecker.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.annotations.Immutable;
@@ -64,8 +63,7 @@ import java.util.Optional;
     name = "Immutable",
     summary = "Type declaration annotated with @Immutable is not immutable",
     severity = ERROR,
-    documentSuppression = false,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    documentSuppression = false)
 public class ImmutableChecker extends BugChecker
     implements ClassTreeMatcher,
         NewClassTreeMatcher,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableEnumChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableEnumChecker.java
@@ -24,7 +24,6 @@ import static com.google.errorprone.util.ASTHelpers.getType;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.annotations.Immutable;
@@ -46,8 +45,7 @@ import java.util.stream.Stream;
     name = "ImmutableEnumChecker",
     altNames = "Immutable",
     summary = "Enums should always be immutable",
-    severity = WARNING,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public class ImmutableEnumChecker extends BugChecker implements ClassTreeMatcher {
 
   public static final String ANNOTATED_ENUM_MESSAGE =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableRefactoring.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableRefactoring.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
@@ -40,8 +39,7 @@ import java.util.Optional;
 @BugPattern(
     name = "ImmutableRefactoring",
     summary = "Refactors uses of the JSR 305 @Immutable to Error Prone's annotation",
-    severity = SUGGESTION,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = SUGGESTION)
 public class ImmutableRefactoring extends BugChecker implements CompilationUnitTreeMatcher {
 
   @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationFrom.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationFrom.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.matchers.Matchers.isSameType;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -44,8 +43,7 @@ import java.time.Period;
     explanation =
         "Duration.from(TemporalAmount) will always throw a UnsupportedTemporalTypeException when "
             + "passed a Period and return itself when passed a Duration.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public final class DurationFrom extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> DURATION_FROM =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationGetTemporalUnit.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationGetTemporalUnit.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -51,8 +50,7 @@ import java.util.Optional;
             + "`duration.get(ChronoUnit)`. Instead, please use `duration.toNanos()`, "
             + "`Durations.toMicros(duration)`, `duration.toMillis()`, `duration.getSeconds()`, "
             + "`duration.toMinutes()`, `duration.toHours()`, or `duration.toDays()`.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public final class DurationGetTemporalUnit extends BugChecker
     implements MethodInvocationTreeMatcher {
   private static final EnumSet<ChronoUnit> INVALID_TEMPORAL_UNITS =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationTemporalUnit.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationTemporalUnit.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns.time;
 
 import static com.google.common.collect.Sets.toImmutableEnumSet;
-import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.bugpatterns.time.DurationGetTemporalUnit.getInvalidChronoUnit;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -49,8 +48,7 @@ import java.util.Arrays;
         "Duration APIs only work for TemporalUnits with exact durations or"
             + " ChronoUnit.DAYS. E.g., Duration.of(1, ChronoUnit.YEARS) is guaranteed to throw a"
             + " DateTimeException.",
-    severity = ERROR,
-    providesFix = NO_FIX)
+    severity = ERROR)
 public final class DurationTemporalUnit extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final String DURATION = "java.time.Duration";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationToLongTimeUnit.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/DurationToLongTimeUnit.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
@@ -54,8 +53,7 @@ import java.util.concurrent.TimeUnit;
 @BugPattern(
     name = "DurationToLongTimeUnit",
     summary = "Unit mismatch when decomposing a Duration or Instant to call a <long, TimeUnit> API",
-    severity = ERROR,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 // TODO(kak): we should probably rename this as it works for Instants/Timestamps too
 public final class DurationToLongTimeUnit extends BugChecker
     implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/InstantTemporalUnit.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/InstantTemporalUnit.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns.time;
 
 import static com.google.common.collect.Sets.toImmutableEnumSet;
-import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.bugpatterns.time.DurationGetTemporalUnit.getInvalidChronoUnit;
 import static com.google.errorprone.matchers.Matchers.allOf;
@@ -46,8 +45,7 @@ import java.util.Arrays;
     summary =
         "Instant APIs only work for NANOS, MICROS, MILLIS, SECONDS, MINUTES, HOURS, HALF_DAYS and"
             + " DAYS.",
-    severity = ERROR,
-    providesFix = NO_FIX)
+    severity = ERROR)
 public final class InstantTemporalUnit extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final String INSTANT = "java.time.Instant";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaDurationWithNanos.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaDurationWithNanos.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.not;
@@ -45,8 +44,7 @@ import com.sun.tools.javac.tree.JCTree;
             + "the current Duration instance, but _only_ the nano field is mutated (the seconds "
             + "field is copied directly). Use Duration.ofSeconds(duration.getSeconds(), nanos) "
             + "instead.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class JavaDurationWithNanos extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaDurationWithSeconds.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaDurationWithSeconds.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.Iterables;
@@ -41,8 +40,7 @@ import com.sun.source.tree.MethodInvocationTree;
             + "of the current Duration instance, but _only_ the seconds field is mutated (the "
             + "nanos field is copied directly). Use Duration.ofSeconds(seconds, "
             + "duration.getNano()) instead.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class JavaDurationWithSeconds extends BugChecker
     implements MethodInvocationTreeMatcher {
   private static final Matcher<ExpressionTree> MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaTimeDefaultTimeZone.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JavaTimeDefaultTimeZone.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.ImmutableSet;
@@ -43,8 +42,7 @@ import com.google.errorprone.fixes.SuggestedFixes;
             + "The default system time-zone can vary from machine to machine or JVM to JVM. "
             + "You must choose an explicit ZoneId."
     ,
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class JavaTimeDefaultTimeZone extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaDurationConstructor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaDurationConstructor.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -44,8 +43,7 @@ import com.sun.tools.javac.tree.JCTree;
             + "is frequently a source of bugs. Please use Duration.millis(long) instead. If your "
             + "Duration is better expressed in terms of other units, use standardSeconds(long), "
             + "standardMinutes(long), standardHours(long), or standardDays(long) instead.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class JodaDurationConstructor extends BugChecker implements NewClassTreeMatcher {
   private static final Matcher<ExpressionTree> MATCHER =
       allOf(

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaDurationWithMillis.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaDurationWithMillis.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.Iterables;
@@ -45,8 +44,7 @@ import com.sun.tools.javac.tree.JCTree;
             + "Please use Duration.millis(long) instead. If your Duration is better expressed in "
             + "terms of other units, use standardSeconds(long), standardMinutes(long), "
             + "standardHours(long), or standardDays(long) instead.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class JodaDurationWithMillis extends BugChecker
     implements MethodInvocationTreeMatcher {
   private static final Matcher<ExpressionTree> MATCHER =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaInstantWithMillis.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaInstantWithMillis.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.Iterables;
@@ -41,8 +40,7 @@ import com.sun.tools.javac.tree.JCTree;
         "Joda-Time's 'instant.withMillis(long)' method is often a source of bugs because it "
             + "doesn't mutate the current instance but rather returns a new immutable Instant "
             + "instance. Please use new Instant(long) instead.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class JodaInstantWithMillis extends BugChecker implements MethodInvocationTreeMatcher {
   private static final Matcher<ExpressionTree> MATCHER =
       Matchers.allOf(

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaNewPeriod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaNewPeriod.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -47,8 +46,7 @@ import java.util.List;
     summary =
         "This may have surprising semantics, e.g. new Period(LocalDate.parse(\"1970-01-01\"), "
             + "LocalDate.parse(\"1970-02-02\")).getDays() == 1, not 32.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class JodaNewPeriod extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final String READABLE_PARTIAL = "org.joda.time.ReadablePartial";

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaPlusMinusLong.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaPlusMinusLong.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.common.collect.ImmutableSet;
@@ -49,8 +48,7 @@ import java.util.List;
         "JodaTime's type.plus(long) and type.minus(long) methods are often a source of bugs "
             + "because the units of the parameters are ambiguous. Please use "
             + "type.plus(Duration.millis(long)) or type.minus(Duration.millis(long)) instead.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class JodaPlusMinusLong extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final ImmutableSet<String> TYPES =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaTimeConverterManager.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaTimeConverterManager.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.not;
@@ -38,8 +37,7 @@ import com.sun.source.tree.MethodInvocationTree;
         "Joda-Time's ConverterManager makes the semantics of DateTime/Instant/etc construction"
             + " subject to global static state. If you need to define your own converters, use"
             + " a helper.",
-    severity = WARNING,
-    providesFix = NO_FIX)
+    severity = WARNING)
 public final class JodaTimeConverterManager extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaToSelf.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaToSelf.java
@@ -17,7 +17,6 @@ package com.google.errorprone.bugpatterns.time;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.common.collect.ImmutableSet;
@@ -46,8 +45,7 @@ import com.sun.source.tree.NewClassTree;
         "Joda-Time's DateTime.toDateTime(), Duration.toDuration(), Instant.toInstant(), "
             + "Interval.toInterval(), and Period.toPeriod() are always unnecessary, since they "
             + "simply 'return this'. There is no reason to ever call them.",
-    severity = ERROR,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public final class JodaToSelf extends BugChecker
     implements MethodInvocationTreeMatcher, NewClassTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaWithDurationAddedLong.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/JodaWithDurationAddedLong.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.anyOf;
@@ -50,8 +49,7 @@ import com.sun.source.tree.MethodInvocationTree;
         "JodaTime's type.withDurationAdded(long, int) is often a source of bugs "
             + "because the units of the parameters are ambiguous. Please use "
             + "type.withDurationAdded(Duration.millis(long), int) instead.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class JodaWithDurationAddedLong extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/LocalDateTemporalAmount.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/LocalDateTemporalAmount.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Matchers.allOf;
 import static com.google.errorprone.matchers.Matchers.argument;
@@ -42,8 +41,7 @@ import com.sun.source.tree.MethodInvocationTree;
         "LocalDate.plus() and minus() does not work with Durations. LocalDate represents civil"
             + " time (years/months/days), so java.time.Period is the appropriate thing to add or"
             + " subtract instead.",
-    severity = ERROR,
-    providesFix = NO_FIX)
+    severity = ERROR)
 public final class LocalDateTemporalAmount extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PeriodFrom.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PeriodFrom.java
@@ -20,7 +20,6 @@ import static com.google.errorprone.matchers.Matchers.isSameType;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -44,8 +43,7 @@ import java.time.Duration;
     explanation =
         "Period.from(TemporalAmount) will always throw a DateTimeException when "
             + "passed a Duration and return itself when passed a Period.",
-    severity = ERROR,
-    providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+    severity = ERROR)
 public final class PeriodFrom extends BugChecker implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> PERIOD_FROM =

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PeriodGetTemporalUnit.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PeriodGetTemporalUnit.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.bugpatterns.time.DurationGetTemporalUnit.getInvalidChronoUnit;
 
@@ -43,8 +42,7 @@ import java.util.EnumSet;
         "`Period.get(TemporalUnit)` only works when passed `ChronoUnit.YEARS`, `ChronoUnit.MONTHS`,"
             + " or `ChronoUnit.DAYS`. All other values are guaranteed to throw an"
             + " `UnsupportedTemporalTypeException`.",
-    severity = ERROR,
-    providesFix = NO_FIX)
+    severity = ERROR)
 public final class PeriodGetTemporalUnit extends BugChecker implements MethodInvocationTreeMatcher {
   private static final EnumSet<ChronoUnit> INVALID_TEMPORAL_UNITS =
       EnumSet.complementOf(EnumSet.of(ChronoUnit.YEARS, ChronoUnit.MONTHS, ChronoUnit.DAYS));

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PeriodTimeMath.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PeriodTimeMath.java
@@ -23,7 +23,6 @@ import static com.google.errorprone.matchers.Matchers.isSameType;
 import static com.google.errorprone.matchers.Matchers.not;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -40,8 +39,7 @@ import com.sun.source.tree.MethodInvocationTree;
     explanation =
         "Period.(plus|minus)(TemporalAmount) will always throw a DateTimeException when passed a "
             + "Duration.",
-    severity = ERROR,
-    providesFix = ProvidesFix.NO_FIX)
+    severity = ERROR)
 public final class PeriodTimeMath extends BugChecker implements MethodInvocationTreeMatcher {
 
   private final Matcher<MethodInvocationTree> matcherToCheck;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.constructor;
@@ -74,8 +73,7 @@ import javax.annotation.Nullable;
         "Prefer using java.time-based APIs when available. Note that this checker does"
             + " not and cannot guarantee that the overloads have equivalent semantics, but that is"
             + " generally the case with overloaded methods.",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class PreferJavaTimeOverload extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/TemporalAccessorGetChronoField.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/TemporalAccessorGetChronoField.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.NO_FIX;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
 import com.google.common.collect.ImmutableList;
@@ -74,8 +73,7 @@ import java.util.Optional;
         "TemporalAccessor.get(ChronoField) only works for certain values of ChronoField. E.g., "
             + "DayOfWeek only supports DAY_OF_WEEK. All other values are guaranteed to throw an "
             + "UnsupportedTemporalTypeException.",
-    severity = ERROR,
-    providesFix = NO_FIX)
+    severity = ERROR)
 public final class TemporalAccessorGetChronoField extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/TimeUnitConversionChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/TimeUnitConversionChecker.java
@@ -15,7 +15,6 @@
  */
 package com.google.errorprone.bugpatterns.time;
 
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.instanceMethod;
 
@@ -48,8 +47,7 @@ import java.util.concurrent.TimeUnit;
             + "2) conversions that are converting from a given unit back to the same unit; "
             + "3) conversions that are converting from a smaller unit to a larger unit and passing "
             + "a constant value",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class TimeUnitConversionChecker extends BugChecker
     implements MethodInvocationTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/TimeUnitMismatch.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/TimeUnitMismatch.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns.time;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.isSameType;
@@ -79,8 +78,7 @@ import javax.annotation.Nullable;
     summary =
         "An value that appears to be represented in one unit is used where another appears to be "
             + "required (e.g., seconds where nanos are needed)",
-    severity = WARNING,
-    providesFix = REQUIRES_HUMAN_ATTENTION)
+    severity = WARNING)
 public final class TimeUnitMismatch extends BugChecker
     implements AssignmentTreeMatcher,
         MethodInvocationTreeMatcher,

--- a/core/src/test/java/com/google/errorprone/ErrorProneJavaCompilerTest.java
+++ b/core/src/test/java/com/google/errorprone/ErrorProneJavaCompilerTest.java
@@ -30,7 +30,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.bugpatterns.ArrayEquals;
 import com.google.errorprone.bugpatterns.BadShiftAmount;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -367,8 +366,7 @@ public class ErrorProneJavaCompilerTest {
               + " function by flipping bits in a single long[].",
       explanation = "",
       severity = ERROR,
-      disableable = false,
-      providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+      disableable = false)
   public static class DeleteMethod extends BugChecker implements ClassTreeMatcher {
     @Override
     public Description matchClass(ClassTree tree, VisitorState state) {

--- a/core/src/test/java/com/google/errorprone/ErrorProneJavacPluginTest.java
+++ b/core/src/test/java/com/google/errorprone/ErrorProneJavacPluginTest.java
@@ -31,7 +31,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.ReturnTreeMatcher;
@@ -317,11 +316,7 @@ public class ErrorProneJavacPluginTest {
   }
 
   /** A bugpattern for testing. */
-  @BugPattern(
-      name = "TestCompilesWithFix",
-      summary = "",
-      severity = SeverityLevel.ERROR,
-      providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+  @BugPattern(name = "TestCompilesWithFix", summary = "", severity = SeverityLevel.ERROR)
   public static class TestCompilesWithFix extends BugChecker implements ReturnTreeMatcher {
 
     @Override

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ReturnValueIgnoredTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ReturnValueIgnoredTest.java
@@ -141,6 +141,22 @@ public class ReturnValueIgnoredTest {
   }
 
   @Test
+  public void issue1565_enumDeclaration() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.function.Function;",
+            "enum Test {",
+            "  A;",
+            "  void f(Function<Integer, Integer> f) {",
+            "    // BUG: Diagnostic contains: ReturnValueIgnored",
+            "    f.apply(0);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void issue1363_dateTimeFormatterBuilder() {
     compilationHelper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
+++ b/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.fixes;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH;
-import static com.google.errorprone.BugPattern.ProvidesFix.REQUIRES_HUMAN_ATTENTION;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.matchers.Matchers.isSameType;
@@ -31,7 +30,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -92,11 +90,7 @@ public class SuggestedFixesTest {
   }
 
   /** Test checker that adds or removes modifiers. */
-  @BugPattern(
-      name = "EditModifiers",
-      summary = "Edits modifiers",
-      severity = ERROR,
-      providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+  @BugPattern(name = "EditModifiers", summary = "Edits modifiers", severity = ERROR)
   public static class EditModifiersChecker extends BugChecker
       implements VariableTreeMatcher, MethodTreeMatcher {
 
@@ -263,11 +257,7 @@ public class SuggestedFixesTest {
   }
 
   /** Test checker that casts returned expression. */
-  @BugPattern(
-      name = "CastReturn",
-      severity = ERROR,
-      summary = "Adds casts to returned expressions",
-      providesFix = REQUIRES_HUMAN_ATTENTION)
+  @BugPattern(name = "CastReturn", severity = ERROR, summary = "Adds casts to returned expressions")
   public static class CastReturn extends BugChecker implements ReturnTreeMatcher {
 
     @Override
@@ -286,11 +276,7 @@ public class SuggestedFixesTest {
   }
 
   /** Test checker that casts returned expression. */
-  @BugPattern(
-      name = "CastReturn",
-      severity = ERROR,
-      summary = "Adds casts to returned expressions",
-      providesFix = REQUIRES_HUMAN_ATTENTION)
+  @BugPattern(name = "CastReturn", severity = ERROR, summary = "Adds casts to returned expressions")
   public static class CastReturnFullType extends BugChecker implements ReturnTreeMatcher {
 
     @Override
@@ -423,11 +409,7 @@ public class SuggestedFixesTest {
   }
 
   /** A test check that adds an annotation to all return types. */
-  @BugPattern(
-      name = "AddAnnotation",
-      summary = "Add an annotation",
-      severity = ERROR,
-      providesFix = REQUIRES_HUMAN_ATTENTION)
+  @BugPattern(name = "AddAnnotation", summary = "Add an annotation", severity = ERROR)
   public static class AddAnnotation extends BugChecker implements BugChecker.MethodTreeMatcher {
     @Override
     public Description matchMethod(MethodTree tree, VisitorState state) {
@@ -586,8 +568,7 @@ public class SuggestedFixesTest {
   @BugPattern(
       name = "ReplaceReturnType",
       summary = "Change the method return type",
-      severity = ERROR,
-      providesFix = REQUIRES_HUMAN_ATTENTION)
+      severity = ERROR)
   public static class ReplaceReturnType extends BugChecker implements BugChecker.MethodTreeMatcher {
     private final String newReturnType;
 
@@ -619,8 +600,7 @@ public class SuggestedFixesTest {
   @BugPattern(
       name = "ReplaceReturnTypeString",
       summary = "Change the method return type",
-      severity = ERROR,
-      providesFix = REQUIRES_HUMAN_ATTENTION)
+      severity = ERROR)
   public static class ReplaceReturnTypeString extends BugChecker
       implements BugChecker.MethodTreeMatcher {
     private final String newReturnType;
@@ -786,8 +766,7 @@ public class SuggestedFixesTest {
   @BugPattern(
       name = "ReplaceMethodInvocations",
       summary = "Replaces checkNotNull with verifyNotNull.",
-      severity = ERROR,
-      providesFix = REQUIRES_HUMAN_ATTENTION)
+      severity = ERROR)
   public static class ReplaceMethodInvocations extends BugChecker
       implements BugChecker.MethodInvocationTreeMatcher {
     private static final Matcher<ExpressionTree> CHECK_NOT_NULL =
@@ -893,8 +872,7 @@ public class SuggestedFixesTest {
   @BugPattern(
       name = "JavadocQualifier",
       summary = "all javadoc links should be qualified",
-      severity = ERROR,
-      providesFix = REQUIRES_HUMAN_ATTENTION)
+      severity = ERROR)
   public static class JavadocQualifier extends BugChecker implements BugChecker.ClassTreeMatcher {
     @Override
     public Description matchClass(ClassTree tree, final VisitorState state) {
@@ -943,11 +921,7 @@ public class SuggestedFixesTest {
         .doTest(TEXT_MATCH);
   }
 
-  @BugPattern(
-      name = "SuppressMe",
-      summary = "",
-      severity = ERROR,
-      providesFix = REQUIRES_HUMAN_ATTENTION)
+  @BugPattern(name = "SuppressMe", summary = "", severity = ERROR)
   static final class SuppressMe extends BugChecker
       implements LiteralTreeMatcher, VariableTreeMatcher {
     @Override
@@ -1022,11 +996,7 @@ public class SuggestedFixesTest {
         .doTest();
   }
 
-  @BugPattern(
-      name = "SuppressMeWithComment",
-      summary = "",
-      severity = ERROR,
-      providesFix = REQUIRES_HUMAN_ATTENTION)
+  @BugPattern(name = "SuppressMeWithComment", summary = "", severity = ERROR)
   static final class SuppressMeWithComment extends BugChecker implements LiteralTreeMatcher {
     private final String lineComment;
 
@@ -1114,11 +1084,7 @@ public class SuggestedFixesTest {
         .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
   }
 
-  @BugPattern(
-      name = "RemoveSuppressFromMe",
-      summary = "",
-      severity = ERROR,
-      providesFix = REQUIRES_HUMAN_ATTENTION)
+  @BugPattern(name = "RemoveSuppressFromMe", summary = "", severity = ERROR)
   static final class RemoveSuppressFromMe extends BugChecker implements LiteralTreeMatcher {
 
     @Override
@@ -1212,11 +1178,7 @@ public class SuggestedFixesTest {
   }
 
   /** A test bugchecker that deletes any field whose removal doesn't break the compilation. */
-  @BugPattern(
-      name = "CompilesWithFixChecker",
-      summary = "",
-      severity = ERROR,
-      providesFix = REQUIRES_HUMAN_ATTENTION)
+  @BugPattern(name = "CompilesWithFixChecker", summary = "", severity = ERROR)
   public static class CompilesWithFixChecker extends BugChecker implements VariableTreeMatcher {
     @Override
     public Description matchVariable(VariableTree tree, VisitorState state) {
@@ -1251,11 +1213,7 @@ public class SuggestedFixesTest {
   }
 
   /** A test bugchecker that deletes an exception from throws. */
-  @BugPattern(
-      name = "RemovesExceptionChecker",
-      summary = "",
-      severity = ERROR,
-      providesFix = REQUIRES_HUMAN_ATTENTION)
+  @BugPattern(name = "RemovesExceptionChecker", summary = "", severity = ERROR)
   public static class RemovesExceptionsChecker extends BugChecker implements MethodTreeMatcher {
 
     private final int index;
@@ -1352,11 +1310,7 @@ public class SuggestedFixesTest {
   }
 
   /** Test checker that renames variables. */
-  @BugPattern(
-      name = "RenamesVariableChecker",
-      summary = "",
-      severity = ERROR,
-      providesFix = REQUIRES_HUMAN_ATTENTION)
+  @BugPattern(name = "RenamesVariableChecker", summary = "", severity = ERROR)
   public static class RenamesVariableChecker extends BugChecker implements VariableTreeMatcher {
 
     private final String toReplace;
@@ -1554,11 +1508,7 @@ public class SuggestedFixesTest {
   }
 
   /** Test checker that removes and adds modifiers in the same fix. */
-  @BugPattern(
-      name = "RemoveAddModifier",
-      summary = "",
-      severity = ERROR,
-      providesFix = REQUIRES_HUMAN_ATTENTION)
+  @BugPattern(name = "RemoveAddModifier", summary = "", severity = ERROR)
   public static class RemoveAddModifier extends BugChecker implements ClassTreeMatcher {
 
     @Override
@@ -1584,8 +1534,7 @@ public class SuggestedFixesTest {
   @BugPattern(
       name = "PrefixAddImportCheck",
       summary = "A bugchecker for testing suggested fixes.",
-      severity = ERROR,
-      providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+      severity = ERROR)
   public static class PrefixAddImportCheck extends BugChecker implements ClassTreeMatcher {
     @Override
     public Description matchClass(ClassTree tree, VisitorState state) {
@@ -1622,11 +1571,7 @@ public class SuggestedFixesTest {
         .isEqualTo(URI.create("file:/com/google/Foo.java"));
   }
 
-  @BugPattern(
-      name = "RenameMethodChecker",
-      summary = "RenameMethodChecker",
-      severity = ERROR,
-      providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+  @BugPattern(name = "RenameMethodChecker", summary = "RenameMethodChecker", severity = ERROR)
   private static class RenameMethodChecker extends BugChecker
       implements MethodInvocationTreeMatcher {
     @Override
@@ -1670,8 +1615,7 @@ public class SuggestedFixesTest {
   @BugPattern(
       name = "QualifyTypeLocalClassChecker",
       summary = "QualifyTypeLocalClassChecker",
-      severity = ERROR,
-      providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+      severity = ERROR)
   public static class QualifyTypeLocalClassChecker extends BugChecker
       implements NewClassTreeMatcher {
 

--- a/core/src/test/java/com/google/errorprone/matchers/MethodMatchersTest.java
+++ b/core/src/test/java/com/google/errorprone/matchers/MethodMatchersTest.java
@@ -23,7 +23,6 @@ import static com.google.errorprone.matchers.Matchers.staticMethod;
 import static com.google.errorprone.matchers.method.MethodMatchers.constructor;
 
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
@@ -45,11 +44,7 @@ import org.junit.runners.JUnit4;
 public class MethodMatchersTest {
 
   /** A bugchecker to test constructor matching. */
-  @BugPattern(
-      name = "ConstructorDeleter",
-      summary = "Deletes constructors",
-      severity = ERROR,
-      providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+  @BugPattern(name = "ConstructorDeleter", summary = "Deletes constructors", severity = ERROR)
   public static class ConstructorDeleter extends BugChecker
       implements BugChecker.MethodInvocationTreeMatcher,
           BugChecker.NewClassTreeMatcher,

--- a/test_helpers/src/test/java/com/google/errorprone/BugCheckerRefactoringTestHelperTest.java
+++ b/test_helpers/src/test/java/com/google/errorprone/BugCheckerRefactoringTestHelperTest.java
@@ -21,7 +21,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static org.junit.Assert.fail;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
-import com.google.errorprone.BugPattern.ProvidesFix;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.AnnotationTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
@@ -191,8 +190,7 @@ public class BugCheckerRefactoringTestHelperTest {
       name = "ReturnNullRefactoring",
       summary = "Mock refactoring that replaces all returns with 'return null;' statement.",
       explanation = "For test purposes only.",
-      severity = SUGGESTION,
-      providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+      severity = SUGGESTION)
   public static class ReturnNullRefactoring extends BugChecker implements ReturnTreeMatcher {
     @Override
     public Description matchReturn(ReturnTree tree, VisitorState state) {
@@ -204,8 +202,7 @@ public class BugCheckerRefactoringTestHelperTest {
       name = "RemoveAnnotationRefactoring",
       summary = "Mock refactoring that removes all annotations declared in package bar ",
       explanation = "For test purposes only.",
-      severity = SUGGESTION,
-      providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+      severity = SUGGESTION)
   public static class RemoveAnnotationRefactoring extends BugChecker
       implements AnnotationTreeMatcher {
 
@@ -252,8 +249,7 @@ public class BugCheckerRefactoringTestHelperTest {
       name = "ImportArrayList",
       summary = "Mock refactoring that imports an ArrayList",
       explanation = "For test purposes only.",
-      severity = SUGGESTION,
-      providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
+      severity = SUGGESTION)
   public static class ImportArrayList extends BugChecker implements CompilationUnitTreeMatcher {
 
     @Override


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove use of about-to-be-deprecated @BugPattern.providesFix.

61e9cf47daefe064fe4b9cd217d697ffa6da5d51

-------

<p> Update AbstractReturnValueIgnored to look for surrounding enum declarations.

Before this change, a function call in a top-level enum declaration would explode with a VerifyException.

Fixes #1565

c3deb94c2e3672013668082c04974bdb48d64d51