### PR TITLE
MOE Sync 2020-04-28

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/FindIdentifiers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/FindIdentifiers.java
@@ -61,7 +61,9 @@ import com.sun.tools.javac.comp.MemberEnter;
 import com.sun.tools.javac.comp.Resolve;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
+import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 import com.sun.tools.javac.util.Name;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
@@ -98,15 +100,29 @@ public final class FindIdentifiers {
       }
     }
     try {
-      Method method =
-          Resolve.class.getDeclaredMethod("findIdent", Env.class, Name.class, KindSelector.class);
-      method.setAccessible(true);
-      Symbol result =
-          (Symbol) method.invoke(Resolve.instance(state.context), env, state.getName(name), kind);
+      Symbol result = findIdent(name, state, kind, env);
       return result.exists() ? result : null;
     } catch (ReflectiveOperationException e) {
       throw new LinkageError(e.getMessage(), e);
     }
+  }
+
+  // Signature was changed in Java 13: https://bugs.openjdk.java.net/browse/JDK-8223305
+  private static Symbol findIdent(
+      String name, VisitorState state, KindSelector kind, Env<AttrContext> env)
+      throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    if (RuntimeVersion.isAtLeast13()) {
+      Method method =
+          Resolve.class.getDeclaredMethod(
+              "findIdent", DiagnosticPosition.class, Env.class, Name.class, KindSelector.class);
+      method.setAccessible(true);
+      return (Symbol)
+          method.invoke(Resolve.instance(state.context), null, env, state.getName(name), kind);
+    }
+    Method method =
+        Resolve.class.getDeclaredMethod("findIdent", Env.class, Name.class, KindSelector.class);
+    method.setAccessible(true);
+    return (Symbol) method.invoke(Resolve.instance(state.context), env, state.getName(name), kind);
   }
 
   @Nullable
@@ -246,7 +262,7 @@ public final class FindIdentifiers {
     }
 
     return result.build().stream()
-        .filter(var -> isVisible(var, state.getPath()))
+        .filter(variable -> isVisible(variable, state.getPath()))
         .collect(toImmutableSet());
   }
 

