### PR TITLE
MOE Sync 2020-04-20

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/TrustingNullnessAnalysis.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/TrustingNullnessAnalysis.java
@@ -116,7 +116,7 @@ public final class TrustingNullnessAnalysis implements Serializable {
           .setCompilationUnit(fieldDeclPath.getCompilationUnit());
 
       Analysis<Nullness, AccessPathStore<Nullness>, TrustingNullnessPropagation> analysis =
-          new Analysis<>(nullnessPropagation, javacEnv);
+          new Analysis<>(nullnessPropagation);
       analysis.performAnalysis(cfg);
       return analysis.getValue(initializer);
     } finally {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DefaultPackage.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DefaultPackage.java
@@ -33,7 +33,6 @@ import com.sun.source.tree.CompilationUnitTree;
 @BugPattern(
     name = "DefaultPackage",
     summary = "Java classes shouldn't use default package",
-    documentSuppression = false,
     severity = WARNING)
 public final class DefaultPackage extends BugChecker implements CompilationUnitTreeMatcher {
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsInvalidPlaceholder.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PreconditionsInvalidPlaceholder.java
@@ -17,7 +17,11 @@
 package com.google.errorprone.bugpatterns;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Matchers.allOf;
+import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.google.errorprone.util.ASTHelpers.isSubtype;
 
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.StandardTags;
@@ -26,11 +30,11 @@ import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.Matchers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.MethodInvocationTree;
-import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import java.util.regex.Pattern;
 
 /** @author Louis Wasserman */
@@ -43,31 +47,33 @@ public class PreconditionsInvalidPlaceholder extends BugChecker
     implements MethodInvocationTreeMatcher {
 
   private static final Matcher<ExpressionTree> PRECONDITIONS_CHECK =
-      Matchers.<ExpressionTree>anyOf(
-          staticMethod().onClass("com.google.common.base.Preconditions").named("checkArgument"),
-          staticMethod().onClass("com.google.common.base.Preconditions").named("checkNotNull"),
-          staticMethod().onClass("com.google.common.base.Preconditions").named("checkState"));
+      allOf(
+          anyOf(
+              staticMethod().onClass("com.google.common.base.Preconditions"),
+              staticMethod().onClass("com.google.common.base.Verify")),
+          PreconditionsInvalidPlaceholder::secondParameterIsString);
 
-  private static int expectedArguments(String formatString) {
-    int count = 0;
-    for (int i = formatString.indexOf("%s"); i != -1; i = formatString.indexOf("%s", i + 1)) {
-      count++;
+  private static boolean secondParameterIsString(ExpressionTree tree, VisitorState state) {
+    Symbol symbol = getSymbol(tree);
+    if (!(symbol instanceof MethodSymbol)) {
+      return false;
     }
-    return count;
+    MethodSymbol methodSymbol = (MethodSymbol) symbol;
+    return methodSymbol.getParameters().size() >= 2
+        && isSubtype(methodSymbol.getParameters().get(1).type, state.getSymtab().stringType, state);
   }
 
   @Override
-  public Description matchMethodInvocation(MethodInvocationTree t, VisitorState state) {
-    if (PRECONDITIONS_CHECK.matches(t, state)
-        && t.getArguments().size() >= 2
-        && t.getArguments().get(1) instanceof LiteralTree) {
-      LiteralTree formatStringTree = (LiteralTree) t.getArguments().get(1);
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (PRECONDITIONS_CHECK.matches(tree, state)
+        && tree.getArguments().get(1) instanceof LiteralTree) {
+      LiteralTree formatStringTree = (LiteralTree) tree.getArguments().get(1);
       if (formatStringTree.getValue() instanceof String) {
         String formatString = (String) formatStringTree.getValue();
         int expectedArgs = expectedArguments(formatString);
-        if (expectedArgs < t.getArguments().size() - 2
+        if (expectedArgs < tree.getArguments().size() - 2
             && BAD_PLACEHOLDER_REGEX.matcher(formatString).find()) {
-          return describe(t, state);
+          return describe(tree, state);
         }
       }
     }
@@ -81,25 +87,32 @@ public class PreconditionsInvalidPlaceholder extends BugChecker
    * <p>This does not need to be completely exhaustive, since it is only used to suggest fixes.
    */
   private static final Pattern BAD_PLACEHOLDER_REGEX =
-      Pattern.compile("\\$s|%(?:\\d+\\$)??[dbBhHScCdoxXeEfgGaAtTn]|\\{\\d+\\}");
+      Pattern.compile("\\$s|%(?:\\d+\\$)??[dbBhHScCoxXeEfgGaAtTn]|\\{\\d+}");
 
-  public Description describe(MethodInvocationTree t, VisitorState state) {
-    LiteralTree formatTree = (LiteralTree) t.getArguments().get(1);
+  public Description describe(MethodInvocationTree tree, VisitorState state) {
+    LiteralTree formatTree = (LiteralTree) tree.getArguments().get(1);
 
     String fixedFormatString =
-        BAD_PLACEHOLDER_REGEX.matcher(state.getSourceForNode((JCTree) formatTree)).replaceAll("%s");
-    if (expectedArguments(fixedFormatString) == t.getArguments().size() - 2) {
+        BAD_PLACEHOLDER_REGEX.matcher(state.getSourceForNode(formatTree)).replaceAll("%s");
+    if (expectedArguments(fixedFormatString) == tree.getArguments().size() - 2) {
       return describeMatch(formatTree, SuggestedFix.replace(formatTree, fixedFormatString));
-    } else {
-      int missing = t.getArguments().size() - 2 - expectedArguments(fixedFormatString);
-      StringBuilder builder = new StringBuilder(fixedFormatString);
-      builder.deleteCharAt(builder.length() - 1);
-      builder.append(" [%s");
-      for (int i = 1; i < missing; i++) {
-        builder.append(", %s");
-      }
-      builder.append("]\"");
-      return describeMatch(t, SuggestedFix.replace(formatTree, builder.toString()));
     }
+    int missing = tree.getArguments().size() - 2 - expectedArguments(fixedFormatString);
+    StringBuilder builder = new StringBuilder(fixedFormatString);
+    builder.deleteCharAt(builder.length() - 1);
+    builder.append(" [%s");
+    for (int i = 1; i < missing; i++) {
+      builder.append(", %s");
+    }
+    builder.append("]\"");
+    return describeMatch(tree, SuggestedFix.replace(formatTree, builder.toString()));
+  }
+
+  private static int expectedArguments(String formatString) {
+    int count = 0;
+    for (int i = formatString.indexOf("%s"); i != -1; i = formatString.indexOf("%s", i + 1)) {
+      count++;
+    }
+    return count;
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ProtectedMembersInFinalClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ProtectedMembersInFinalClass.java
@@ -63,9 +63,6 @@ public class ProtectedMembersInFinalClass extends BugChecker implements ClassTre
     if (!HAS_FINAL.matches(tree, state)) {
       return NO_MATCH;
     }
-    if (tree.getMembers().isEmpty()) {
-      return NO_MATCH;
-    }
 
     ImmutableList<Tree> relevantMembers =
         tree.getMembers().stream()
@@ -73,6 +70,7 @@ public class ProtectedMembersInFinalClass extends BugChecker implements ClassTre
             .filter(m -> HAS_PROTECTED.matches(m, state))
             .filter(
                 m -> !(m instanceof MethodTree) || methodHasNoParentMethod((MethodTree) m, state))
+            .filter(m -> !isSuppressed(m))
             .collect(toImmutableList());
     if (relevantMembers.isEmpty()) {
       return NO_MATCH;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/apidiff/AndroidJdkLibsChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/apidiff/AndroidJdkLibsChecker.java
@@ -125,6 +125,7 @@ public class AndroidJdkLibsChecker extends ApiDiffChecker {
         ImmutableSet.<String>builder()
             .addAll(BASE_ALLOWED_CLASSES)
             .add("java/io/UncheckedIOException")
+            .add("java/util/ArrayList")
             .add("java/util/Collection")
             .add("java/util/Comparator")
             .add("java/util/DoubleSummaryStatistics")

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MutableMethodReturnTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MutableMethodReturnTypeTest.java
@@ -393,4 +393,29 @@ public class MutableMethodReturnTypeTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void overridingMethod_specialNotice() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.collect.ImmutableList;",
+            "import com.google.inject.Provider;",
+            "import java.util.List;",
+            "class Test {",
+            "  private static final int getFooLength() {",
+            "    final Provider<List<String>> fooProvider = ",
+            "      new Provider<List<String>>() {",
+            "        @Override",
+            "        // BUG: Diagnostic contains: narrow the return type",
+            "        public List<String> get() {",
+            "          return ImmutableList.of(\"foo\", \"bar\");",
+            "        }",
+            "      };",
+            "    List<String> foo = fooProvider.get();",
+            "    return foo.size();",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/PreconditionsInvalidPlaceholderTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/PreconditionsInvalidPlaceholderTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,14 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author eaftan@google.com (Eddie Aftandilian) */
 @RunWith(JUnit4.class)
 public class PreconditionsInvalidPlaceholderTest {
-
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(PreconditionsInvalidPlaceholder.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(PreconditionsInvalidPlaceholder.class, getClass());
 
   @Test
   public void testPositiveCase1() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ProtectedMembersInFinalClassTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ProtectedMembersInFinalClassTest.java
@@ -99,4 +99,16 @@ public class ProtectedMembersInFinalClassTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void methodSuppression() {
+    compilationHelper
+        .addSourceLines(
+            "in/Test.java",
+            "final class Test {",
+            "  @SuppressWarnings(\"ProtectedMembersInFinalClass\")",
+            "  protected void methodOne() {}",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/PreconditionsInvalidPlaceholderPositiveCase1.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/PreconditionsInvalidPlaceholderPositiveCase1.java
@@ -19,6 +19,7 @@ package com.google.errorprone.bugpatterns.testdata;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 
 public class PreconditionsInvalidPlaceholderPositiveCase1 {
   int foo;
@@ -31,5 +32,10 @@ public class PreconditionsInvalidPlaceholderPositiveCase1 {
   public void checkFoo() {
     // BUG: Diagnostic contains: foo must be equal to 0 but was %s
     Preconditions.checkState(foo == 0, "foo must be equal to 0 but was {0}", foo);
+  }
+
+  public void verifyFoo(int x) {
+    // BUG: Diagnostic contains:
+    Verify.verify(x > 0, "%d > 0", x);
   }
 }

--- a/core/src/test/java/com/google/errorprone/refaster/Match.java
+++ b/core/src/test/java/com/google/errorprone/refaster/Match.java
@@ -40,5 +40,5 @@ public abstract class Match {
     return new AutoValue_Match(ImmutableMap.copyOf(bindings));
   }
 
-  abstract Map<String, String> bindings();
+  abstract ImmutableMap<String, String> bindings();
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> ProtectedMembersInFinalClass: allow suppression at the method level.

d7e2a9f5bcf8117166bca35874c58a0c2f0619c5

-------

<p> Update checker framework version 3.3.0

Relevant changes (see https://checkerframework.org/changelog.txt):

* For collection methods with `Object` formal parameter type, such as
  contains, indexOf, and remove, the annotated JDK now forbids null as an
  argument.  To make the Nullness Checker permit null, pass
  `-Astubs=collection-object-parameters-may-be-null.astub`.

* The wrapper annotation EnsuresQualifiersIf was renamed to EnsuresQualifierIf.list

* Deprecated Analysis#Analysis(ProcessingEnvironment) and Analysis#Analysis(T,
  int, ProcessingEnvironment); use Analysis#Analysis(), Analysis#Analysis(int),
  Analysis#Analysis(T), and Analysis#Analysis(T, int) instead.

./third_party/java/checker_framework/update-checker \
    --old_version 3.2.0  \
    --checker_release 3.3.0

318f88f36309da729ab815ceb6d1631eaa10de51

-------

<p> Add MOE:strip_line for documentSuppression in DefaultPackage now that it is suppressible at class level (b1d6b6269a1ac38daad50453c211bb2e11d13faf)

RELNOTES: N/A

4ee35e095e61c0fa7b7519360deff5aa9923ae37

-------

<p> MutableMethodReturnType: add a note that you can return tighter types when overriding.

Seems to cause a lot of confusion.

d70c03972b57ddba0f103d9c8d6a29dcb24b90fd

-------

<p> Don't complain about ArrayList.sort in AndroidJdkLibsChecker when Java 8 library
desugaring is enabled

follow-up to 278733336a29a604a568e3cf2c5dc9fa601c43ad

f17121a46c86a7e0eefd847445ba5dcd91a2c387

-------

<p> Fix AutoValueImmutableFields warning by making Match#bindings return ImmutableMap.

https://errorprone.info/bugpattern/AutoValueImmutableFields

3bb8ca191ad371af7b4665dd0ac2200506cf44a5

-------

<p> PreconditionsInvalidPlaceholder: match more methods (including Verify).

79c79d23427b814966a6f614dc915f52c79aa380