### PR TITLE
Fix NPE in MutablePublicArray check

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/MutablePublicArray.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MutablePublicArray.java
@@ -67,7 +67,7 @@ public class MutablePublicArray extends BugChecker implements VariableTreeMatche
       return false;
     }
     JCNewArray newArray = (JCNewArray) arrayExpression.getInitializer();
-    if (!newArray.getDimensions().isEmpty()) {
+    if (newArray != null && !newArray.getDimensions().isEmpty()) {
       return newArray.getDimensions().stream()
           .allMatch(
               jcExpression -> {
@@ -76,6 +76,6 @@ public class MutablePublicArray extends BugChecker implements VariableTreeMatche
               });
     }
     // For in line array initializer.
-    return newArray.getInitializers() != null && !newArray.getInitializers().isEmpty();
+    return newArray != null && newArray.getInitializers() != null && !newArray.getInitializers().isEmpty();
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MutablePublicArrayTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MutablePublicArrayTest.java
@@ -159,4 +159,18 @@ public class MutablePublicArrayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void publicStaticFinalStaticInitializeBlock() {
+      compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  public static final long[] l;",
+            "  static {",
+            "    l = new long[1];",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
The MutablePublicArray check throws a NPE when examining
an array that's initialized during a static init block. Add a test case
and null checks.