--- a/check_api/src/main/java/com/google/errorprone/util/RuntimeVersion.java
+++ b/check_api/src/main/java/com/google/errorprone/util/RuntimeVersion.java
@@ -64,4 +64,9 @@ public class RuntimeVersion {
   public static boolean isAtLeast12() {
     return MAJOR >= 12;
   }
+
+  /** Returns true if the current runtime is JDK 13 or newer. */
+  public static boolean isAtLeast13() {
+    return MAJOR >= 13;
+  }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
@@ -57,7 +57,7 @@ import javax.lang.model.element.Name;
     severity = WARNING)
 public class BadImport extends BugChecker implements ImportTreeMatcher {
 
-  private static final ImmutableSet<String> BAD_NESTED_CLASSES =
+  static final ImmutableSet<String> BAD_NESTED_CLASSES =
       ImmutableSet.of(
           "Builder",
           "Callback",

--- a/core/src/main/java/com/google/errorprone/bugpatterns/EqualsGetClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/EqualsGetClass.java
@@ -62,9 +62,7 @@ import javax.lang.model.element.Modifier;
  */
 @BugPattern(
     name = "EqualsGetClass",
-    summary =
-        "Overriding Object#equals in a non-final class by using getClass rather than instanceof "
-            + "breaks substitutability of subclasses.",
+    summary = "Prefer instanceof to getClass when implementing Object#equals.",
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE)
 public final class EqualsGetClass extends BugChecker implements MethodInvocationTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualified.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualified.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.util.ASTHelpers.getGeneratedBy;
+import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.google.errorprone.util.FindIdentifiers.findIdent;
+import static com.sun.tools.javac.code.Kinds.KindSelector.VAL_TYP;
+
+import com.google.common.base.Ascii;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.ImportTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.SimpleTreeVisitor;
+import com.sun.source.util.TreePath;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.code.Symbol.PackageSymbol;
+import com.sun.tools.javac.code.Symbol.TypeSymbol;
+import com.sun.tools.javac.util.Position;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.lang.model.element.Name;
+
+/** Flags uses of fully qualified names which are not ambiguous if imported. */
+@BugPattern(
+    name = "UnnecessarilyFullyQualified",
+    severity = SeverityLevel.WARNING,
+    summary = "This fully qualified name is unambiguous if imported.")
+public final class UnnecessarilyFullyQualified extends BugChecker
+    implements CompilationUnitTreeMatcher {
+
+  @Override
+  public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {
+    if (tree.getTypeDecls().stream()
+        .anyMatch(
+            t -> getSymbol(tree) != null && !getGeneratedBy(getSymbol(tree), state).isEmpty())) {
+      return NO_MATCH;
+    }
+    Table<Name, TypeSymbol, List<TreePath>> table = HashBasedTable.create();
+    Set<Name> identifiersSeen = new HashSet<>();
+    new SuppressibleTreePathScanner<Void, Void>() {
+      @Override
+      public Void visitImport(ImportTree importTree, Void aVoid) {
+        return null;
+      }
+
+      @Override
+      public Void visitMemberSelect(MemberSelectTree memberSelectTree, Void unused) {
+        if (!shouldIgnore()) {
+          handle(getCurrentPath());
+        }
+        return super.visitMemberSelect(memberSelectTree, null);
+      }
+
+      @Override
+      public Void visitIdentifier(IdentifierTree identifierTree, Void unused) {
+        identifiersSeen.add(identifierTree.getName());
+        return null;
+      }
+
+      private boolean shouldIgnore() {
+        // Don't report duplicate hits if we're not at the tail of a series of member selects on
+        // classes.
+        Tree parentTree = getCurrentPath().getParentPath().getLeaf();
+        return parentTree instanceof MemberSelectTree
+            && getSymbol(parentTree) instanceof ClassSymbol;
+      }
+
+      private void handle(TreePath path) {
+        MemberSelectTree tree = (MemberSelectTree) path.getLeaf();
+        if (!isFullyQualified(tree)) {
+          return;
+        }
+        if (BadImport.BAD_NESTED_CLASSES.contains(tree.getIdentifier().toString())) {
+          if (tree.getExpression() instanceof MemberSelectTree
+              && getSymbol(tree.getExpression()) instanceof ClassSymbol) {
+            handle(new TreePath(path, tree.getExpression()));
+          }
+          return;
+        }
+        Symbol symbol = getSymbol(tree);
+        if (symbol instanceof ClassSymbol) {
+          List<TreePath> treePaths = table.get(tree.getIdentifier(), symbol.type.tsym);
+          if (treePaths == null) {
+            treePaths = new ArrayList<>();
+            table.put(tree.getIdentifier(), symbol.type.tsym, treePaths);
+          }
+          if (state.getEndPosition(tree) != Position.NOPOS) {
+            treePaths.add(path);
+          }
+        }
+      }
+
+      private boolean isFullyQualified(MemberSelectTree tree) {
+        AtomicBoolean isFullyQualified = new AtomicBoolean();
+        new SimpleTreeVisitor<Void, Void>() {
+          @Override
+          public Void visitMemberSelect(MemberSelectTree memberSelectTree, Void unused) {
+            return visit(memberSelectTree.getExpression(), null);
+          }
+
+          @Override
+          public Void visitIdentifier(IdentifierTree identifierTree, Void aVoid) {
+            if (getSymbol(identifierTree) instanceof PackageSymbol) {
+              isFullyQualified.set(true);
+            }
+            return null;
+          }
+        }.visit(tree, null);
+        return isFullyQualified.get();
+      }
+    }.scan(state.getPath(), null);
+
+    for (Map.Entry<Name, Map<TypeSymbol, List<TreePath>>> rows : table.rowMap().entrySet()) {
+      Name name = rows.getKey();
+      Map<TypeSymbol, List<TreePath>> types = rows.getValue();
+      // Skip places where the same simple name refers to multiple types.
+      if (types.size() > 1) {
+        continue;
+      }
+      // Skip weird Android classes which don't look like classes.
+      if (Ascii.isLowerCase(name.charAt(0))) {
+        continue;
+      }
+      if (identifiersSeen.contains(name)) {
+        continue;
+      }
+      List<TreePath> pathsToFix = getOnlyElement(types.values());
+      if (pathsToFix.stream()
+          .anyMatch(path -> findIdent(name.toString(), state, VAL_TYP) != null)) {
+        continue;
+      }
+      SuggestedFix.Builder fix = SuggestedFix.builder();
+      fix.addImport(getOnlyElement(types.keySet()).getQualifiedName().toString());
+      for (TreePath path : pathsToFix) {
+        fix.replace(path.getLeaf(), name.toString());
+      }
+      state.reportMatch(describeMatch(pathsToFix.get(0).getLeaf(), fix.build()));
+    }
+    return NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -303,6 +303,7 @@ import com.google.errorprone.bugpatterns.TypeParameterUnusedInFormals;
 import com.google.errorprone.bugpatterns.URLEqualsHashCode;
 import com.google.errorprone.bugpatterns.UndefinedEquals;
 import com.google.errorprone.bugpatterns.UngroupedOverloads;
+import com.google.errorprone.bugpatterns.UnnecessarilyFullyQualified;
 import com.google.errorprone.bugpatterns.UnnecessaryAnonymousClass;
 import com.google.errorprone.bugpatterns.UnnecessaryBoxedAssignment;
 import com.google.errorprone.bugpatterns.UnnecessaryBoxedVariable;
@@ -840,8 +841,8 @@ public class BuiltInCheckerSuppliers {
 
   /** A list of all checks that are off by default. */
   public static final ImmutableSet<BugCheckerInfo> DISABLED_CHECKS =
-      // start
       getSuppliers(
+          // start
           AndroidJdkLibsChecker.class,
           AnnotationPosition.class,
           AssertFalse.class,
@@ -925,6 +926,7 @@ public class BuiltInCheckerSuppliers {
           TypeParameterNaming.class,
           UngroupedOverloads.class,
           UnlockMethodChecker.class,
+          UnnecessarilyFullyQualified.class,
           UnnecessaryBoxedAssignment.class,
           UnnecessaryBoxedVariable.class,
           UnnecessaryDefaultInEnumSwitch.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualifiedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualifiedTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link UnnecessarilyFullyQualified}. */
+@RunWith(JUnit4.class)
+public final class UnnecessarilyFullyQualifiedTest {
+  private final BugCheckerRefactoringTestHelper helper =
+      BugCheckerRefactoringTestHelper.newInstance(new UnnecessarilyFullyQualified(), getClass());
+
+  @Test
+  public void singleUse() {
+    helper
+        .addInputLines(
+            "Test.java", //
+            "interface Test {",
+            "  java.util.List foo();",
+            "  java.util.List bar();",
+            "}")
+        .addOutputLines(
+            "Test.java", //
+            "import java.util.List;",
+            "interface Test {",
+            "  List foo();",
+            "  List bar();",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void wouldBeAmbiguous() {
+    helper
+        .addInputLines("List.java", "class List {}")
+        .expectUnchanged()
+        .addInputLines(
+            "Test.java", //
+            "interface Test {",
+            "  java.util.List foo();",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
+
+  @Test
+  public void refersToMultipleTypes() {
+    helper
+        .addInputLines(
+            "List.java", //
+            "package a;",
+            "public class List {}")
+        .expectUnchanged()
+        .addInputLines(
+            "Test.java",
+            "package b;",
+            "interface Test {",
+            "  java.util.List foo();",
+            "  a.List bar();",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
+
+  @Test
+  public void builder() {
+    helper
+        .addInputLines(
+            "Foo.java", //
+            "package a;",
+            "public class Foo {",
+            "  public static final class Builder {}",
+            "}")
+        .expectUnchanged()
+        .addInputLines(
+            "Test.java",
+            "package b;",
+            "interface Test {",
+            "  a.Foo foo();",
+            "  a.Foo.Builder fooBuilder();",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "package b;",
+            "import a.Foo;",
+            "interface Test {",
+            "  Foo foo();",
+            "  Foo.Builder fooBuilder();",
+            "}")
+        .doTest();
+  }
+}

--- a/docs/bugpattern/EqualsGetClass.md
+++ b/docs/bugpattern/EqualsGetClass.md
@@ -5,6 +5,8 @@ Such code should be modified to use an `instanceof` test instead of `getClass`.
 
 ## Extending a value class to add attributes
 
+TL;DR: use composition rather than inheritance to add fields to value types.
+
 The most common objection objection to this rule arises from a scenario like the
 following:
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Only apply UnnecessaryLambda to FIs in core packages

e.g. java.util.function.Function, not arbitrary user-defined FI types,
which may have more documentation value.

2c0ad302ab6cc1be86a70e287c628bba149124cc

-------

<p> Add a check to suggest importing unnecessarily qualified names.

a29b13a860ff11f1adefeaedb00a2023c71d6846

-------

<p> EqualsGetClass: call out violating symmetry as a problem in the summary, rather than burying it in the details.

3d1228daa68d05b63b93188cb75c90b4a4087dd8

-------

<p> Fix findIdent incompatibility with Java 13

Fixes #1432
Fixes #1439

af9e57ce9e5161d4dd2fd2eded09848469e836a6