### PR TITLE
RestrictedApi support for Type

### DIFF
--- a/annotations/src/main/java/com/google/errorprone/annotations/RestrictedApi.java
+++ b/annotations/src/main/java/com/google/errorprone/annotations/RestrictedApi.java
@@ -20,7 +20,6 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
-// TODO(b/157082874): Allow restricting entire classes.
 /**
  * Restrict this method to callsites with a whitelist annotation.
  *
@@ -80,7 +79,7 @@ import java.lang.annotation.Target;
  * }
  * }</pre>
  */
-@Target({ElementType.CONSTRUCTOR, ElementType.METHOD})
+@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.TYPE})
 public @interface RestrictedApi {
   /** Explanation why the API is restricted, to be inserted into the compiler output. */
   String explanation();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/RestrictedApiCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/RestrictedApiCheckerTest.java
@@ -138,6 +138,22 @@ public class RestrictedApiCheckerTest {
   }
 
   @Test
+  public void testRestrictedClassProhibited() {
+    helper
+            .addSourceLines(
+                    "Testcase.java",
+                    "package com.google.errorprone.bugpatterns.testdata;",
+                    "class RestrictedApiTestSample {",
+                    "    RestrictedApiTestSample(EntireClassRestriction entireClassRestriction) {",
+                    "        // BUG: Diagnostic contains: type restriction",
+                    "        entireClassRestriction.cantTouchThis();",
+                    "    }",
+                    "}")
+            .expectResult(Result.ERROR)
+            .doTest();
+  }
+
+  @Test
   public void testImplicitRestrictedConstructorProhibited() {
     helper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/RestrictedApiMethods.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/RestrictedApiMethods.java
@@ -86,6 +86,11 @@ interface IFaceWithRestriction {
   void dontCallMe();
 }
 
+@RestrictedApi(explanation = "type restriction", link = "nothing")
+interface EntireClassRestriction {
+  void cantTouchThis();
+}
+
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 @interface Whitelist {}
 


### PR DESCRIPTION
Adding support for restricting API for the entire type. RestrictedApi check currently only supports for annotating methods, with this change, it will be possible to annotate the class and make sure all the methods in that class will be restricted with given annotation configuration.

```java
@RestrictedApi(explanation = "type restriction", link = "nothing")
interface EntireClassRestriction {
  void cantTouchThis();
}
```