### PR TITLE
Fix to FallThrough to skip generated/mutated AST nodes (e.g. Lombok)

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/FallThrough.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FallThrough.java
@@ -61,10 +61,16 @@ public class FallThrough extends BugChecker implements SwitchTreeMatcher {
       // reported an error if that statement wasn't reachable, and the answer is
       // independent of any preceding statements.
       boolean completes = Reachability.canCompleteNormally(getLast(caseTree.stats));
+      int endPos = caseEndPosition(state, caseTree);
+      if (endPos < 0) {
+        // endPos is -1 when there is no matching source for this statement. This means
+        // we are looking at generated/mutated AST nodes (e.g. Lombok), skip.
+        break;
+      }
       String comments =
           state
               .getSourceCode()
-              .subSequence(caseEndPosition(state, caseTree), next.getStartPosition())
+              .subSequence(endPos, next.getStartPosition())
               .toString()
               .trim();
       if (completes && !FALL_THROUGH_PATTERN.matcher(comments).find()) {


### PR DESCRIPTION
There is a general issue with Lombok in that, by default, it modifies the AST on the fly.
In particular, this causes trouble for EP checks which query `state. getSourceCode()` and
try to match it to `Tree` objects they see. This is a hard problem to fix in general, but
this PR fixes a particular instance of this involving the `FallThrough` checker and 
`@lombok.Builder` on `@lombok.Singular` map fields.

In particular, we skip the check whenever we see that the end position of a case statement's
`Tree` seems to be less than 0 (e.g. not in the source).

I tried to construct a repro/test case for this, but it's not easy to include within `core/src/test`
as it would require the code to be built using the Lombok annotation processor in addition to 
the EP test compiler.

For reference, the code showing the issue looks something like this:

```
@lombok.Builder(toBuilder = true)
@lombok.Data
public class Test {
  @Singular private @Nullable Map<String, String> m;
  ...
}
```

Where Lombok constructs the initializer for `m` as something including a new switch
statement at the AST level (without matching source).