### PR TITLE
MOE Sync 2020-04-27

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/matchers/CompileTimeConstantExpressionMatcher.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/CompileTimeConstantExpressionMatcher.java
@@ -83,7 +83,7 @@ public class CompileTimeConstantExpressionMatcher implements Matcher<ExpressionT
                 }
 
                 @Override
-                protected Boolean defaultAction(Tree node, Void aVoid) {
+                protected Boolean defaultAction(Tree node, Void unused) {
                   Object constValue = ASTHelpers.constValue(node);
                   return constValue != null;
                 }

--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -1474,7 +1474,7 @@ public class ASTHelpers {
 
     @Nullable
     @Override
-    public Type visitArrayAccess(ArrayAccessTree node, Void aVoid) {
+    public Type visitArrayAccess(ArrayAccessTree node, Void unused) {
       if (current.equals(node.getIndex())) {
         return state.getSymtab().intType;
       } else {
@@ -1483,7 +1483,7 @@ public class ASTHelpers {
     }
 
     @Override
-    public Type visitAssert(AssertTree node, Void aVoid) {
+    public Type visitAssert(AssertTree node, Void unused) {
       return current.equals(node.getCondition())
           ? state.getSymtab().booleanType
           : state.getSymtab().stringType;
@@ -1507,7 +1507,7 @@ public class ASTHelpers {
     }
 
     @Override
-    public Type visitClass(ClassTree node, Void aVoid) {
+    public Type visitClass(ClassTree node, Void unused) {
       return null;
     }
 
@@ -1547,7 +1547,7 @@ public class ASTHelpers {
     }
 
     @Override
-    public Type visitEnhancedForLoop(EnhancedForLoopTree node, Void aVoid) {
+    public Type visitEnhancedForLoop(EnhancedForLoopTree node, Void unused) {
       Type variableType = ASTHelpers.getType(node.getVariable());
       if (state.getTypes().isArray(ASTHelpers.getType(node.getExpression()))) {
         // For iterating an array, the target type is LoopVariableType[].
@@ -1562,7 +1562,7 @@ public class ASTHelpers {
     }
 
     @Override
-    public Type visitInstanceOf(InstanceOfTree node, Void aVoid) {
+    public Type visitInstanceOf(InstanceOfTree node, Void unused) {
       return state.getSymtab().objectType;
     }
 
@@ -1572,7 +1572,7 @@ public class ASTHelpers {
     }
 
     @Override
-    public Type visitMethod(MethodTree node, Void aVoid) {
+    public Type visitMethod(MethodTree node, Void unused) {
       return null;
     }
 
@@ -1598,18 +1598,18 @@ public class ASTHelpers {
     }
 
     @Override
-    public Type visitSynchronized(SynchronizedTree node, Void aVoid) {
+    public Type visitSynchronized(SynchronizedTree node, Void unused) {
       // The null occurs if you've asked for the type of the parentheses around the expression.
       return Objects.equals(current, node.getExpression()) ? state.getSymtab().objectType : null;
     }
 
     @Override
-    public Type visitThrow(ThrowTree node, Void aVoid) {
+    public Type visitThrow(ThrowTree node, Void unused) {
       return ASTHelpers.getType(current);
     }
 
     @Override
-    public Type visitTypeCast(TypeCastTree node, Void aVoid) {
+    public Type visitTypeCast(TypeCastTree node, Void unused) {
       return getType(node.getType());
     }
 
@@ -1787,7 +1787,7 @@ public class ASTHelpers {
 
     @Nullable
     @Override
-    public Type visitNewArray(NewArrayTree node, Void aVoid) {
+    public Type visitNewArray(NewArrayTree node, Void unused) {
       if (Objects.equals(node.getType(), current)) {
         return null;
       }
@@ -1802,7 +1802,7 @@ public class ASTHelpers {
 
     @Nullable
     @Override
-    public Type visitMemberSelect(MemberSelectTree node, Void aVoid) {
+    public Type visitMemberSelect(MemberSelectTree node, Void unused) {
       if (current.equals(node.getExpression())) {
         return ASTHelpers.getType(node.getExpression());
       }
@@ -1810,7 +1810,7 @@ public class ASTHelpers {
     }
 
     @Override
-    public Type visitMemberReference(MemberReferenceTree node, Void aVoid) {
+    public Type visitMemberReference(MemberReferenceTree node, Void unused) {
       return state.getTypes().findDescriptorType(getType(node)).getReturnType();
     }
 

--- a/check_api/src/main/java/com/google/errorprone/util/Signatures.java
+++ b/check_api/src/main/java/com/google/errorprone/util/Signatures.java
@@ -115,7 +115,7 @@ public class Signatures {
   private static final Type.Visitor<String, Void> PRETTY_TYPE_VISITOR =
       new DefaultTypeVisitor<String, Void>() {
         @Override
-        public String visitWildcardType(Type.WildcardType t, Void aVoid) {
+        public String visitWildcardType(Type.WildcardType t, Void unused) {
           StringBuilder sb = new StringBuilder();
           sb.append(t.kind);
           if (t.kind != BoundKind.UNBOUND) {
@@ -145,7 +145,7 @@ public class Signatures {
         }
 
         @Override
-        public String visitArrayType(Type.ArrayType t, Void aVoid) {
+        public String visitArrayType(Type.ArrayType t, Void unused) {
           return t.elemtype.accept(this, null) + "[]";
         }
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
@@ -165,7 +165,7 @@ public class BadImport extends BugChecker implements ImportTreeMatcher {
           }
 
           @Override
-          public IdentifierTree visitIdentifier(IdentifierTree node, Void aVoid) {
+          public IdentifierTree visitIdentifier(IdentifierTree node, Void unused) {
             Symbol nodeSymbol = ASTHelpers.getSymbol(node);
             if (symbols.contains(nodeSymbol) && !isSuppressed(node)) {
               if (getCurrentPath().getParentPath().getLeaf().getKind() != Kind.CASE) {
@@ -174,7 +174,7 @@ public class BadImport extends BugChecker implements ImportTreeMatcher {
                 return node;
               }
             }
-            return super.visitIdentifier(node, aVoid);
+            return super.visitIdentifier(node, unused);
           }
 
           // We need to move any type annotation inside the qualified usage to preserve semantics,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CanBeStaticAnalyzer.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CanBeStaticAnalyzer.java
@@ -120,13 +120,13 @@ public class CanBeStaticAnalyzer extends TreeScanner {
   // }
   private class TypeVariableScanner extends Types.SimpleVisitor<Void, Void> {
     @Override
-    public Void visitTypeVar(Type.TypeVar t, Void aVoid) {
+    public Void visitTypeVar(Type.TypeVar t, Void unused) {
       canPossiblyBeStatic = false;
       return null;
     }
 
     @Override
-    public Void visitClassType(Type.ClassType t, Void aVoid) {
+    public Void visitClassType(Type.ClassType t, Void unused) {
       for (Type a : t.getTypeArguments()) {
         a.accept(this, null);
       }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CanonicalDuration.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CanonicalDuration.java
@@ -276,15 +276,15 @@ public class CanonicalDuration extends BugChecker implements MethodInvocationTre
     List<MethodInvocationTree> sameMethodInvocations = new ArrayList<>();
     new TreeScanner<Void, Void>() {
       @Override
-      public Void scan(Tree node, Void aVoid) {
+      public Void scan(Tree node, Void unused) {
         if (notFirst.get()) {
           return null;
         }
-        return super.scan(node, aVoid);
+        return super.scan(node, unused);
       }
 
       @Override
-      public Void visitMethodInvocation(MethodInvocationTree node, Void aVoid) {
+      public Void visitMethodInvocation(MethodInvocationTree node, Void unused) {
         if (Objects.equals(methodSymbol, ASTHelpers.getSymbol(node))) {
           if (sameMethodInvocations.isEmpty()) {
             if (!Objects.equals(node, tree)) {
@@ -294,9 +294,9 @@ public class CanonicalDuration extends BugChecker implements MethodInvocationTre
           }
 
           sameMethodInvocations.add(node);
-          return super.visitMethodInvocation(node, aVoid);
+          return super.visitMethodInvocation(node, unused);
         }
-        return super.visitMethodInvocation(node, aVoid);
+        return super.visitMethodInvocation(node, unused);
       }
     }.scan(expressionPath.getLeaf(), null);
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CatchFail.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CatchFail.java
@@ -237,11 +237,11 @@ public class CatchFail extends BugChecker implements TryTreeMatcher {
         .accept(
             new TreeScanner<Void, Void>() {
               @Override
-              public Void visitIdentifier(IdentifierTree node, Void aVoid) {
+              public Void visitIdentifier(IdentifierTree node, Void unused) {
                 if (Objects.equals(sym, ASTHelpers.getSymbol(node))) {
                   found[0] = true;
                 }
-                return super.visitIdentifier(node, aVoid);
+                return super.visitIdentifier(node, unused);
               }
             },
             null);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ComplexBooleanConstant.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ComplexBooleanConstant.java
@@ -61,7 +61,7 @@ public class ComplexBooleanConstant extends BugChecker implements BinaryTreeMatc
     SimpleTreeVisitor<Boolean, Void> boolValue =
         new SimpleTreeVisitor<Boolean, Void>() {
           @Override
-          public Boolean visitLiteral(LiteralTree node, Void aVoid) {
+          public Boolean visitLiteral(LiteralTree node, Void unused) {
             if (node.getValue() instanceof Boolean) {
               return (Boolean) node.getValue();
             }
@@ -69,7 +69,7 @@ public class ComplexBooleanConstant extends BugChecker implements BinaryTreeMatc
           }
 
           @Override
-          public Boolean visitUnary(UnaryTree node, Void aVoid) {
+          public Boolean visitUnary(UnaryTree node, Void unused) {
             Boolean r = node.getExpression().accept(this, null);
             if (r == null) {
               return null;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DefaultCharset.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DefaultCharset.java
@@ -376,7 +376,7 @@ public class DefaultCharset extends BugChecker
         .accept(
             new TreeScanner<Void, Void>() {
               @Override
-              public Void visitVariable(VariableTree node, Void aVoid) {
+              public Void visitVariable(VariableTree node, Void unused) {
                 if (sym.equals(ASTHelpers.getSymbol(node))) {
                   fix.replace(node.getType(), replacement.getSimpleName())
                       .addImport(replacement.getCanonicalName());

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InterruptedExceptionSwallowed.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InterruptedExceptionSwallowed.java
@@ -189,7 +189,7 @@ public final class InterruptedExceptionSwallowed extends BugChecker
           }
 
           @Override
-          public Boolean visitInstanceOf(InstanceOfTree instanceOfTree, Void aVoid) {
+          public Boolean visitInstanceOf(InstanceOfTree instanceOfTree, Void unused) {
             return isSubtype(
                 getType(instanceOfTree.getType()),
                 state.getSymtab().interruptedExceptionType,

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LoopConditionChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LoopConditionChecker.java
@@ -134,12 +134,12 @@ public class LoopConditionChecker extends BugChecker
     }
 
     @Override
-    public Boolean visitUnary(UnaryTree node, Void aVoid) {
+    public Boolean visitUnary(UnaryTree node, Void unused) {
       return node.getExpression().accept(this, null);
     }
 
     @Override
-    public Boolean visitBinary(BinaryTree node, Void aVoid) {
+    public Boolean visitBinary(BinaryTree node, Void unused) {
       return firstNonNull(node.getLeftOperand().accept(this, null), false)
           && firstNonNull(node.getRightOperand().accept(this, null), false);
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MockitoCast.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MockitoCast.java
@@ -118,15 +118,15 @@ public class MockitoCast extends BugChecker implements CompilationUnitTreeMatche
     }
 
     @Override
-    public Void visitVariable(VariableTree node, Void aVoid) {
+    public Void visitVariable(VariableTree node, Void unused) {
       recordInitialization(node, node.getInitializer());
-      return super.visitVariable(node, aVoid);
+      return super.visitVariable(node, unused);
     }
 
     @Override
-    public Void visitAssignment(AssignmentTree node, Void aVoid) {
+    public Void visitAssignment(AssignmentTree node, Void unused) {
       recordInitialization(node.getVariable(), node.getExpression());
-      return super.visitAssignment(node, aVoid);
+      return super.visitAssignment(node, unused);
     }
 
     private void recordInitialization(Tree varTree, ExpressionTree initializer) {
@@ -257,7 +257,7 @@ public class MockitoCast extends BugChecker implements CompilationUnitTreeMatche
     }
 
     @Override
-    public Boolean scan(Tree tree, Void aVoid) {
+    public Boolean scan(Tree tree, Void unused) {
       Symbol sym = ASTHelpers.getSymbol(tree);
       if (sym instanceof VarSymbol) {
         VarSymbol varSym = (VarSymbol) sym;
@@ -274,7 +274,7 @@ public class MockitoCast extends BugChecker implements CompilationUnitTreeMatche
           return true;
         }
       }
-      return super.scan(tree, aVoid);
+      return super.scan(tree, unused);
     }
 
     @Override

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ModifiedButNotUsed.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ModifiedButNotUsed.java
@@ -208,11 +208,11 @@ public class ModifiedButNotUsed extends BugChecker
     if (tree.getInitializer() == null) {
       new TreePathScanner<Void, Void>() {
         @Override
-        public Void visitAssignment(AssignmentTree node, Void aVoid) {
+        public Void visitAssignment(AssignmentTree node, Void unused) {
           if (symbol.equals(getSymbol(node.getVariable()))) {
             initializers.add(new TreePath(getCurrentPath(), node.getExpression()));
           }
-          return super.visitAssignment(node, aVoid);
+          return super.visitAssignment(node, unused);
         }
       }.scan(state.getPath().getParentPath(), null);
     } else {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/StringSplitter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StringSplitter.java
@@ -191,7 +191,7 @@ public class StringSplitter extends BugChecker implements MethodInvocationTreeMa
         }
 
         @Override
-        public Boolean visitMemberSelect(MemberSelectTree tree, Void aVoid) {
+        public Boolean visitMemberSelect(MemberSelectTree tree, Void unused) {
           // replace `pieces.length` with `pieces.size`
           if (sym.equals(ASTHelpers.getSymbol(tree.getExpression()))
               && tree.getIdentifier().contentEquals("length")) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypesWithUndefinedEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypesWithUndefinedEquality.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.util.ASTHelpers.isSameType;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.VisitorState;
+import com.sun.tools.javac.code.Type;
+
+/** Enumerates types which have poorly-defined behaviour for equals. */
+public enum TypesWithUndefinedEquality {
+  LONG_SPARSE_ARRAY(
+      "LongSparseArray",
+      "android.util.LongSparseArray",
+      "android.support.v4.util.LongSparseArrayCompat",
+      "androidx.collection.LongSparseArrayCompat"),
+  SPARSE_ARRAY(
+      "SparseArray",
+      "android.util.SparseArray",
+      "android.support.v4.util.SparseArrayCompat",
+      "androidx.collection.SparseArrayCompat"),
+  MULTIMAP("Multimap", "com.google.common.collect.Multimap"),
+  CHAR_SEQUENCE("CharSequence", "java.lang.CharSequence"),
+  ITERABLE("Iterable", "java.lang.Iterable", "com.google.common.collect.FluentIterable"),
+  COLLECTION("Collection", "java.util.Collection"),
+  IMMUTABLE_COLLECTION("ImmutableCollection", "com.google.common.collect.ImmutableCollection"),
+  QUEUE("Queue", "java.util.Queue");
+
+  private final String shortName;
+  private final ImmutableSet<String> typeNames;
+
+  TypesWithUndefinedEquality(String shortName, String... typeNames) {
+    this.shortName = shortName;
+    this.typeNames = ImmutableSet.copyOf(typeNames);
+  }
+
+  public boolean matchesType(Type type, VisitorState state) {
+    return typeNames.stream()
+        .anyMatch(typeName -> isSameType(type, state.getTypeFromString(typeName), state));
+  }
+
+  public String shortName() {
+    return shortName;
+  }
+
+  public ImmutableSet<String> typeNames() {
+    return typeNames;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryBoxedVariable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryBoxedVariable.java
@@ -446,7 +446,7 @@ public class UnnecessaryBoxedVariable extends BugChecker implements VariableTree
     }
 
     @Override
-    public Void visitMemberReference(MemberReferenceTree node, Void aVoid) {
+    public Void visitMemberReference(MemberReferenceTree node, Void unused) {
       ExpressionTree qualifierExpression = node.getQualifierExpression();
       if (qualifierExpression.getKind() == Kind.IDENTIFIER) {
         Symbol symbol = ASTHelpers.getSymbol(qualifierExpression);
@@ -456,7 +456,7 @@ public class UnnecessaryBoxedVariable extends BugChecker implements VariableTree
           return null;
         }
       }
-      return super.visitMemberReference(node, aVoid);
+      return super.visitMemberReference(node, unused);
     }
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryLambda.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessaryLambda.java
@@ -259,7 +259,7 @@ public class UnnecessaryLambda extends BugChecker
         }
 
         @Override
-        public LambdaExpressionTree visitBlock(BlockTree node, Void aVoid) {
+        public LambdaExpressionTree visitBlock(BlockTree node, Void unused) {
           // when processing a method body, only consider methods with a single `return` statement
           // that returns a method
           return node.getStatements().size() == 1
@@ -268,17 +268,17 @@ public class UnnecessaryLambda extends BugChecker
         }
 
         @Override
-        public LambdaExpressionTree visitReturn(ReturnTree node, Void aVoid) {
+        public LambdaExpressionTree visitReturn(ReturnTree node, Void unused) {
           return node.getExpression() != null ? node.getExpression().accept(this, null) : null;
         }
 
         @Override
-        public LambdaExpressionTree visitTypeCast(TypeCastTree node, Void aVoid) {
+        public LambdaExpressionTree visitTypeCast(TypeCastTree node, Void unused) {
           return node.getExpression().accept(this, null);
         }
 
         @Override
-        public LambdaExpressionTree visitParenthesized(ParenthesizedTree node, Void aVoid) {
+        public LambdaExpressionTree visitParenthesized(ParenthesizedTree node, Void unused) {
           return node.getExpression().accept(this, null);
         }
       };

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnsynchronizedOverridesSynchronized.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnsynchronizedOverridesSynchronized.java
@@ -114,7 +114,7 @@ public class UnsynchronizedOverridesSynchronized extends BugChecker implements M
           }
 
           @Override
-          public Boolean visitMethodInvocation(MethodInvocationTree node, Void aVoid) {
+          public Boolean visitMethodInvocation(MethodInvocationTree node, Void unused) {
             ExpressionTree receiver = ASTHelpers.getReceiver(node);
             return receiver instanceof IdentifierTree
                 && ((IdentifierTree) receiver).getName().contentEquals("super")

--- a/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/CreatesDuplicateCallHeuristic.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/argumentselectiondefects/CreatesDuplicateCallHeuristic.java
@@ -87,19 +87,19 @@ class CreatesDuplicateCallHeuristic implements Heuristic {
     ImmutableList.Builder<List<Parameter>> resultBuilder = ImmutableList.builder();
     new TreeScanner<Void, Void>() {
       @Override
-      public Void visitMethodInvocation(MethodInvocationTree methodInvocationTree, Void aVoid) {
+      public Void visitMethodInvocation(MethodInvocationTree methodInvocationTree, Void unused) {
         addToResult(ASTHelpers.getSymbol(methodInvocationTree), methodInvocationTree);
-        return super.visitMethodInvocation(methodInvocationTree, aVoid);
+        return super.visitMethodInvocation(methodInvocationTree, unused);
       }
 
       @Override
-      public Void visitNewClass(NewClassTree newClassTree, Void aVoid) {
+      public Void visitNewClass(NewClassTree newClassTree, Void unused) {
         addToResult(ASTHelpers.getSymbol(newClassTree), newClassTree);
-        return super.visitNewClass(newClassTree, aVoid);
+        return super.visitNewClass(newClassTree, unused);
       }
 
       @Override
-      public Void visitMethod(MethodTree methodTree, Void aVoid) {
+      public Void visitMethod(MethodTree methodTree, Void unused) {
         MethodSymbol methodSymbol = ASTHelpers.getSymbol(methodTree);
         if (methodSymbol != null) {
           // if the method declared here is the one we are calling then add it
@@ -111,7 +111,7 @@ class CreatesDuplicateCallHeuristic implements Heuristic {
             addToResult(superSymbol, methodTree);
           }
         }
-        return super.visitMethod(methodTree, aVoid);
+        return super.visitMethod(methodTree, unused);
       }
 
       private void addToResult(MethodSymbol foundSymbol, Tree tree) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/BinopMatcher.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/BinopMatcher.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.collectionincompatibletype;
+
+import static com.google.errorprone.util.ASTHelpers.getType;
+
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MemberReferenceTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.code.Type;
+import javax.annotation.Nullable;
+
+final class BinopMatcher extends AbstractCollectionIncompatibleTypeMatcher {
+
+  private final Matcher<ExpressionTree> matcher;
+  private final String collectionType;
+
+  BinopMatcher(String collectionType, String className, String methodName) {
+    this.collectionType = collectionType;
+    matcher = Matchers.staticMethod().onClass(className).named(methodName);
+  }
+
+  @Override
+  Matcher<ExpressionTree> methodMatcher() {
+    return matcher;
+  }
+
+  @Nullable
+  @Override
+  Type extractSourceType(MethodInvocationTree tree, VisitorState state) {
+    return extractTypeArgAsMemberOfSupertype(
+        getType(tree.getArguments().get(0)),
+        state.getSymbolFromString(collectionType),
+        0,
+        state.getTypes());
+  }
+
+  @Nullable
+  @Override
+  Type extractSourceType(MemberReferenceTree tree, VisitorState state) {
+    Type descriptorType = state.getTypes().findDescriptorType(getType(tree));
+    return extractTypeArgAsMemberOfSupertype(
+        descriptorType.getParameterTypes().get(0),
+        state.getSymbolFromString(collectionType),
+        0,
+        state.getTypes());
+  }
+
+  @Nullable
+  @Override
+  ExpressionTree extractSourceTree(MethodInvocationTree tree, VisitorState state) {
+    return tree.getArguments().get(0);
+  }
+
+  @Nullable
+  @Override
+  ExpressionTree extractSourceTree(MemberReferenceTree tree, VisitorState state) {
+    return tree;
+  }
+
+  @Nullable
+  @Override
+  Type extractTargetType(MethodInvocationTree tree, VisitorState state) {
+    return extractTypeArgAsMemberOfSupertype(
+        getType(tree.getArguments().get(1)),
+        state.getSymbolFromString(collectionType),
+        0,
+        state.getTypes());
+  }
+
+  @Nullable
+  @Override
+  Type extractTargetType(MemberReferenceTree tree, VisitorState state) {
+    Type descriptorType = state.getTypes().findDescriptorType(getType(tree));
+    return extractTypeArgAsMemberOfSupertype(
+        descriptorType.getParameterTypes().get(1),
+        state.getSymbolFromString(collectionType),
+        0,
+        state.getTypes());
+  }
+
+  @Override
+  protected String message(MatchResult result, String sourceType, String targetType) {
+    return String.format(
+        "Argument '%s' should not be passed to this method; its type %s is not compatible with"
+            + " %s",
+        result.sourceTree(), sourceType, targetType);
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionIncompatibleType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionIncompatibleType.java
@@ -19,12 +19,8 @@ package com.google.errorprone.bugpatterns.collectionincompatibletype;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.fixes.SuggestedFixes.addSuppressWarnings;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
-import static com.google.errorprone.predicates.TypePredicates.isDescendantOfAny;
-import static com.google.errorprone.util.ASTHelpers.getType;
 
-import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
-import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MemberReferenceTreeMatcher;
@@ -34,19 +30,15 @@ import com.google.errorprone.bugpatterns.TypeCompatibilityUtils.TypeCompatibilit
 import com.google.errorprone.bugpatterns.collectionincompatibletype.AbstractCollectionIncompatibleTypeMatcher.MatchResult;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
-import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.util.ASTHelpers;
 import com.google.errorprone.util.Signatures;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MethodInvocationTree;
-import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 
 /**
  * Checker for calling Object-accepting methods with types that don't match the type arguments of
@@ -81,93 +73,14 @@ public class CollectionIncompatibleType extends BugChecker
   private final FixType fixType;
 
   /** Creates a new {@link CollectionIncompatibleType} checker that provides no fix. */
-  public CollectionIncompatibleType(ErrorProneFlags flags) {
-    this(FixType.NONE, flags);
+  public CollectionIncompatibleType() {
+    this(FixType.NONE);
   }
 
   /** Creates a new {@link CollectionIncompatibleType} checker with the given {@code fixType}. */
-  public CollectionIncompatibleType(FixType fixType, ErrorProneFlags flags) {
+  public CollectionIncompatibleType(FixType fixType) {
     this.fixType = fixType;
   }
-
-  /**
-   * The least-common ancestor of all of the types of {@link #DIRECT_MATCHERS} and {@link
-   * #TYPE_ARG_MATCHERS}.
-   */
-  private static final Matcher<ExpressionTree> FIRST_ORDER_MATCHER =
-      Matchers.anyMethod()
-          .onClass(
-              isDescendantOfAny(
-                  ImmutableList.of(
-                      "java.util.Collection",
-                      "java.util.Dictionary",
-                      "java.util.Map",
-                      "java.util.Collections",
-                      "com.google.common.collect.Sets")));
-
-  // The "normal" case of extracting the type of a method argument
-  private static final ImmutableList<MethodArgMatcher> DIRECT_MATCHERS =
-      ImmutableList.of(
-          // "Normal" cases, e.g. Collection#remove(Object)
-          // Make sure to keep that the type or one of its supertype should be present in
-          // FIRST_ORDER_MATCHER
-          new MethodArgMatcher("java.util.Collection", "contains(java.lang.Object)", 0, 0),
-          new MethodArgMatcher("java.util.Collection", "remove(java.lang.Object)", 0, 0),
-          new MethodArgMatcher("java.util.Deque", "removeFirstOccurrence(java.lang.Object)", 0, 0),
-          new MethodArgMatcher("java.util.Deque", "removeLastOccurrence(java.lang.Object)", 0, 0),
-          new MethodArgMatcher("java.util.Dictionary", "get(java.lang.Object)", 0, 0),
-          new MethodArgMatcher("java.util.Dictionary", "remove(java.lang.Object)", 0, 0),
-          new MethodArgMatcher("java.util.List", "indexOf(java.lang.Object)", 0, 0),
-          new MethodArgMatcher("java.util.List", "lastIndexOf(java.lang.Object)", 0, 0),
-          new MethodArgMatcher("java.util.Map", "containsKey(java.lang.Object)", 0, 0),
-          new MethodArgMatcher("java.util.Map", "containsValue(java.lang.Object)", 1, 0),
-          new MethodArgMatcher("java.util.Map", "get(java.lang.Object)", 0, 0),
-          new MethodArgMatcher("java.util.Map", "getOrDefault(java.lang.Object,V)", 0, 0),
-          new MethodArgMatcher("java.util.Map", "remove(java.lang.Object)", 0, 0),
-          new MethodArgMatcher("java.util.Stack", "search(java.lang.Object)", 0, 0),
-          new MethodArgMatcher("java.util.Vector", "indexOf(java.lang.Object,int)", 0, 0),
-          new MethodArgMatcher("java.util.Vector", "lastIndexOf(java.lang.Object,int)", 0, 0),
-          new MethodArgMatcher("java.util.Vector", "removeElement(java.lang.Object)", 0, 0));
-
-  // Cases where we need to extract the type argument from a method argument, e.g.
-  // Collection#containsAll(Collection<?>)
-  private static final ImmutableList<TypeArgOfMethodArgMatcher> TYPE_ARG_MATCHERS =
-      ImmutableList.of(
-          // Make sure to keep that the type or one of its supertype should be present in
-          // FIRST_ORDER_MATCHER
-          new TypeArgOfMethodArgMatcher(
-              "java.util.Collection", // class that defines the method
-              "containsAll(java.util.Collection<?>)", // method signature
-              0, // index of the owning class's type argument to extract
-              0, // index of the method argument whose type argument to extract
-              "java.util.Collection", // type of the method argument
-              0), // index of the method argument's type argument to extract
-          new TypeArgOfMethodArgMatcher(
-              "java.util.Collection", // class that defines the method
-              "removeAll(java.util.Collection<?>)", // method signature
-              0, // index of the owning class's type argument to extract
-              0, // index of the method argument whose type argument to extract
-              "java.util.Collection", // type of the method argument
-              0), // index of the method argument's type argument to extract
-          new TypeArgOfMethodArgMatcher(
-              "java.util.Collection", // class that defines the method
-              "retainAll(java.util.Collection<?>)", // method signature
-              0, // index of the owning class's type argument to extract
-              0, // index of the method argument whose type argument to extract
-              "java.util.Collection", // type of the method argument
-              0)); // index of the method argument's type argument to extract
-
-  private static final ImmutableList<BinopMatcher> STATIC_MATCHERS =
-      ImmutableList.of(
-          new BinopMatcher("java.util.Collection", "java.util.Collections", "disjoint"),
-          new BinopMatcher("java.util.Set", "com.google.common.collect.Sets", "difference"));
-
-  private static final ImmutableList<AbstractCollectionIncompatibleTypeMatcher> ALL_MATCHERS =
-      ImmutableList.<AbstractCollectionIncompatibleTypeMatcher>builder()
-          .addAll(DIRECT_MATCHERS)
-          .addAll(TYPE_ARG_MATCHERS)
-          .addAll(STATIC_MATCHERS)
-          .build();
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
@@ -180,11 +93,7 @@ public class CollectionIncompatibleType extends BugChecker
   }
 
   public Description match(ExpressionTree tree, VisitorState state) {
-    if (!FIRST_ORDER_MATCHER.matches(tree, state)) {
-      return NO_MATCH;
-    }
-
-    MatchResult result = firstNonNullMatchResult(ALL_MATCHERS, tree, state);
+    MatchResult result = ContainmentMatchers.firstNonNullMatchResult(tree, state);
     if (result == null) {
       return NO_MATCH;
     }
@@ -206,8 +115,8 @@ public class CollectionIncompatibleType extends BugChecker
       targetType = result.targetType().toString();
     }
 
-    Description.Builder description = buildDescription(tree);
-    description.setMessage(result.message(sourceType, targetType));
+    Description.Builder description =
+        buildDescription(tree).setMessage(result.message(sourceType, targetType));
 
     switch (fixType) {
       case PRINT_TYPES_AS_COMMENT:
@@ -236,95 +145,4 @@ public class CollectionIncompatibleType extends BugChecker
     return description.build();
   }
 
-  @Nullable
-  private static MatchResult firstNonNullMatchResult(
-      Iterable<? extends AbstractCollectionIncompatibleTypeMatcher> matchers,
-      ExpressionTree tree,
-      VisitorState state) {
-    for (AbstractCollectionIncompatibleTypeMatcher matcher : matchers) {
-      MatchResult result = matcher.matches(tree, state);
-      if (result != null) {
-        return result;
-      }
-    }
-    return null;
-  }
-
-  private static class BinopMatcher extends AbstractCollectionIncompatibleTypeMatcher {
-
-    private final Matcher<ExpressionTree> matcher;
-    private final String collectionType;
-
-    BinopMatcher(String collectionType, String className, String methodName) {
-      this.collectionType = collectionType;
-      matcher = Matchers.staticMethod().onClass(className).named(methodName);
-    }
-
-    @Override
-    Matcher<ExpressionTree> methodMatcher() {
-      return matcher;
-    }
-
-    @Nullable
-    @Override
-    Type extractSourceType(MethodInvocationTree tree, VisitorState state) {
-      return extractTypeArgAsMemberOfSupertype(
-          getType(tree.getArguments().get(0)),
-          state.getSymbolFromString(collectionType),
-          0,
-          state.getTypes());
-    }
-
-    @Nullable
-    @Override
-    Type extractSourceType(MemberReferenceTree tree, VisitorState state) {
-      Type descriptorType = state.getTypes().findDescriptorType(getType(tree));
-      return extractTypeArgAsMemberOfSupertype(
-          descriptorType.getParameterTypes().get(0),
-          state.getSymbolFromString(collectionType),
-          0,
-          state.getTypes());
-    }
-
-    @Nullable
-    @Override
-    ExpressionTree extractSourceTree(MethodInvocationTree tree, VisitorState state) {
-      return tree.getArguments().get(0);
-    }
-
-    @Nullable
-    @Override
-    ExpressionTree extractSourceTree(MemberReferenceTree tree, VisitorState state) {
-      return tree;
-    }
-
-    @Nullable
-    @Override
-    Type extractTargetType(MethodInvocationTree tree, VisitorState state) {
-      return extractTypeArgAsMemberOfSupertype(
-          getType(tree.getArguments().get(1)),
-          state.getSymbolFromString(collectionType),
-          0,
-          state.getTypes());
-    }
-
-    @Nullable
-    @Override
-    Type extractTargetType(MemberReferenceTree tree, VisitorState state) {
-      Type descriptorType = state.getTypes().findDescriptorType(getType(tree));
-      return extractTypeArgAsMemberOfSupertype(
-          descriptorType.getParameterTypes().get(1),
-          state.getSymbolFromString(collectionType),
-          0,
-          state.getTypes());
-    }
-
-    @Override
-    protected String message(MatchResult result, String sourceType, String targetType) {
-      return String.format(
-          "Argument '%s' should not be passed to this method; its type %s is not compatible with"
-              + " %s",
-          result.sourceTree(), sourceType, targetType);
-    }
-  }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionUndefinedEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionUndefinedEquality.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.collectionincompatibletype;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.StandardTags;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MemberReferenceTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.bugpatterns.TypesWithUndefinedEquality;
+import com.google.errorprone.bugpatterns.collectionincompatibletype.AbstractCollectionIncompatibleTypeMatcher.MatchResult;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MemberReferenceTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.Arrays;
+
+/**
+ * Highlights use of {@code Collection#contains} (and others) with types that do not have
+ * well-defined equals.
+ */
+@BugPattern(
+    name = "CollectionUndefinedEquality",
+    summary = "This type does not have well-defined equals behavior.",
+    tags = StandardTags.FRAGILE_CODE,
+    severity = WARNING)
+public final class CollectionUndefinedEquality extends BugChecker
+    implements MethodInvocationTreeMatcher, MemberReferenceTreeMatcher {
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    return match(tree, state);
+  }
+
+  @Override
+  public Description matchMemberReference(MemberReferenceTree tree, VisitorState state) {
+    return match(tree, state);
+  }
+
+  public Description match(ExpressionTree tree, VisitorState state) {
+    MatchResult result = ContainmentMatchers.firstNonNullMatchResult(tree, state);
+    if (result == null) {
+      return NO_MATCH;
+    }
+
+    return Arrays.stream(TypesWithUndefinedEquality.values())
+        .filter(
+            b ->
+                b.matchesType(result.sourceType(), state)
+                    || b.matchesType(result.targetType(), state))
+        .findFirst()
+        .map(
+            b ->
+                buildDescription(tree)
+                    .setMessage(b.shortName() + " does not have well-defined equals behavior.")
+                    .build())
+        .orElse(NO_MATCH);
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/ContainmentMatchers.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/ContainmentMatchers.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.collectionincompatibletype;
+
+import static com.google.errorprone.predicates.TypePredicates.isDescendantOfAny;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.collectionincompatibletype.AbstractCollectionIncompatibleTypeMatcher.MatchResult;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ExpressionTree;
+import javax.annotation.Nullable;
+
+/** Matchers for methods which express containment, like {@link java.util.Collection#contains}. */
+public final class ContainmentMatchers {
+
+  /**
+   * The least-common ancestor of all of the types of {@link #DIRECT_MATCHERS} and {@link
+   * #TYPE_ARG_MATCHERS}.
+   */
+  private static final Matcher<ExpressionTree> FIRST_ORDER_MATCHER =
+      Matchers.anyMethod()
+          .onClass(
+              isDescendantOfAny(
+                  ImmutableList.of(
+                      "java.util.Collection",
+                      "java.util.Dictionary",
+                      "java.util.Map",
+                      "java.util.Collections",
+                      "com.google.common.collect.Sets")));
+
+  /** The "normal" case of extracting the type of a method argument */
+  private static final ImmutableList<MethodArgMatcher> DIRECT_MATCHERS =
+      ImmutableList.of(
+          // "Normal" cases, e.g. Collection#remove(Object)
+          // Make sure to keep that the type or one of its supertype should be present in
+          // FIRST_ORDER_MATCHER
+          new MethodArgMatcher("java.util.Collection", "contains(java.lang.Object)", 0, 0),
+          new MethodArgMatcher("java.util.Collection", "remove(java.lang.Object)", 0, 0),
+          new MethodArgMatcher("java.util.Deque", "removeFirstOccurrence(java.lang.Object)", 0, 0),
+          new MethodArgMatcher("java.util.Deque", "removeLastOccurrence(java.lang.Object)", 0, 0),
+          new MethodArgMatcher("java.util.Dictionary", "get(java.lang.Object)", 0, 0),
+          new MethodArgMatcher("java.util.Dictionary", "remove(java.lang.Object)", 0, 0),
+          new MethodArgMatcher("java.util.List", "indexOf(java.lang.Object)", 0, 0),
+          new MethodArgMatcher("java.util.List", "lastIndexOf(java.lang.Object)", 0, 0),
+          new MethodArgMatcher("java.util.Map", "containsKey(java.lang.Object)", 0, 0),
+          new MethodArgMatcher("java.util.Map", "containsValue(java.lang.Object)", 1, 0),
+          new MethodArgMatcher("java.util.Map", "get(java.lang.Object)", 0, 0),
+          new MethodArgMatcher("java.util.Map", "getOrDefault(java.lang.Object,V)", 0, 0),
+          new MethodArgMatcher("java.util.Map", "remove(java.lang.Object)", 0, 0),
+          new MethodArgMatcher("java.util.Stack", "search(java.lang.Object)", 0, 0),
+          new MethodArgMatcher("java.util.Vector", "indexOf(java.lang.Object,int)", 0, 0),
+          new MethodArgMatcher("java.util.Vector", "lastIndexOf(java.lang.Object,int)", 0, 0),
+          new MethodArgMatcher("java.util.Vector", "removeElement(java.lang.Object)", 0, 0));
+
+  /**
+   * Cases where we need to extract the type argument from a method argument, e.g.
+   * Collection#containsAll(Collection<?>)
+   */
+  private static final ImmutableList<TypeArgOfMethodArgMatcher> TYPE_ARG_MATCHERS =
+      ImmutableList.of(
+          // Make sure to keep that the type or one of its supertype should be present in
+          // FIRST_ORDER_MATCHER
+          new TypeArgOfMethodArgMatcher(
+              "java.util.Collection", // class that defines the method
+              "containsAll(java.util.Collection<?>)", // method signature
+              0, // index of the owning class's type argument to extract
+              0, // index of the method argument whose type argument to extract
+              "java.util.Collection", // type of the method argument
+              0), // index of the method argument's type argument to extract
+          new TypeArgOfMethodArgMatcher(
+              "java.util.Collection", // class that defines the method
+              "removeAll(java.util.Collection<?>)", // method signature
+              0, // index of the owning class's type argument to extract
+              0, // index of the method argument whose type argument to extract
+              "java.util.Collection", // type of the method argument
+              0), // index of the method argument's type argument to extract
+          new TypeArgOfMethodArgMatcher(
+              "java.util.Collection", // class that defines the method
+              "retainAll(java.util.Collection<?>)", // method signature
+              0, // index of the owning class's type argument to extract
+              0, // index of the method argument whose type argument to extract
+              "java.util.Collection", // type of the method argument
+              0)); // index of the method argument's type argument to extract
+
+  private static final ImmutableList<BinopMatcher> STATIC_MATCHERS =
+      ImmutableList.of(
+          new BinopMatcher("java.util.Collection", "java.util.Collections", "disjoint"),
+          new BinopMatcher("java.util.Set", "com.google.common.collect.Sets", "difference"));
+
+  private static final ImmutableList<AbstractCollectionIncompatibleTypeMatcher> ALL_MATCHERS =
+      ImmutableList.<AbstractCollectionIncompatibleTypeMatcher>builder()
+          .addAll(DIRECT_MATCHERS)
+          .addAll(TYPE_ARG_MATCHERS)
+          .addAll(STATIC_MATCHERS)
+          .build();
+
+  @Nullable
+  static MatchResult firstNonNullMatchResult(ExpressionTree tree, VisitorState state) {
+    if (!FIRST_ORDER_MATCHER.matches(tree, state)) {
+      return null;
+    }
+
+    for (AbstractCollectionIncompatibleTypeMatcher matcher : ContainmentMatchers.ALL_MATCHERS) {
+      MatchResult result = matcher.matches(tree, state);
+      if (result != null) {
+        return result;
+      }
+    }
+    return null;
+  }
+
+  private ContainmentMatchers() {}
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/MethodArgMatcher.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/collectionincompatibletype/MethodArgMatcher.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
  * Matches an instance method like {@link Collection#contains}, for which we just need to compare
  * the method argument's type to the receiver's type argument. This is the common case.
  */
-class MethodArgMatcher extends AbstractCollectionIncompatibleTypeMatcher {
+final class MethodArgMatcher extends AbstractCollectionIncompatibleTypeMatcher {
 
   private final Matcher<ExpressionTree> methodMatcher;
   private final String typeName;
@@ -50,7 +50,7 @@ class MethodArgMatcher extends AbstractCollectionIncompatibleTypeMatcher {
    * @param typeArgIndex The index of the type argument that should match the method argument
    * @param methodArgIndex The index of the method argument that should match the type argument
    */
-  public MethodArgMatcher(String typeName, String signature, int typeArgIndex, int methodArgIndex) {
+  MethodArgMatcher(String typeName, String signature, int typeArgIndex, int methodArgIndex) {
     this.methodMatcher = instanceMethod().onDescendantOf(typeName).withSignature(signature);
     this.typeName = typeName;
     this.typeArgIndex = typeArgIndex;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/AndroidInjectionBeforeSuper.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/dagger/AndroidInjectionBeforeSuper.java
@@ -126,7 +126,7 @@ public final class AndroidInjectionBeforeSuper extends BugChecker implements Met
     private boolean foundSuper = false;
 
     @Override
-    public Description visitMethodInvocation(MethodInvocationTree node, Void aVoid) {
+    public Description visitMethodInvocation(MethodInvocationTree node, Void unused) {
       if (foundSuper && matchType.injectMethodMatcher.matches(node, state)) {
         return buildDescription(node)
             .setMessage(
@@ -141,7 +141,7 @@ public final class AndroidInjectionBeforeSuper extends BugChecker implements Met
     }
 
     @Override
-    public Description visitMethod(MethodTree node, Void aVoid) {
+    public Description visitMethod(MethodTree node, Void unused) {
       BlockTree methodBody = node.getBody();
       if (methodBody == null) {
         return Description.NO_MATCH;
@@ -155,7 +155,7 @@ public final class AndroidInjectionBeforeSuper extends BugChecker implements Met
     }
 
     @Override
-    public Description visitExpressionStatement(ExpressionStatementTree node, Void aVoid) {
+    public Description visitExpressionStatement(ExpressionStatementTree node, Void unused) {
       return node.getExpression().accept(this, null);
     }
   }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/UrlInSee.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/UrlInSee.java
@@ -80,7 +80,7 @@ public final class UrlInSee extends BugChecker
     }
 
     @Override
-    public Void visitErroneous(ErroneousTree erroneousTree, Void aVoid) {
+    public Void visitErroneous(ErroneousTree erroneousTree, Void unused) {
       if (erroneousTree.getBody().startsWith("@see http")) {
         state.reportMatch(
             describeMatch(
@@ -88,7 +88,7 @@ public final class UrlInSee extends BugChecker
                 replace(
                     erroneousTree, erroneousTree.getBody().replaceFirst("@see", "See"), state)));
       }
-      return super.visitErroneous(erroneousTree, aVoid);
+      return super.visitErroneous(erroneousTree, unused);
     }
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/StaticGuardedByInstance.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/StaticGuardedByInstance.java
@@ -116,13 +116,13 @@ public class StaticGuardedByInstance extends BugChecker implements SynchronizedT
     }
 
     @Override
-    public Void visitSynchronized(SynchronizedTree node, Void aVoid) {
+    public Void visitSynchronized(SynchronizedTree node, Void unused) {
       // don't descend into nested synchronized blocks
       return null;
     }
 
     @Override
-    public Void visitNewClass(NewClassTree node, Void aVoid) {
+    public Void visitNewClass(NewClassTree node, Void unused) {
       // don't descend into nested synchronized blocks
       return null;
     }

--- a/core/src/main/java/com/google/errorprone/refaster/ImportPolicy.java
+++ b/core/src/main/java/com/google/errorprone/refaster/ImportPolicy.java
@@ -72,7 +72,8 @@ public enum ImportPolicy {
       List<String> topLevelPath = Splitter.on('.').splitToList(topLevelClazz);
       String topClazz = Iterables.getLast(topLevelPath);
       List<String> qualifiedPath = Splitter.on('.').splitToList(fullyQualifiedClazz);
-      boolean importTopLevelClazz = false, conflictTopLevelClazz = false;
+      boolean importTopLevelClazz = false;
+      boolean conflictTopLevelClazz = false;
       for (String importName : allImports) {
         if (importName.contentEquals(fullyQualifiedClazz)) {
           // fullyQualifiedClazz already imported

--- a/core/src/main/java/com/google/errorprone/refaster/annotation/Placeholder.java
+++ b/core/src/main/java/com/google/errorprone/refaster/annotation/Placeholder.java
@@ -75,8 +75,9 @@ import java.lang.annotation.Target;
  * is not permitted to reassign the contents of {@code resource}.
  *
  * <p>Placeholder methods are not permitted to refer to any local variables or parameters of the
- * {@code @BeforeTemplate} that are not passed to them as arguments, and must currently contain
- * references to all arguments that <em>are</em> passed to them.
+ * {@code @BeforeTemplate} that are not passed to them as arguments. Additionally, they
+ * <em>must</em> contain references to all arguments that <em>are</em> passed to them -- except
+ * those corresponding to parameters annotated with {@link MayOptionallyUse}.
  *
  * @author lowasser@google.com (Louis Wasserman)
  */

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -348,6 +348,7 @@ import com.google.errorprone.bugpatterns.argumentselectiondefects.ArgumentSelect
 import com.google.errorprone.bugpatterns.argumentselectiondefects.AssertEqualsArgumentOrderChecker;
 import com.google.errorprone.bugpatterns.argumentselectiondefects.AutoValueConstructorOrderChecker;
 import com.google.errorprone.bugpatterns.collectionincompatibletype.CollectionIncompatibleType;
+import com.google.errorprone.bugpatterns.collectionincompatibletype.CollectionUndefinedEquality;
 import com.google.errorprone.bugpatterns.collectionincompatibletype.CompatibleWithMisuse;
 import com.google.errorprone.bugpatterns.collectionincompatibletype.IncompatibleArgumentType;
 import com.google.errorprone.bugpatterns.collectionincompatibletype.TruthIncompatibleType;
@@ -673,6 +674,7 @@ public class BuiltInCheckerSuppliers {
           ClassCanBeStatic.class,
           ClassNewInstance.class,
           CloseableProvides.class,
+          CollectionUndefinedEquality.class,
           CollectorShouldNotUseState.class,
           ComparableAndComparator.class,
           CompareToZero.class,

--- a/core/src/test/java/com/google/errorprone/ErrorProneCompilerIntegrationTest.java
+++ b/core/src/test/java/com/google/errorprone/ErrorProneCompilerIntegrationTest.java
@@ -356,7 +356,14 @@ public class ErrorProneCompilerIntegrationTest {
 
   @Test
   public void severityIsResetOnNextCompilation() {
-    String[] testFile = {"public class Test {", "  void doIt (int i) {", "    i = i;", "  }", "}"};
+    String[] testFile = {
+      "package test;", //
+      "public class Test {",
+      "  void doIt (int i) {",
+      "    i = i;",
+      "  }",
+      "}"
+    };
     List<JavaFileObject> fileObjects =
         Arrays.asList(compiler.fileManager().forSourceLines("Test.java", testFile));
     String[] args = {"-Xep:SelfAssignment:WARN"};
@@ -548,7 +555,13 @@ public class ErrorProneCompilerIntegrationTest {
     Result exitCode =
         compiler.compile(
             new String[] {"-XDcompilePolicy=byfile"},
-            Arrays.asList(compiler.fileManager().forSourceLines("Test.java", "class Test {}")));
+            Arrays.asList(
+                compiler
+                    .fileManager()
+                    .forSourceLines(
+                        "Test.java", //
+                        "package test;",
+                        "class Test {}")));
     outputStream.flush();
     assertWithMessage(outputStream.toString()).that(exitCode).isEqualTo(Result.OK);
   }
@@ -558,7 +571,13 @@ public class ErrorProneCompilerIntegrationTest {
     Result exitCode =
         compiler.compile(
             new String[] {"-XDcompilePolicy=simple"},
-            Arrays.asList(compiler.fileManager().forSourceLines("Test.java", "class Test {}")));
+            Arrays.asList(
+                compiler
+                    .fileManager()
+                    .forSourceLines(
+                        "Test.java", //
+                        "package test;",
+                        "class Test {}")));
     outputStream.flush();
     assertWithMessage(outputStream.toString()).that(exitCode).isEqualTo(Result.OK);
   }

--- a/core/src/test/java/com/google/errorprone/ErrorProneJavacPluginTest.java
+++ b/core/src/test/java/com/google/errorprone/ErrorProneJavacPluginTest.java
@@ -78,6 +78,7 @@ public class ErrorProneJavacPluginTest {
     Files.write(
         source,
         ImmutableList.of(
+            "package test;",
             "import java.util.HashSet;",
             "import java.util.Set;",
             "class Test {",
@@ -268,6 +269,7 @@ public class ErrorProneJavacPluginTest {
     Files.write(
         one,
         ImmutableList.of(
+            "package test;",
             "import java.util.HashSet;",
             "import java.util.Set;",
             "class One {",
@@ -284,6 +286,7 @@ public class ErrorProneJavacPluginTest {
     Files.write(
         two,
         ImmutableList.of(
+            "package test;",
             "class Two {",
             "  public static void main(String[] args) {",
             "    new Exception();",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ArrayAsKeyOfSetOrMapTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ArrayAsKeyOfSetOrMapTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -32,12 +31,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class ArrayAsKeyOfSetOrMapTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(ArrayAsKeyOfSetOrMap.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ArrayAsKeyOfSetOrMap.class, getClass());
 
   @Test
   public void positive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ArrayEqualsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ArrayEqualsTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ArrayEqualsTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(ArrayEquals.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ArrayEquals.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ArrayHashCodeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ArrayHashCodeTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ArrayHashCodeTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(ArrayHashCode.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ArrayHashCode.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/AssertFalseTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/AssertFalseTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class AssertFalseTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(AssertFalse.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(AssertFalse.class, getClass());
 
   @Test
   public void testNegativeCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/AsyncFunctionReturnsNullTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/AsyncFunctionReturnsNullTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link AsyncFunctionReturnsNull}. */
 @RunWith(JUnit4.class)
 public class AsyncFunctionReturnsNullTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(AsyncFunctionReturnsNull.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(AsyncFunctionReturnsNull.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/BadAnnotationImplementationTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/BadAnnotationImplementationTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class BadAnnotationImplementationTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(BadAnnotationImplementation.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(BadAnnotationImplementation.class, getClass());
 
   @Test
   public void declaredClassImplementsAnnotation() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/BadComparableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/BadComparableTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author irogers@google.com (Ian Rogers) */
 @RunWith(JUnit4.class)
 public class BadComparableTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(BadComparable.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(BadComparable.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/BadShiftAmountTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/BadShiftAmountTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class BadShiftAmountTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(BadShiftAmount.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(BadShiftAmount.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/BoxedPrimitiveEqualityTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/BoxedPrimitiveEqualityTest.java
@@ -25,7 +25,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class BoxedPrimitiveEqualityTest {
 
-  private CompilationTestHelper compilationHelper =
+  private final CompilationTestHelper compilationHelper =
       CompilationTestHelper.newInstance(BoxedPrimitiveEquality.class, getClass());
 
   @Test

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ByteBufferBackingArrayTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ByteBufferBackingArrayTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ByteBufferBackingArrayTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(ByteBufferBackingArray.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ByteBufferBackingArray.class, getClass());
 
   @Test
   public void testPositiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/CannotMockFinalClassTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/CannotMockFinalClassTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,12 +28,8 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class CannotMockFinalClassTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(CannotMockFinalClass.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(CannotMockFinalClass.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ChainedAssertionLosesContextTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ChainedAssertionLosesContextTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author cpovirk@google.com (Chris Povirk) */
 @RunWith(JUnit4.class)
 public class ChainedAssertionLosesContextTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(ChainedAssertionLosesContext.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ChainedAssertionLosesContext.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ChainingConstructorIgnoresParameterTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ChainingConstructorIgnoresParameterTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author cpovirk@google.com (Chris Povirk) */
 @RunWith(JUnit4.class)
 public class ChainingConstructorIgnoresParameterTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(ChainingConstructorIgnoresParameter.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ChainingConstructorIgnoresParameter.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/CheckReturnValueTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/CheckReturnValueTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CheckReturnValueTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(CheckReturnValue.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(CheckReturnValue.class, getClass());
 
   @Test
   public void testPositiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ClassCanBeStaticTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ClassCanBeStaticTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ClassCanBeStaticTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(ClassCanBeStatic.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ClassCanBeStatic.class, getClass());
 
   @Test
   public void testNegativeCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ClassNameTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ClassNameTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ClassNameTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(ClassName.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ClassName.class, getClass());
 
   @Test
   public void twoClasses() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ClassNamedLikeTypeParameterTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ClassNamedLikeTypeParameterTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ClassNamedLikeTypeParameterTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public final void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(ClassNamedLikeTypeParameter.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ClassNamedLikeTypeParameter.class, getClass());
 
   @Test
   public void positiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/CollectionToArraySafeParameterTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/CollectionToArraySafeParameterTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assume.assumeFalse;
 
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.util.RuntimeVersion;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,13 +26,8 @@ import org.junit.runners.JUnit4;
 /** @author mariasam@google.com (Maria Sam) on 6/27/17. */
 @RunWith(JUnit4.class)
 public class CollectionToArraySafeParameterTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(CollectionToArraySafeParameter.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(CollectionToArraySafeParameter.class, getClass());
 
   @Test
   public void testPositiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/CollectorShouldNotUseStateTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/CollectorShouldNotUseStateTest.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -24,13 +23,8 @@ import org.junit.runners.JUnit4;
 /** @author sulku@google.com (Marsela Sulku) */
 @RunWith(JUnit4.class)
 public class CollectorShouldNotUseStateTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(CollectorShouldNotUseState.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(CollectorShouldNotUseState.class, getClass());
 
   @Test
   public void testPositiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ComparableAndComparatorTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ComparableAndComparatorTest.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,13 +26,8 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class ComparableAndComparatorTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(ComparableAndComparator.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ComparableAndComparator.class, getClass());
 
   @Test
   public void testCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ComparableTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ComparableTypeTest.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -24,12 +23,8 @@ import org.junit.runners.JUnit4;
 /** {@link ComparableType}Test */
 @RunWith(JUnit4.class)
 public class ComparableTypeTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(ComparableType.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ComparableType.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ComparisonContractViolatedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ComparisonContractViolatedTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author lowasser@google.com (Louis Wasserman) */
 @RunWith(JUnit4.class)
 public class ComparisonContractViolatedTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(ComparisonContractViolated.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ComparisonContractViolated.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ComparisonOutOfRangeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ComparisonOutOfRangeTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ComparisonOutOfRangeTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(ComparisonOutOfRange.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ComparisonOutOfRange.class, getClass());
 
   @Test
   public void testPositiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/DeadExceptionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/DeadExceptionTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DeadExceptionTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(DeadException.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(DeadException.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/DefaultCharsetTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/DefaultCharsetTest.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.FixChoosers;
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -28,12 +27,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DefaultCharsetTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(DefaultCharset.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(DefaultCharset.class, getClass());
 
   private BugCheckerRefactoringTestHelper refactoringTest() {
     return BugCheckerRefactoringTestHelper.newInstance(new DefaultCharset(), getClass());

--- a/core/src/test/java/com/google/errorprone/bugpatterns/DepAnnTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/DepAnnTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,14 +25,10 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DepAnnTest {
 
-  private CompilationTestHelper compilationHelper;
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(DepAnn.class, getClass());
 
-  public static final ImmutableList<String> JAVACOPTS = ImmutableList.of("-Xlint:-dep-ann");
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(DepAnn.class, getClass());
-  }
+  private static final ImmutableList<String> JAVACOPTS = ImmutableList.of("-Xlint:-dep-ann");
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/DivZeroTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/DivZeroTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DivZeroTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(DivZero.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(DivZero.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/DuplicateMapKeysTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/DuplicateMapKeysTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assume.assumeTrue;
 
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.util.RuntimeVersion;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -33,12 +32,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class DuplicateMapKeysTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(DuplicateMapKeys.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(DuplicateMapKeys.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/EmptyIfStatementTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/EmptyIfStatementTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class EmptyIfStatementTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(EmptyIfStatement.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(EmptyIfStatement.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/EmptyTopLevelDeclarationTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/EmptyTopLevelDeclarationTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class EmptyTopLevelDeclarationTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(EmptyTopLevelDeclaration.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(EmptyTopLevelDeclaration.class, getClass());
 
   @Test
   public void negative() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/EqualsIncompatibleTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/EqualsIncompatibleTypeTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
 import java.util.Arrays;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 /** @author avenet@google.com (Arnaud J. Venet) */
 @RunWith(JUnit4.class)
 public class EqualsIncompatibleTypeTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(EqualsIncompatibleType.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(EqualsIncompatibleType.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/EqualsNaNTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/EqualsNaNTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class EqualsNaNTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(EqualsNaN.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(EqualsNaN.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/EqualsReferenceTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/EqualsReferenceTest.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class EqualsReferenceTest {
 
-  private CompilationTestHelper compilationTestHelper;
-
-  @Before
-  public void setup() {
-    compilationTestHelper = CompilationTestHelper.newInstance(EqualsReference.class, getClass());
-  }
+  private final CompilationTestHelper compilationTestHelper =
+      CompilationTestHelper.newInstance(EqualsReference.class, getClass());
 
   @Test
   public void testPositiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/FinallyTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/FinallyTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class FinallyTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(Finally.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(Finally.class, getClass());
 
   @Test
   public void testPositiveCase1() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ForOverrideCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ForOverrideCheckerTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,25 +25,20 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ForOverrideCheckerTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(ForOverrideChecker.class, getClass())
-            .addSourceLines(
-                "test/ExtendMe.java",
-                "package test;",
-                "import com.google.errorprone.annotations.ForOverride;",
-                "public class ExtendMe {",
-                "  @ForOverride",
-                "  protected int overrideMe() { return 1; }",
-                "",
-                "  public final void callMe() {",
-                "    overrideMe();",
-                "  }",
-                "}");
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ForOverrideChecker.class, getClass())
+          .addSourceLines(
+              "test/ExtendMe.java",
+              "package test;",
+              "import com.google.errorprone.annotations.ForOverride;",
+              "public class ExtendMe {",
+              "  @ForOverride",
+              "  protected int overrideMe() { return 1; }",
+              "",
+              "  public final void callMe() {",
+              "    overrideMe();",
+              "  }",
+              "}");
 
   @Test
   public void testCanApplyForOverrideToProtectedMethod() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/FunctionalInterfaceMethodChangedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/FunctionalInterfaceMethodChangedTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class FunctionalInterfaceMethodChangedTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(FunctionalInterfaceMethodChanged.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(FunctionalInterfaceMethodChanged.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnoredTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnoredTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,13 +26,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class FutureReturnValueIgnoredTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(FutureReturnValueIgnored.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(FutureReturnValueIgnored.class, getClass());
 
   @Test
   public void testPositiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/FuturesGetCheckedIllegalExceptionTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/FuturesGetCheckedIllegalExceptionTypeTest.java
@@ -15,7 +15,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -23,13 +22,8 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link FuturesGetCheckedIllegalExceptionType}. */
 @RunWith(JUnit4.class)
 public class FuturesGetCheckedIllegalExceptionTypeTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(FuturesGetCheckedIllegalExceptionType.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(FuturesGetCheckedIllegalExceptionType.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/FuzzyEqualsShouldNotBeUsedInEqualsMethodTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/FuzzyEqualsShouldNotBeUsedInEqualsMethodTest.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,14 +24,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class FuzzyEqualsShouldNotBeUsedInEqualsMethodTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(
-            FuzzyEqualsShouldNotBeUsedInEqualsMethod.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(FuzzyEqualsShouldNotBeUsedInEqualsMethod.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/GetClassOnAnnotationTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/GetClassOnAnnotationTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class GetClassOnAnnotationTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(GetClassOnAnnotation.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(GetClassOnAnnotation.class, getClass());
 
   @Test
   public void positive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/GetClassOnClassTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/GetClassOnClassTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -28,12 +27,8 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class GetClassOnClassTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(GetClassOnClass.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(GetClassOnClass.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/GetClassOnEnumTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/GetClassOnEnumTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class GetClassOnEnumTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(GetClassOnEnum.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(GetClassOnEnum.class, getClass());
 
   @Test
   public void positive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/HashtableContainsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/HashtableContainsTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 /** {@link HashtableContains}Test */
 @RunWith(JUnit4.class)
 public class HashtableContainsTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(HashtableContains.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(HashtableContains.class, getClass());
 
   @Test
   public void positive_CHM() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ImplementAssertionWithChainingTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ImplementAssertionWithChainingTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author cpovirk@google.com (Chris Povirk) */
 @RunWith(JUnit4.class)
 public class ImplementAssertionWithChainingTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(ImplementAssertionWithChaining.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ImplementAssertionWithChaining.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/IncompatibleModifiersCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/IncompatibleModifiersCheckerTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -31,39 +30,34 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class IncompatibleModifiersCheckerTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(IncompatibleModifiersChecker.class, getClass())
-            .addSourceLines(
-                "test/NotPrivateOrFinal.java",
-                "package test;",
-                "import static javax.lang.model.element.Modifier.FINAL;",
-                "import static javax.lang.model.element.Modifier.PRIVATE;",
-                "import com.google.errorprone.annotations.IncompatibleModifiers;",
-                "@IncompatibleModifiers({PRIVATE, FINAL})",
-                "public @interface NotPrivateOrFinal {",
-                "}")
-            .addSourceLines(
-                "test/NotPublicOrFinal.java",
-                "package test;",
-                "import static javax.lang.model.element.Modifier.FINAL;",
-                "import static javax.lang.model.element.Modifier.PUBLIC;",
-                "import com.google.errorprone.annotations.IncompatibleModifiers;",
-                "@IncompatibleModifiers({PUBLIC, FINAL})",
-                "public @interface NotPublicOrFinal {",
-                "}")
-            .addSourceLines(
-                "test/NotAbstract.java",
-                "package test;",
-                "import static javax.lang.model.element.Modifier.ABSTRACT;",
-                "import com.google.errorprone.annotations.IncompatibleModifiers;",
-                "@IncompatibleModifiers(ABSTRACT)",
-                "public @interface NotAbstract {",
-                "}");
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(IncompatibleModifiersChecker.class, getClass())
+          .addSourceLines(
+              "test/NotPrivateOrFinal.java",
+              "package test;",
+              "import static javax.lang.model.element.Modifier.FINAL;",
+              "import static javax.lang.model.element.Modifier.PRIVATE;",
+              "import com.google.errorprone.annotations.IncompatibleModifiers;",
+              "@IncompatibleModifiers({PRIVATE, FINAL})",
+              "public @interface NotPrivateOrFinal {",
+              "}")
+          .addSourceLines(
+              "test/NotPublicOrFinal.java",
+              "package test;",
+              "import static javax.lang.model.element.Modifier.FINAL;",
+              "import static javax.lang.model.element.Modifier.PUBLIC;",
+              "import com.google.errorprone.annotations.IncompatibleModifiers;",
+              "@IncompatibleModifiers({PUBLIC, FINAL})",
+              "public @interface NotPublicOrFinal {",
+              "}")
+          .addSourceLines(
+              "test/NotAbstract.java",
+              "package test;",
+              "import static javax.lang.model.element.Modifier.ABSTRACT;",
+              "import com.google.errorprone.annotations.IncompatibleModifiers;",
+              "@IncompatibleModifiers(ABSTRACT)",
+              "public @interface NotAbstract {",
+              "}");
 
   @Test
   public void testAnnotationWithIncompatibleModifierOnClassFails() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/InputStreamSlowMultibyteReadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/InputStreamSlowMultibyteReadTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class InputStreamSlowMultibyteReadTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(InputStreamSlowMultibyteRead.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(InputStreamSlowMultibyteRead.class, getClass());
 
   @Test
   public void doingItRight() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/InsecureCipherModeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/InsecureCipherModeTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author avenet@google.com (Arnaud J. Venet) */
 @RunWith(JUnit4.class)
 public class InsecureCipherModeTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(InsecureCipherMode.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(InsecureCipherMode.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/InstanceOfAndCastMatchWrongTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/InstanceOfAndCastMatchWrongTypeTest.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,13 +26,8 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class InstanceOfAndCastMatchWrongTypeTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(InstanceOfAndCastMatchWrongType.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(InstanceOfAndCastMatchWrongType.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/InvalidPatternSyntaxTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/InvalidPatternSyntaxTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class InvalidPatternSyntaxTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(InvalidPatternSyntax.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(InvalidPatternSyntax.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/InvalidTimeZoneIDTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/InvalidTimeZoneIDTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class InvalidTimeZoneIDTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(InvalidTimeZoneID.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(InvalidTimeZoneID.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/InvalidZoneIdTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/InvalidZoneIdTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class InvalidZoneIdTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(InvalidZoneId.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(InvalidZoneId.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/IsInstanceOfClassTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/IsInstanceOfClassTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 /** {@link IsInstanceOfClass}Test */
 @RunWith(JUnit4.class)
 public class IsInstanceOfClassTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(IsInstanceOfClass.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(IsInstanceOfClass.class, getClass());
 
   @Test
   public void positive_clazz_enclosingClass() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/IterableAndIteratorTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/IterableAndIteratorTest.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -24,12 +23,8 @@ import org.junit.runners.JUnit4;
 /** @author jsjeon@google.com (Jinseong Jeon) */
 @RunWith(JUnit4.class)
 public class IterableAndIteratorTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(IterableAndIterator.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(IterableAndIterator.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/JMockTestWithoutRunWithOrRuleAnnotationTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/JMockTestWithoutRunWithOrRuleAnnotationTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,14 +24,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class JMockTestWithoutRunWithOrRuleAnnotationTest {
 
-  private CompilationTestHelper compilationTestHelper;
-
-  @Before
-  public void setup() {
-    compilationTestHelper =
-        CompilationTestHelper.newInstance(
-            JMockTestWithoutRunWithOrRuleAnnotation.class, getClass());
-  }
+  private final CompilationTestHelper compilationTestHelper =
+      CompilationTestHelper.newInstance(JMockTestWithoutRunWithOrRuleAnnotation.class, getClass());
 
   @Test
   public void testShouldFlagNoRuleAndNoRunWith() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/JUnit3FloatingPointComparisonWithoutDeltaTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/JUnit3FloatingPointComparisonWithoutDeltaTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -30,14 +29,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class JUnit3FloatingPointComparisonWithoutDeltaTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void createCompilerWithErrorProneCheck() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(
-            JUnit3FloatingPointComparisonWithoutDelta.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(
+          JUnit3FloatingPointComparisonWithoutDelta.class, getClass());
 
   @Test
   public void match_TwoPrimitiveDoubles() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/JUnit4SetUpNotRunTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/JUnit4SetUpNotRunTest.java
@@ -29,14 +29,10 @@ import org.junit.runners.ParentRunner;
 @RunWith(JUnit4.class)
 public class JUnit4SetUpNotRunTest {
 
-  private CompilationTestHelper compilationHelper;
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(JUnit4SetUpNotRun.class, getClass());
   private final BugCheckerRefactoringTestHelper refactoringTestHelper =
       BugCheckerRefactoringTestHelper.newInstance(new JUnit4SetUpNotRun(), getClass());
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(JUnit4SetUpNotRun.class, getClass());
-  }
 
   @Test
   public void testPositiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/JUnit4TearDownNotRunTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/JUnit4TearDownNotRunTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class JUnit4TearDownNotRunTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(JUnit4TearDownNotRun.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(JUnit4TearDownNotRun.class, getClass());
 
   @Test
   public void testPositiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/LiteByteStringUtf8Test.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/LiteByteStringUtf8Test.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class LiteByteStringUtf8Test {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(LiteByteStringUtf8.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(LiteByteStringUtf8.class, getClass());
 
   @Test
   public void positiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/LockOnBoxedPrimitiveTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/LockOnBoxedPrimitiveTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -28,12 +27,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class LockOnBoxedPrimitiveTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(LockOnBoxedPrimitive.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(LockOnBoxedPrimitive.class, getClass());
 
   @Test
   public void detectsSynchronizedBoxedLocks() throws Exception {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/LongLiteralLowerCaseSuffixTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/LongLiteralLowerCaseSuffixTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -31,13 +30,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class LongLiteralLowerCaseSuffixTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(LongLiteralLowerCaseSuffix.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(LongLiteralLowerCaseSuffix.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MissingCasesInEnumSwitchTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MissingCasesInEnumSwitchTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 /** {@link MissingCasesInEnumSwitch}Test */
 @RunWith(JUnit4.class)
 public class MissingCasesInEnumSwitchTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(MissingCasesInEnumSwitch.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(MissingCasesInEnumSwitch.class, getClass());
 
   @Test
   public void testExhaustive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MissingFailTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MissingFailTest.java
@@ -32,7 +32,6 @@ import com.sun.tools.javac.tree.EndPosTable;
 import com.sun.tools.javac.tree.JCTree;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -41,14 +40,10 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MissingFailTest {
 
-  private CompilationTestHelper compilationHelper;
-  private BugCheckerRefactoringTestHelper refactoringHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(MissingFail.class, getClass());
-    refactoringHelper = BugCheckerRefactoringTestHelper.newInstance(new MissingFail(), getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(MissingFail.class, getClass());
+  private final BugCheckerRefactoringTestHelper refactoringHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new MissingFail(), getClass());
 
   @Test
   public void testPositiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MissingOverrideTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MissingOverrideTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,12 +26,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MissingOverrideTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(MissingOverride.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(MissingOverride.class, getClass());
 
   @Test
   public void simple() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MisusedWeekYearTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MisusedWeekYearTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,12 +26,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MisusedWeekYearTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(MisusedWeekYear.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(MisusedWeekYear.class, getClass());
 
   @Test
   public void testPositiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MockitoCastTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MockitoCastTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MockitoCastTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(MockitoCast.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(MockitoCast.class, getClass());
 
   @Test
   public void defaultAnswerOk() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MockitoUsageTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MockitoUsageTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 /** {@link MockitoUsage}Test */
 @RunWith(JUnit4.class)
 public class MockitoUsageTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(MockitoUsage.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(MockitoUsage.class, getClass());
 
   private static final String[] FOO_SOURCE = {
     "class Foo {",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ModifyCollectionInEnhancedForLoopTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ModifyCollectionInEnhancedForLoopTest.java
@@ -15,7 +15,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -24,13 +23,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ModifyCollectionInEnhancedForLoopTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(ModifyCollectionInEnhancedForLoop.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ModifyCollectionInEnhancedForLoop.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ModifyingCollectionWithItselfTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ModifyingCollectionWithItselfTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ModifyingCollectionWithItselfTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(ModifyingCollectionWithItself.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ModifyingCollectionWithItself.class, getClass());
 
   @Test
   public void testPositiveCases1() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MultipleParallelOrSequentialCallsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MultipleParallelOrSequentialCallsTest.java
@@ -23,7 +23,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** @author @mariasam (Maria Sam) on 7/6/17. */
+/**
+ * Unit tests for {@link MultipleParallelOrSequentialCalls}.
+ *
+ * @author mariasam@google.com (Maria Sam) on 7/6/17.
+ */
 @RunWith(JUnit4.class)
 public class MultipleParallelOrSequentialCallsTest {
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MultipleTopLevelClassesTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MultipleTopLevelClassesTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MultipleTopLevelClassesTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(MultipleTopLevelClasses.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(MultipleTopLevelClasses.class, getClass());
 
   @Test
   public void twoClasses() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MultipleUnaryOperatorsInMethodCallTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MultipleUnaryOperatorsInMethodCallTest.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -24,13 +23,8 @@ import org.junit.runners.JUnit4;
 /** @author sulku@google.com (Marsela Sulku) */
 @RunWith(JUnit4.class)
 public class MultipleUnaryOperatorsInMethodCallTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(MultipleUnaryOperatorsInMethodCall.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(MultipleUnaryOperatorsInMethodCall.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MustBeClosedCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MustBeClosedCheckerTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MustBeClosedCheckerTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(MustBeClosedChecker.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(MustBeClosedChecker.class, getClass());
 
   @Test
   public void positiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MutablePublicArrayTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MutablePublicArrayTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MutablePublicArrayTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(MutablePublicArray.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(MutablePublicArray.class, getClass());
 
   @Test
   public void publicStaticFinalPrimitive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NarrowingCompoundAssignmentTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NarrowingCompoundAssignmentTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @RunWith(JUnit4.class)
 public class NarrowingCompoundAssignmentTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(NarrowingCompoundAssignment.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(NarrowingCompoundAssignment.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NestedInstanceOfConditionsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NestedInstanceOfConditionsTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,13 +28,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class NestedInstanceOfConditionsTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(NestedInstanceOfConditions.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(NestedInstanceOfConditions.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NoAllocationCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NoAllocationCheckerTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class NoAllocationCheckerTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(NoAllocationChecker.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(NoAllocationChecker.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NonAtomicVolatileUpdateTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NonAtomicVolatileUpdateTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class NonAtomicVolatileUpdateTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(NonAtomicVolatileUpdate.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(NonAtomicVolatileUpdate.class, getClass());
 
   @Test
   public void testPositiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NonFinalCompileTimeConstantTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NonFinalCompileTimeConstantTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class NonFinalCompileTimeConstantTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(NonFinalCompileTimeConstant.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(NonFinalCompileTimeConstant.class, getClass());
 
   @Test
   public void positive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NonOverridingEqualsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NonOverridingEqualsTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 // TODO(eaftan): Tests for correctness of suggested fix
 @RunWith(JUnit4.class)
 public class NonOverridingEqualsTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(NonOverridingEquals.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(NonOverridingEquals.class, getClass());
 
   // Positive cases
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NonRuntimeAnnotationTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NonRuntimeAnnotationTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class NonRuntimeAnnotationTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(NonRuntimeAnnotation.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(NonRuntimeAnnotation.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NullableConstructorTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NullableConstructorTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class NullableConstructorTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(NullableConstructor.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(NullableConstructor.class, getClass());
 
   @Test
   public void positive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NullablePrimitiveTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NullablePrimitiveTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author sebastian.h.monte@gmail.com (Sebastian Monte) */
 @RunWith(JUnit4.class)
 public class NullablePrimitiveTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(NullablePrimitive.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(NullablePrimitive.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NullableVoidTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NullableVoidTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class NullableVoidTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(NullableVoid.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(NullableVoid.class, getClass());
 
   @Test
   public void positive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NumericEqualityTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NumericEqualityTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class NumericEqualityTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(NumericEquality.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(NumericEquality.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/OptionalEqualityTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/OptionalEqualityTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class OptionalEqualityTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(OptionalEquality.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(OptionalEquality.class, getClass());
 
   @Test
   public void testPositiveCase_equal() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/OverrideThrowableToStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/OverrideThrowableToStringTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 /** @author mariasam@google.com (Maria Sam) */
 @RunWith(JUnit4.class)
 public class OverrideThrowableToStringTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(OverrideThrowableToString.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(OverrideThrowableToString.class, getClass());
 
   @Test
   public void positiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/OverridesTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/OverridesTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author cushon@google.com (Liam Miller-Cushon) */
 @RunWith(JUnit4.class)
 public class OverridesTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(Overrides.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(Overrides.class, getClass());
 
   @Test
   public void testPositiveCase1() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/PackageLocationTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/PackageLocationTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class PackageLocationTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(PackageLocation.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(PackageLocation.class, getClass());
 
   @Test
   public void positiveCustomRoot() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/PrimitiveArrayPassedToVarargsMethodTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/PrimitiveArrayPassedToVarargsMethodTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class PrimitiveArrayPassedToVarargsMethodTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(PrimitiveArrayPassedToVarargsMethod.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(PrimitiveArrayPassedToVarargsMethod.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/PrivateSecurityContractProtoAccessTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/PrivateSecurityContractProtoAccessTest.java
@@ -17,20 +17,14 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class PrivateSecurityContractProtoAccessTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(PrivateSecurityContractProtoAccess.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(PrivateSecurityContractProtoAccess.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ProtocolBufferOrdinalTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ProtocolBufferOrdinalTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -30,12 +29,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ProtocolBufferOrdinalTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(ProtocolBufferOrdinal.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ProtocolBufferOrdinal.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/RandomModIntegerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/RandomModIntegerTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class RandomModIntegerTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(RandomModInteger.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(RandomModInteger.class, getClass());
 
   @Test
   public void positive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/RedundantConditionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/RedundantConditionTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class RedundantConditionTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(RedundantCondition.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(RedundantCondition.class, getClass());
 
   @Test
   public void singleBinaryInitialization() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/RequiredModifiersCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/RequiredModifiersCheckerTest.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import javax.tools.JavaFileObject;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -32,33 +31,28 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class RequiredModifiersCheckerTest {
 
-  private CompilationTestHelper compilationHelper;
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(RequiredModifiersChecker.class, getClass())
+          .addSourceLines(
+              "test/AbstractRequired.java",
+              "package test;",
+              "import static javax.lang.model.element.Modifier.ABSTRACT;",
+              "import com.google.errorprone.annotations.RequiredModifiers;",
+              "@RequiredModifiers(ABSTRACT)",
+              "public @interface AbstractRequired {",
+              "}")
+          .addSourceLines(
+              "test/PublicAndFinalRequired.java",
+              "package test;",
+              "import static javax.lang.model.element.Modifier.FINAL;",
+              "import static javax.lang.model.element.Modifier.PUBLIC;",
+              "import com.google.errorprone.annotations.RequiredModifiers;",
+              "@RequiredModifiers({PUBLIC, FINAL})",
+              "public @interface PublicAndFinalRequired {",
+              "}");
 
   JavaFileObject abstractRequired;
   JavaFileObject publicAndFinalRequired;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(RequiredModifiersChecker.class, getClass())
-            .addSourceLines(
-                "test/AbstractRequired.java",
-                "package test;",
-                "import static javax.lang.model.element.Modifier.ABSTRACT;",
-                "import com.google.errorprone.annotations.RequiredModifiers;",
-                "@RequiredModifiers(ABSTRACT)",
-                "public @interface AbstractRequired {",
-                "}")
-            .addSourceLines(
-                "test/PublicAndFinalRequired.java",
-                "package test;",
-                "import static javax.lang.model.element.Modifier.FINAL;",
-                "import static javax.lang.model.element.Modifier.PUBLIC;",
-                "import com.google.errorprone.annotations.RequiredModifiers;",
-                "@RequiredModifiers({PUBLIC, FINAL})",
-                "public @interface PublicAndFinalRequired {",
-                "}");
-  }
 
   @Test
   public void testAnnotationWithRequiredModifiersMissingOnClassFails() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/RestrictedApiCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/RestrictedApiCheckerTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
 import com.sun.tools.javac.main.Main.Result;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,15 +25,10 @@ import org.junit.runners.JUnit4;
 /** Unit test for {@link RestrictedApiChecker} */
 @RunWith(JUnit4.class)
 public class RestrictedApiCheckerTest {
-  private CompilationTestHelper helper;
-
-  @Before
-  public void setUp() {
-    helper =
-        CompilationTestHelper.newInstance(RestrictedApiChecker.class, getClass())
-            .addSourceFile("RestrictedApiMethods.java")
-            .matchAllDiagnostics();
-  }
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(RestrictedApiChecker.class, getClass())
+          .addSourceFile("RestrictedApiMethods.java")
+          .matchAllDiagnostics();
 
   @Test
   public void testNormalCallAllowed() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/SelfAssignmentTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/SelfAssignmentTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class SelfAssignmentTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(SelfAssignment.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(SelfAssignment.class, getClass());
 
   @Test
   public void testPositiveCases1() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/StreamToStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/StreamToStringTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class StreamToStringTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(StreamToString.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(StreamToString.class, getClass());
 
   @Test
   public void positive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/StringBuilderInitWithCharTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/StringBuilderInitWithCharTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class StringBuilderInitWithCharTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(StringBuilderInitWithChar.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(StringBuilderInitWithChar.class, getClass());
 
   @Test
   public void testPositiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/StringEqualityTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/StringEqualityTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class StringEqualityTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(StringEquality.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(StringEquality.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/SuppressWarningsDeprecatedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/SuppressWarningsDeprecatedTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -30,13 +29,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class SuppressWarningsDeprecatedTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(SuppressWarningsDeprecated.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(SuppressWarningsDeprecated.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/SwigMemoryLeakTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/SwigMemoryLeakTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class SwigMemoryLeakTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(SwigMemoryLeak.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(SwigMemoryLeak.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ThreeLetterTimeZoneIDTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ThreeLetterTimeZoneIDTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,12 +35,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ThreeLetterTimeZoneIDTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(ThreeLetterTimeZoneID.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ThreeLetterTimeZoneID.class, getClass());
 
   @Test
   public void testAllThreeLetterIdsAreCoveredByZoneIdShortIds() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ThrowIfUncheckedKnownCheckedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ThrowIfUncheckedKnownCheckedTest.java
@@ -15,7 +15,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -23,13 +22,8 @@ import org.junit.runners.JUnit4;
 /** @author cpovirk@google.com (Chris Povirk) */
 @RunWith(JUnit4.class)
 public class ThrowIfUncheckedKnownCheckedTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(ThrowIfUncheckedKnownChecked.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ThrowIfUncheckedKnownChecked.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ThrowsUncheckedExceptionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ThrowsUncheckedExceptionTest.java
@@ -19,7 +19,6 @@ import static com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode.TEX
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,13 +26,8 @@ import org.junit.runners.JUnit4;
 /** @author yulissa@google.com (Yulissa Arroyo-Paredes) */
 @RunWith(JUnit4.class)
 public final class ThrowsUncheckedExceptionTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(ThrowsUncheckedException.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ThrowsUncheckedException.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ToStringReturnsNullTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ToStringReturnsNullTest.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,12 +28,8 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public final class ToStringReturnsNullTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(ToStringReturnsNull.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ToStringReturnsNull.class, getClass());
 
   @Test
   public void positive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TryFailThrowableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TryFailThrowableTest.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TryFailThrowableTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(TryFailThrowable.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(TryFailThrowable.class, getClass());
 
   @Test
   public void testPositiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TypeNameShadowingTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TypeNameShadowingTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,14 +26,10 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TypeNameShadowingTest {
 
-  private CompilationTestHelper compilationHelper;
-  private BugCheckerRefactoringTestHelper refactoring;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(TypeNameShadowing.class, getClass());
-    refactoring = BugCheckerRefactoringTestHelper.newInstance(new TypeNameShadowing(), getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(TypeNameShadowing.class, getClass());
+  private final BugCheckerRefactoringTestHelper refactoring =
+      BugCheckerRefactoringTestHelper.newInstance(new TypeNameShadowing(), getClass());
 
   @Test
   public void positiveClass() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterQualifierTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterQualifierTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TypeParameterQualifierTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(TypeParameterQualifier.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(TypeParameterQualifier.class, getClass());
 
   @Test
   public void positive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterShadowingTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterShadowingTest.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -28,15 +27,10 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TypeParameterShadowingTest {
 
-  private CompilationTestHelper compilationHelper;
-  private BugCheckerRefactoringTestHelper refactoring;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(TypeParameterShadowing.class, getClass());
-    refactoring =
-        BugCheckerRefactoringTestHelper.newInstance(new TypeParameterShadowing(), getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(TypeParameterShadowing.class, getClass());
+  private final BugCheckerRefactoringTestHelper refactoring =
+      BugCheckerRefactoringTestHelper.newInstance(new TypeParameterShadowing(), getClass());
 
   @Test
   public void singleLevel() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterUnusedInFormalsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterUnusedInFormalsTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TypeParameterUnusedInFormalsTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(TypeParameterUnusedInFormals.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(TypeParameterUnusedInFormals.class, getClass());
 
   @Test
   public void evilCastImpl() {
@@ -80,7 +74,8 @@ public class TypeParameterUnusedInFormalsTest {
             "package foo.bar;",
             "class Test {",
             "  // BUG: Diagnostic contains:",
-            "  static <V extends Object, T, U extends Object> T doCast(U o, V v) { T t = (T) o; return t; }",
+            "  static <V extends Object, T, U extends Object> T doCast(U o, V v) { T t = (T) o;"
+                + " return t; }",
             "}")
         .doTest();
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryStaticImportTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryStaticImportTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class UnnecessaryStaticImportTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(UnnecessaryStaticImport.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(UnnecessaryStaticImport.class, getClass());
 
   @Test
   public void positive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryTypeArgumentTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryTypeArgumentTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class UnnecessaryTypeArgumentTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(UnnecessaryTypeArgument.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(UnnecessaryTypeArgument.class, getClass());
 
   @Test
   public void positiveCall() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnsynchronizedOverridesSynchronizedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnsynchronizedOverridesSynchronizedTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class UnsynchronizedOverridesSynchronizedTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(UnsynchronizedOverridesSynchronized.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(UnsynchronizedOverridesSynchronized.class, getClass());
 
   @Test
   public void positive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedAnonymousClassTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedAnonymousClassTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 /** {@link UnusedAnonymousClass}Test */
 @RunWith(JUnit4.class)
 public class UnusedAnonymousClassTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(UnusedAnonymousClass.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(UnusedAnonymousClass.class, getClass());
 
   @Test
   public void deadObject() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/VarCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/VarCheckerTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
 import java.util.Arrays;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,12 +26,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class VarCheckerTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(VarChecker.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(VarChecker.class, getClass());
 
   // fields are ignored
   @Test

--- a/core/src/test/java/com/google/errorprone/bugpatterns/WaitNotInLoopTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/WaitNotInLoopTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class WaitNotInLoopTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(WaitNotInLoop.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(WaitNotInLoop.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/WrongParameterPackageTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/WrongParameterPackageTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class WrongParameterPackageTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(WrongParameterPackage.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(WrongParameterPackage.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/android/HardCodedSdCardPathTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/android/HardCodedSdCardPathTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.android;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author avenet@google.com (Arnaud J. Venet) */
 @RunWith(JUnit4.class)
 public class HardCodedSdCardPathTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(HardCodedSdCardPath.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(HardCodedSdCardPath.class, getClass());
 
   @Test
   public void testPositiveCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/android/RectIntersectReturnValueIgnoredTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/android/RectIntersectReturnValueIgnoredTest.java
@@ -25,13 +25,12 @@ import org.junit.runners.JUnit4;
 /** @author avenet@google.com (Arnaud J. Venet) */
 @RunWith(JUnit4.class)
 public class RectIntersectReturnValueIgnoredTest {
-  private CompilationTestHelper compilationHelper;
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(RectIntersectReturnValueIgnored.class, getClass())
+          .addSourceFile("testdata/stubs/android/graphics/Rect.java");
 
   @Before
   public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(RectIntersectReturnValueIgnored.class, getClass())
-            .addSourceFile("testdata/stubs/android/graphics/Rect.java");
   }
 
   @Test

--- a/core/src/test/java/com/google/errorprone/bugpatterns/android/StaticOrDefaultInterfaceMethodTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/android/StaticOrDefaultInterfaceMethodTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.android;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class StaticOrDefaultInterfaceMethodTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(StaticOrDefaultInterfaceMethod.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(StaticOrDefaultInterfaceMethod.class, getClass());
 
   @Test
   public void testPositiveCaseDefault() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/AssertEqualsArgumentOrderCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/AssertEqualsArgumentOrderCheckerTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.argumentselectiondefects;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class AssertEqualsArgumentOrderCheckerTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(AssertEqualsArgumentOrderChecker.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(AssertEqualsArgumentOrderChecker.class, getClass());
 
   @Test
   public void assertEqualsCheck_makesNoSuggestion_withOrderExpectedActual() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/AutoValueConstructorOrderCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/argumentselectiondefects/AutoValueConstructorOrderCheckerTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.argumentselectiondefects;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class AutoValueConstructorOrderCheckerTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(AutoValueConstructorOrderChecker.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(AutoValueConstructorOrderChecker.class, getClass());
 
   @Test
   public void autoValueChecker_detectsSwap_withExactNames() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionIncompatibleTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionIncompatibleTypeTest.java
@@ -19,7 +19,6 @@ package com.google.errorprone.bugpatterns.collectionincompatibletype;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
-import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.bugpatterns.collectionincompatibletype.CollectionIncompatibleType.FixType;
 import com.google.errorprone.scanner.ErrorProneScanner;
 import com.google.errorprone.scanner.ScannerSupplier;
@@ -59,8 +58,7 @@ public class CollectionIncompatibleTypeTest {
     CompilationTestHelper compilationHelperWithCastFix =
         CompilationTestHelper.newInstance(
             ScannerSupplier.fromScanner(
-                new ErrorProneScanner(
-                    new CollectionIncompatibleType(FixType.CAST, ErrorProneFlags.empty()))),
+                new ErrorProneScanner(new CollectionIncompatibleType(FixType.CAST))),
             getClass());
     compilationHelperWithCastFix
         .addSourceLines(
@@ -81,8 +79,7 @@ public class CollectionIncompatibleTypeTest {
   public void testSuppressWarningsFix() {
     BugCheckerRefactoringTestHelper refactorTestHelper =
         BugCheckerRefactoringTestHelper.newInstance(
-            new CollectionIncompatibleType(FixType.SUPPRESS_WARNINGS, ErrorProneFlags.empty()),
-            getClass());
+            new CollectionIncompatibleType(FixType.SUPPRESS_WARNINGS), getClass());
     refactorTestHelper
         .addInputLines(
             "in/Test.java",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionUndefinedEqualityTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionUndefinedEqualityTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.collectionincompatibletype;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link CollectionUndefinedEquality}. */
+@RunWith(JUnit4.class)
+public final class CollectionUndefinedEqualityTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(CollectionUndefinedEquality.class, getClass());
+
+  @Test
+  public void collectionOfCollections() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Collection;",
+            "class Test {",
+            "  boolean foo(Collection<Collection<Integer>> xs, Collection<Integer> x) {",
+            "    // BUG: Diagnostic contains:",
+            "    return xs.contains(x);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void collectionOfLists_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Collection;",
+            "import java.util.List;",
+            "class Test {",
+            "  boolean foo(Collection<List<Integer>> xs, List<Integer> x) {",
+            "    return xs.contains(x);",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CompatibleWithMisuseTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CompatibleWithMisuseTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.collectionincompatibletype;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CompatibleWithMisuseTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(CompatibleWithMisuse.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(CompatibleWithMisuse.class, getClass());
 
   @Test
   public void testOK() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/collectionincompatibletype/IncompatibleArgumentTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/collectionincompatibletype/IncompatibleArgumentTypeTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.collectionincompatibletype;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class IncompatibleArgumentTypeTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(IncompatibleArgumentType.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(IncompatibleArgumentType.class, getClass());
 
   @Test
   public void testGenericMethod() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringAnnotationCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringAnnotationCheckerTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.formatstring;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class FormatStringAnnotationCheckerTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(FormatStringAnnotationChecker.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(FormatStringAnnotationChecker.class, getClass());
 
   @Test
   public void testMatches_failsWithNonMatchingFormatArgs() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.formatstring;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class FormatStringTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(FormatString.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(FormatString.class, getClass());
 
   private void testFormat(String expected, String formatString) {
     compilationHelper

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/AssistedInjectAndInjectOnConstructorsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/AssistedInjectAndInjectOnConstructorsTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class AssistedInjectAndInjectOnConstructorsTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(AssistedInjectAndInjectOnConstructors.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(AssistedInjectAndInjectOnConstructors.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/AssistedInjectAndInjectOnSameConstructorTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/AssistedInjectAndInjectOnSameConstructorTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,14 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class AssistedInjectAndInjectOnSameConstructorTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(
-            AssistedInjectAndInjectOnSameConstructor.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(AssistedInjectAndInjectOnSameConstructor.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/AutoFactoryAtInjectTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/AutoFactoryAtInjectTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class AutoFactoryAtInjectTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(AutoFactoryAtInject.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(AutoFactoryAtInject.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/CloseableProvidesTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/CloseableProvidesTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CloseableProvidesTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(CloseableProvides.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(CloseableProvides.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/InjectOnConstructorOfAbstractClassTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/InjectOnConstructorOfAbstractClassTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class InjectOnConstructorOfAbstractClassTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(InjectOnConstructorOfAbstractClass.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(InjectOnConstructorOfAbstractClass.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/InjectOnMemberAndConstructorTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/InjectOnMemberAndConstructorTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,13 +28,8 @@ public class InjectOnMemberAndConstructorTest {
 
   private final BugCheckerRefactoringTestHelper testHelper =
       BugCheckerRefactoringTestHelper.newInstance(new InjectOnMemberAndConstructor(), getClass());
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(InjectOnMemberAndConstructor.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(InjectOnMemberAndConstructor.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/InjectedConstructorAnnotationsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/InjectedConstructorAnnotationsTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class InjectedConstructorAnnotationsTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(InjectedConstructorAnnotations.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(InjectedConstructorAnnotations.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/InvalidTargetingOnScopingAnnotationTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/InvalidTargetingOnScopingAnnotationTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class InvalidTargetingOnScopingAnnotationTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(InvalidTargetingOnScopingAnnotation.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(InvalidTargetingOnScopingAnnotation.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/JavaxInjectOnAbstractMethodTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/JavaxInjectOnAbstractMethodTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class JavaxInjectOnAbstractMethodTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(JavaxInjectOnAbstractMethod.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(JavaxInjectOnAbstractMethod.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/JavaxInjectOnFinalFieldTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/JavaxInjectOnFinalFieldTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author sgoldfeder@google.com (Steven Goldfeder) */
 @RunWith(JUnit4.class)
 public class JavaxInjectOnFinalFieldTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(JavaxInjectOnFinalField.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(JavaxInjectOnFinalField.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/MoreThanOneInjectableConstructorTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/MoreThanOneInjectableConstructorTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MoreThanOneInjectableConstructorTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(MoreThanOneInjectableConstructor.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(MoreThanOneInjectableConstructor.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/MoreThanOneQualifierTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/MoreThanOneQualifierTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MoreThanOneQualifierTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(MoreThanOneQualifier.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(MoreThanOneQualifier.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/MoreThanOneScopeAnnotationOnClassTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/MoreThanOneScopeAnnotationOnClassTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author sgoldfeder@google.com (Steven Goldfeder) */
 @RunWith(JUnit4.class)
 public class MoreThanOneScopeAnnotationOnClassTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(MoreThanOneScopeAnnotationOnClass.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(MoreThanOneScopeAnnotationOnClass.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/OverlappingQualifierAndScopeAnnotationTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/OverlappingQualifierAndScopeAnnotationTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class OverlappingQualifierAndScopeAnnotationTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(OverlappingQualifierAndScopeAnnotation.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(OverlappingQualifierAndScopeAnnotation.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/QualifierOrScopeOnInjectMethodTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/QualifierOrScopeOnInjectMethodTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,17 +26,10 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class QualifierOrScopeOnInjectMethodTest {
 
-  private CompilationTestHelper compilationHelper;
-  private BugCheckerRefactoringTestHelper refactoringHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(QualifierOrScopeOnInjectMethod.class, getClass());
-    refactoringHelper =
-        BugCheckerRefactoringTestHelper.newInstance(
-            new QualifierOrScopeOnInjectMethod(), getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(QualifierOrScopeOnInjectMethod.class, getClass());
+  private final BugCheckerRefactoringTestHelper refactoringHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new QualifierOrScopeOnInjectMethod(), getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/QualifierWithTypeUseTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/QualifierWithTypeUseTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class QualifierWithTypeUseTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(QualifierWithTypeUse.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(QualifierWithTypeUse.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/ScopeAnnotationOnInterfaceOrAbstractClassTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/ScopeAnnotationOnInterfaceOrAbstractClassTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,14 +25,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ScopeAnnotationOnInterfaceOrAbstractClassTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(
-            ScopeAnnotationOnInterfaceOrAbstractClass.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(
+          ScopeAnnotationOnInterfaceOrAbstractClass.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/ScopeOrQualifierAnnotationRetentionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/ScopeOrQualifierAnnotationRetentionTest.java
@@ -18,7 +18,6 @@ package com.google.errorprone.bugpatterns.inject;
 
 import com.google.errorprone.CompilationTestHelper;
 import java.util.Collections;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 /** @author sgoldfeder@google.com (Steven Goldfeder) */
 @RunWith(JUnit4.class)
 public class ScopeOrQualifierAnnotationRetentionTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(ScopeOrQualifierAnnotationRetention.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ScopeOrQualifierAnnotationRetention.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/AndroidInjectionBeforeSuperTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/AndroidInjectionBeforeSuperTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject.dagger;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,20 +25,15 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class AndroidInjectionBeforeSuperTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(AndroidInjectionBeforeSuper.class, getClass())
-            .addSourceFile("testdata/stubs/android/app/Activity.java")
-            .addSourceFile("testdata/stubs/android/app/Fragment.java")
-            .addSourceFile("testdata/stubs/android/app/Service.java")
-            .addSourceFile("testdata/stubs/android/content/Context.java")
-            .addSourceFile("testdata/stubs/android/content/Intent.java")
-            .addSourceFile("testdata/stubs/android/os/Bundle.java")
-            .addSourceFile("testdata/stubs/android/os/IBinder.java");
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(AndroidInjectionBeforeSuper.class, getClass())
+          .addSourceFile("testdata/stubs/android/app/Activity.java")
+          .addSourceFile("testdata/stubs/android/app/Fragment.java")
+          .addSourceFile("testdata/stubs/android/app/Service.java")
+          .addSourceFile("testdata/stubs/android/content/Context.java")
+          .addSourceFile("testdata/stubs/android/content/Intent.java")
+          .addSourceFile("testdata/stubs/android/os/Bundle.java")
+          .addSourceFile("testdata/stubs/android/os/IBinder.java");
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/ProvidesNullTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/dagger/ProvidesNullTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject.dagger;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link ProvidesNull}. */
 @RunWith(JUnit4.class)
 public class ProvidesNullTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(ProvidesNull.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ProvidesNull.class, getClass());
 
   // Positive cases
 
@@ -42,7 +37,8 @@ public class ProvidesNullTest {
             "import dagger.Provides;",
             "public class Test {",
             "  @Provides public Object providesObject() {",
-            "    // BUG: Diagnostic contains: Did you mean '@Nullable' or 'throw new RuntimeException();'",
+            "    // BUG: Diagnostic contains: Did you mean '@Nullable' or 'throw new"
+                + " RuntimeException();'",
             "    return null;",
             "  }",
             "}")
@@ -114,7 +110,8 @@ public class ProvidesNullTest {
             "    try {",
             "      return new Object();",
             "    } catch (Exception e) {",
-            "      // BUG: Diagnostic contains: Did you mean 'throw new RuntimeException(e);' or '@Nullable'",
+            "      // BUG: Diagnostic contains: Did you mean 'throw new RuntimeException(e);' or"
+                + " '@Nullable'",
             "      return null;",
             "    }",
             "  }",
@@ -131,7 +128,8 @@ public class ProvidesNullTest {
             "public class Test {",
             "  @Provides public Object providesObject() {",
             "    try {",
-            "      // BUG: Diagnostic contains: Did you mean '@Nullable' or 'throw new RuntimeException();'",
+            "      // BUG: Diagnostic contains: Did you mean '@Nullable' or 'throw new"
+                + " RuntimeException();'",
             "      return null;",
             "    } catch (Exception e) {",
             "      return new Object();",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/guice/AssistedInjectScopingTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/guice/AssistedInjectScopingTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject.guice;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class AssistedInjectScopingTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(AssistedInjectScoping.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(AssistedInjectScoping.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/guice/AssistedParametersTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/guice/AssistedParametersTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject.guice;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class AssistedParametersTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(AssistedParameters.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(AssistedParameters.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/guice/BindingToUnqualifiedCommonTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/guice/BindingToUnqualifiedCommonTypeTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject.guice;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author glorioso@google.com (Nick Glorioso) */
 @RunWith(JUnit4.class)
 public class BindingToUnqualifiedCommonTypeTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(BindingToUnqualifiedCommonType.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(BindingToUnqualifiedCommonType.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/guice/InjectOnFinalFieldTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/guice/InjectOnFinalFieldTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject.guice;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author sgoldfeder@google.com (Steven Goldfeder) */
 @RunWith(JUnit4.class)
 public class InjectOnFinalFieldTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(InjectOnFinalField.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(InjectOnFinalField.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/guice/OverridesGuiceInjectableMethodTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/guice/OverridesGuiceInjectableMethodTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject.guice;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author sgoldfeder@google.com (Steven Goldfeder) */
 @RunWith(JUnit4.class)
 public class OverridesGuiceInjectableMethodTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(OverridesGuiceInjectableMethod.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(OverridesGuiceInjectableMethod.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/guice/OverridesJavaxInjectableMethodTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/guice/OverridesJavaxInjectableMethodTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject.guice;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author sgoldfeder@google.com (Steven Goldfeder) */
 @RunWith(JUnit4.class)
 public class OverridesJavaxInjectableMethodTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(OverridesJavaxInjectableMethod.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(OverridesJavaxInjectableMethod.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/guice/ProvidesMethodOutsideOfModuleTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/guice/ProvidesMethodOutsideOfModuleTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.inject.guice;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 /** @author glorioso@google.com (Nick Glorioso) */
 @RunWith(JUnit4.class)
 public class ProvidesMethodOutsideOfModuleTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(ProvidesMethodOutsideOfModule.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ProvidesMethodOutsideOfModule.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/EqualsBrokenForNullTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/EqualsBrokenForNullTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.nullness;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,12 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class EqualsBrokenForNullTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(EqualsBrokenForNull.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(EqualsBrokenForNull.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/overloading/InconsistentOverloadsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/overloading/InconsistentOverloadsTest.java
@@ -17,8 +17,6 @@
 package com.google.errorprone.bugpatterns.overloading;
 
 import com.google.errorprone.CompilationTestHelper;
-import com.google.errorprone.bugpatterns.BugChecker;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -30,14 +28,8 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public final class InconsistentOverloadsTest {
-
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void createCompilationHelper() {
-    Class<? extends BugChecker> bugCheckerClass = InconsistentOverloads.class;
-    compilationHelper = CompilationTestHelper.newInstance(bugCheckerClass, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(InconsistentOverloads.class, getClass());
 
   @Test
   public void inconsistentOverloadsNegativeCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByLockMethodTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByLockMethodTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.threadsafety;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,12 +28,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class GuardedByLockMethodTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(GuardedByChecker.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(GuardedByChecker.class, getClass());
 
   @Test
   public void testSimple() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByValidatorTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByValidatorTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.threadsafety;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 /** {@link GuardedByChecker} annotation syntax GuardedByValidationResult test */
 @RunWith(JUnit4.class)
 public class GuardedByValidatorTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(GuardedByChecker.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(GuardedByChecker.class, getClass());
 
   @Test
   public void testPositive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/HeldLockAnalyzerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/HeldLockAnalyzerTest.java
@@ -26,7 +26,6 @@ import com.sun.source.tree.Tree;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -34,13 +33,8 @@ import org.junit.runners.JUnit4;
 /** {@link GuardedByLockSetAnalyzer}Test */
 @RunWith(JUnit4.class)
 public class HeldLockAnalyzerTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(GuardedByLockSetAnalyzer.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(GuardedByLockSetAnalyzer.class, getClass());
 
   @Test
   public void testInstance() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/LockMethodCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/LockMethodCheckerTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.threadsafety;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 /** {@link LockMethodChecker}Test */
 @RunWith(JUnit4.class)
 public class LockMethodCheckerTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(LockMethodChecker.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(LockMethodChecker.class, getClass());
 
   @Test
   public void testLocked() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/StaticGuardedByInstanceTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/StaticGuardedByInstanceTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.threadsafety;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,13 +25,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class StaticGuardedByInstanceTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(StaticGuardedByInstance.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(StaticGuardedByInstance.class, getClass());
 
   @Test
   public void positive() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/SynchronizeOnNonFinalFieldTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/SynchronizeOnNonFinalFieldTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.threadsafety;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +24,8 @@ import org.junit.runners.JUnit4;
 /** {@link SynchronizeOnNonFinalFieldTest}Test */
 @RunWith(JUnit4.class)
 public class SynchronizeOnNonFinalFieldTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(SynchronizeOnNonFinalField.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(SynchronizeOnNonFinalField.class, getClass());
 
   @Test
   public void testPositive1() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/ThreadPriorityCheckTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/ThreadPriorityCheckTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.threadsafety;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -31,12 +30,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class ThreadPriorityCheckTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(ThreadPriorityCheck.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ThreadPriorityCheck.class, getClass());
 
   @Test
   public void yieldThread() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/UnlockMethodCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/UnlockMethodCheckerTest.java
@@ -17,7 +17,6 @@
 package com.google.errorprone.bugpatterns.threadsafety;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,12 +24,8 @@ import org.junit.runners.JUnit4;
 /** {@link UnlockMethodChecker}Test */
 @RunWith(JUnit4.class)
 public class UnlockMethodCheckerTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(UnlockMethodChecker.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(UnlockMethodChecker.class, getClass());
 
   @Test
   public void testUnlocked() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/InvalidJavaTimeConstantTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/InvalidJavaTimeConstantTest.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns.time;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,13 +28,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class InvalidJavaTimeConstantTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(InvalidJavaTimeConstant.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(InvalidJavaTimeConstant.class, getClass());
 
   @Test
   public void cornerCases() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/JavaDurationGetSecondsGetNanoTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/JavaDurationGetSecondsGetNanoTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assume.assumeFalse;
 
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.util.RuntimeVersion;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -32,13 +31,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class JavaDurationGetSecondsGetNanoTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(JavaDurationGetSecondsGetNano.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(JavaDurationGetSecondsGetNano.class, getClass());
 
   @Test
   public void testGetSecondsWithGetNanos() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/JavaInstantGetSecondsGetNanoTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/JavaInstantGetSecondsGetNanoTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assume.assumeFalse;
 
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.util.RuntimeVersion;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -32,13 +31,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class JavaInstantGetSecondsGetNanoTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(JavaInstantGetSecondsGetNano.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(JavaInstantGetSecondsGetNano.class, getClass());
 
   @Test
   public void testGetSecondsWithGetNanos() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/JavaPeriodGetDaysTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/JavaPeriodGetDaysTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assume.assumeFalse;
 
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.util.RuntimeVersion;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -32,12 +31,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class JavaPeriodGetDaysTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(JavaPeriodGetDays.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(JavaPeriodGetDays.class, getClass());
 
   @Test
   public void getBoth() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/ProtoDurationGetSecondsGetNanoTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/ProtoDurationGetSecondsGetNanoTest.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns.time;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -32,13 +31,8 @@ import org.junit.Ignore;
 @Ignore("b/130667208")
 public class ProtoDurationGetSecondsGetNanoTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(ProtoDurationGetSecondsGetNano.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ProtoDurationGetSecondsGetNano.class, getClass());
 
   @Test
   public void testGetSecondsWithGetNanos() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/ProtoTimestampGetSecondsGetNanoTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/ProtoTimestampGetSecondsGetNanoTest.java
@@ -16,7 +16,6 @@
 package com.google.errorprone.bugpatterns.time;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -32,13 +31,8 @@ import org.junit.Ignore;
 @Ignore("b/130667208")
 public class ProtoTimestampGetSecondsGetNanoTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper =
-        CompilationTestHelper.newInstance(ProtoTimestampGetSecondsGetNano.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ProtoTimestampGetSecondsGetNano.class, getClass());
 
   @Test
   public void testGetSecondsWithGetNanos() {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/TimeUnitMismatchTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/TimeUnitMismatchTest.java
@@ -24,7 +24,6 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.errorprone.CompilationTestHelper;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -32,12 +31,8 @@ import org.junit.runners.JUnit4;
 /** @author cpovirk@google.com (Chris Povirk) */
 @RunWith(JUnit4.class)
 public class TimeUnitMismatchTest {
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(TimeUnitMismatch.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(TimeUnitMismatch.class, getClass());
 
   @Test
   public void testPositiveCase() {

--- a/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
+++ b/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
@@ -885,7 +885,7 @@ public class SuggestedFixesTest {
       final SuggestedFix.Builder fix = SuggestedFix.builder();
       new DocTreePathScanner<Void, Void>() {
         @Override
-        public Void visitLink(LinkTree node, Void aVoid) {
+        public Void visitLink(LinkTree node, Void unused) {
           SuggestedFixes.qualifyDocReference(
               fix, new DocTreePath(getCurrentPath(), node.getReference()), state);
           return null;

--- a/core/src/test/java/com/google/errorprone/matchers/MatchersTest.java
+++ b/core/src/test/java/com/google/errorprone/matchers/MatchersTest.java
@@ -43,7 +43,6 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -52,12 +51,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MatchersTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(InLoopChecker.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(InLoopChecker.class, getClass());
 
   @Test
   public void methodNameWithParenthesisThrows() {

--- a/docs/bugpattern/CollectionUndefinedEquality.md
+++ b/docs/bugpattern/CollectionUndefinedEquality.md
@@ -1,0 +1,28 @@
+Using `Collection`s (and other types which rely on equality) to contain elements
+with undefined equality is error-prone. For example, `Collection` itself does
+not have well-defined equality: the `List` and `Set` subinterfaces are not
+necessarily comparable.
+
+```java
+ImmutableList<Collection<Integer>> collectionsOfIntegers =
+    ImmutableList.of(ImmutableSet.of(1, 2), ImmutableSet.of(3, 4));
+
+collectionsOfIntegers.contains(ImmutableSet.of(1, 2)); // true
+collectionsOfIntegers.contains(ImmutableList.of(1, 2)); // false
+```
+
+```java
+boolean containsTest(Collection<CharSequence>> charSequences) {
+  // True if `charSequences` actually contains Strings, but otherwise not necessarily.
+  return charSequences.contains("test");
+}
+```
+
+In this case, an appropriate fix may be,
+
+```java
+boolean containsTest(Collection<CharSequence>> charSequences) {
+  // True if `charSequences` actually contains Strings, but otherwise not necessarily.
+  return charSequences.stream().anyMatch("test"::contentEquals);
+}
+```

--- a/test_helpers/src/test/java/com/google/errorprone/CompilationTestHelperTest.java
+++ b/test_helpers/src/test/java/com/google/errorprone/CompilationTestHelperTest.java
@@ -30,7 +30,6 @@ import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.tools.javac.main.Main.Result;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -39,12 +38,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CompilationTestHelperTest {
 
-  private CompilationTestHelper compilationHelper;
-
-  @Before
-  public void setUp() {
-    compilationHelper = CompilationTestHelper.newInstance(ReturnTreeChecker.class, getClass());
-  }
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(ReturnTreeChecker.class, getClass());
 
   @Test
   public void fileWithNoBugMarkersAndNoErrorsShouldPass() {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Move the matchers in CollectionIncompatibleType out for reuse, as well as the types in UndefinedEquals.

9be6055da156dfee252bea55649b6b070aa28ce2

-------

<p> Belatedly update @Placeholder docs in light of @MayOptionallyUse.

b105ecbd6fd0e57b7178d8ee27f51f7ec0553f80

-------

<p> Fix DefaultPackage violations in ErrorProne tests.

Needed to make DefaultPackage check an ERROR by default in bugpattern

RELNOTES: Fix DefaultPackage violations in ErrorProne tests

836b713c49302ea52379d0d98aa6485d14ab304c

-------

<p> Avoid aVoid

e3900086da3aeb6f9f23a229d3d1d716bda048bd

-------

<p> Fix for InvalidBlockTag warning

d1967af6c4dbad6c1a3943324b825baa395ebf69

-------

<p> Fix style guide violation : Variable declarations should declare only one variable
http://[]

RELNOTES: Fix style guide violation : Variable declarations should declare only one variable

525811030d2d207296a6c582a4c5c50b1a403dbd

-------

<p> Create CompilationTestHelper inline rather than in an unnecessary @Before block.

I guess this is getting cut and pasted, but we might as well cut and paste the simpler option. :)

c31484456890497e626f012ef482f1b6002acc8a

-------

<p> CollectionUndefinedEquality: flag Collection#contains (and similar) where the type parameter does not have well-defined equality.

Basically, there's an outer product of {incompatible types, types with ill-defined equality} x {equals, contains}, of which three already exist, and this is the last.

2e87253bc54d0cc9826ad8b3f5e8679cb0125743