### PR TITLE
MOE Sync 2020-04-27

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/overloading/ParameterTrie.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/overloading/ParameterTrie.java
@@ -26,8 +26,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.Optional;
-import java.util.SortedSet;
 import java.util.TreeSet;
 import javax.lang.model.element.Name;
 
@@ -84,7 +84,7 @@ class ParameterTrie {
 
     private final MethodTree methodTree;
 
-    private final SortedSet<Parameter> inputParameters;
+    private final NavigableSet<Parameter> inputParameters;
     private final List<Parameter> outputParameters;
 
     public ParameterTrieExtender(MethodTree methodTree) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix JdkObsolete warning by switching from SortedSet to NavigableSet

http://errorprone.info/bugpattern/JdkObsolete

RELNOTES: Fix JdkObsolete warning by switching from SortedSet to NavigableSet

de7896f23e0bcbfb13415b76ff825d1472bc534d