### PR TITLE
MOE Sync 2020-04-23

### DIFF
--- a/core/src/main/java/com/google/errorprone/refaster/RefasterRuleBuilderScanner.java
+++ b/core/src/main/java/com/google/errorprone/refaster/RefasterRuleBuilderScanner.java
@@ -160,6 +160,10 @@ public final class RefasterRuleBuilderScanner extends SimpleTreeVisitor<Void, Vo
       if (annotationMap.containsKey(AllowCodeBetweenLines.class)) {
         List<UBlank> blanks = new ArrayList<>();
         for (int i = 0; i < beforeTemplates.size(); i++) {
+          if (beforeTemplates.get(i) instanceof ExpressionTemplate) {
+            throw new IllegalArgumentException(
+                "@AllowCodeBetweenLines may not be specified for expression templates.");
+          }
           BlockTemplate before = (BlockTemplate) beforeTemplates.get(i);
           List<UStatement> stmtsWithBlanks = new ArrayList<>();
           for (UStatement stmt : before.templateStatements()) {

--- a/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assert_;
 import static com.google.errorprone.util.RuntimeVersion.isAtLeast9;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeFalse;
 
 import com.google.common.base.CharMatcher;
@@ -158,6 +159,16 @@ public class TemplateIntegrationTest extends CompilerBasedTest {
   @Test
   public void ifTemplate() throws IOException {
     runTest("IfTemplate");
+  }
+
+  @Test
+  public void expressionForbidsAllowCodeBetweenLines() throws IOException {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> runTest("ExpressionForbidsAllowCodeBetweenLinesTemplate"));
+    assertThat(ex).hasMessageThat().contains("@AllowCodeBetweenLines");
+    assertThat(ex).hasMessageThat().contains("expression templates");
   }
 
   @Test

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/template/ExpressionForbidsAllowCodeBetweenLinesTemplate.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/template/ExpressionForbidsAllowCodeBetweenLinesTemplate.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata.template;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.AllowCodeBetweenLines;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.util.Objects;
+
+/**
+ * Test case demonstrating that {@code @AllowCodeBetweenLines} is forbidden with expression
+ * templates.
+ *
+ * @author jhecht@google.com (Joshua Hecht)
+ */
+@AllowCodeBetweenLines
+public abstract class ExpressionForbidsAllowCodeBetweenLinesTemplate {
+  @BeforeTemplate
+  String before(Object o) {
+    return o.toString();
+  }
+
+  @AfterTemplate
+  String after(Object o) {
+    return Objects.toString(o);
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Refaster: Add an informative exception for an invalid template when @AllowCodeBetweenLines is specified for expression templates, instead of throwing a ClassCastException.

Please advise on how to test this change.

Exception in thread "main" java.lang.ClassCastException: class com.google.errorprone.refaster.AutoValue_ExpressionTemplate cannot be cast to class com.google.errorprone.refaster.BlockTemplate (com.google.errorprone.refaster.AutoValue_ExpressionTemplate and com.google.errorprone.refaster.BlockTemplate are in unnamed module of loader 'app')
        at com.google.errorprone.refaster.RefasterRuleBuilderScanner.createMatchers(RefasterRuleBuilderScanner.java:163)
        at com.google.errorprone.refaster.RefasterRuleBuilderScanner.extractRules(RefasterRuleBuilderScanner.java:102)

240862585731e5b6555333fd249373776fed935c