### PR TITLE
MOE Sync 2020-04-17

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/TrustingNullnessAnalysis.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/TrustingNullnessAnalysis.java
@@ -116,7 +116,7 @@ public final class TrustingNullnessAnalysis implements Serializable {
           .setCompilationUnit(fieldDeclPath.getCompilationUnit());
 
       Analysis<Nullness, AccessPathStore<Nullness>, TrustingNullnessPropagation> analysis =
-          new Analysis<>(nullnessPropagation, javacEnv);
+          new Analysis<>(nullnessPropagation);
       analysis.performAnalysis(cfg);
       return analysis.getValue(initializer);
     } finally {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DefaultPackage.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DefaultPackage.java
@@ -33,7 +33,6 @@ import com.sun.source.tree.CompilationUnitTree;
 @BugPattern(
     name = "DefaultPackage",
     summary = "Java classes shouldn't use default package",
-    documentSuppression = false,
     severity = WARNING)
 public final class DefaultPackage extends BugChecker implements CompilationUnitTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ProtectedMembersInFinalClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ProtectedMembersInFinalClass.java
@@ -63,9 +63,6 @@ public class ProtectedMembersInFinalClass extends BugChecker implements ClassTre
     if (!HAS_FINAL.matches(tree, state)) {
       return NO_MATCH;
     }
-    if (tree.getMembers().isEmpty()) {
-      return NO_MATCH;
-    }
 
     ImmutableList<Tree> relevantMembers =
         tree.getMembers().stream()
@@ -73,6 +70,7 @@ public class ProtectedMembersInFinalClass extends BugChecker implements ClassTre
             .filter(m -> HAS_PROTECTED.matches(m, state))
             .filter(
                 m -> !(m instanceof MethodTree) || methodHasNoParentMethod((MethodTree) m, state))
+            .filter(m -> !isSuppressed(m))
             .collect(toImmutableList());
     if (relevantMembers.isEmpty()) {
       return NO_MATCH;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/apidiff/AndroidJdkLibsChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/apidiff/AndroidJdkLibsChecker.java
@@ -125,6 +125,7 @@ public class AndroidJdkLibsChecker extends ApiDiffChecker {
         ImmutableSet.<String>builder()
             .addAll(BASE_ALLOWED_CLASSES)
             .add("java/io/UncheckedIOException")
+            .add("java/util/ArrayList")
             .add("java/util/Collection")
             .add("java/util/Comparator")
             .add("java/util/DoubleSummaryStatistics")

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MutableMethodReturnTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MutableMethodReturnTypeTest.java
@@ -393,4 +393,29 @@ public class MutableMethodReturnTypeTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void overridingMethod_specialNotice() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableList;",
+            "import com.google.inject.Provider;",
+            "import java.util.List;",
+            "class Test {",
+            "  private static final int getFooLength() {",
+            "    final Provider<List<String>> fooProvider = ",
+            "      new Provider<List<String>>() {",
+            "        @Override",
+            "        // BUG: Diagnostic contains: narrow the return type",
+            "        public List<String> get() {",
+            "          return ImmutableList.of(\"foo\", \"bar\");",
+            "        }",
+            "      };",
+            "    List<String> foo = fooProvider.get();",
+            "    return foo.size();",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ProtectedMembersInFinalClassTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ProtectedMembersInFinalClassTest.java
@@ -99,4 +99,16 @@ public class ProtectedMembersInFinalClassTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void methodSuppression() {
+    compilationHelper
+        .addSourceLines(
+            "in/Test.java",
+            "final class Test {",
+            "  @SuppressWarnings(\"ProtectedMembersInFinalClass\")",
+            "  protected void methodOne() {}",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> ProtectedMembersInFinalClass: allow suppression at the method level.

758b991ef8e2186c4196c5e9e2687b59de676a2b

-------

<p> Update checker framework version 3.3.0

Relevant changes (see https://checkerframework.org/changelog.txt):

* For collection methods with `Object` formal parameter type, such as
  contains, indexOf, and remove, the annotated JDK now forbids null as an
  argument.  To make the Nullness Checker permit null, pass
  `-Astubs=collection-object-parameters-may-be-null.astub`.

* The wrapper annotation EnsuresQualifiersIf was renamed to EnsuresQualifierIf.list

* Deprecated Analysis#Analysis(ProcessingEnvironment) and Analysis#Analysis(T,
  int, ProcessingEnvironment); use Analysis#Analysis(), Analysis#Analysis(int),
  Analysis#Analysis(T), and Analysis#Analysis(T, int) instead.

./third_party/java/checker_framework/update-checker \
    --old_version 3.2.0  \
    --checker_release 3.3.0

See b/144172692 for discussion of []

3514acc165c34f9275ac68e09bb5b80e0658b84a

-------

<p> Add MOE:strip_line for documentSuppression in DefaultPackage now that it is suppressible at class level ([]
RELNOTES: N/A

adb59329ead9d44d884d81be64b004ef6d905866

-------

<p> MutableMethodReturnType: add a note that you can return tighter types when overriding.

Seems to cause a lot of confusion.

a1136d26a4aafdc4cbdbb5c35dabd4c2ce4e400c

-------

<p> Don't complain about ArrayList.sort in AndroidJdkLibsChecker when Java 8 library
desugaring is enabled

follow-up to []

c06ba1314a83f23acf2d8f5e0595cbb4c84b1435