### PR TITLE
MOE Sync 2020-05-01

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/TruthGetOrDefault.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TruthGetOrDefault.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
+import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.Objects;
+
+/**
+ * Flags ambiguous usages of {@code Map#getOrDefault} within {@code Truth#assertThat}.
+ *
+ * @author bhagwani@google.com (Sumit Bhagwani)
+ */
+@BugPattern(
+    name = "TruthGetOrDefault",
+    summary = "Asserting on getOrDefault is unclear; prefer containsEntry or doesNotContainKey",
+    severity = WARNING)
+public final class TruthGetOrDefault extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private static final Matcher<ExpressionTree> ASSERT_THAT =
+      staticMethod().onClass("com.google.common.truth.Truth").named("assertThat");
+
+  private static final Matcher<ExpressionTree> GET_OR_DEFAULT_MATCHER =
+      instanceMethod().onDescendantOf("java.util.Map").named("getOrDefault");
+
+  private static final Matcher<ExpressionTree> SUBJECT_EQUALS_MATCHER =
+      instanceMethod()
+          .onDescendantOf("com.google.common.truth.Subject")
+          .named("isEqualTo")
+          .withParameters("java.lang.Object");
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (!SUBJECT_EQUALS_MATCHER.matches(tree, state)) {
+      return Description.NO_MATCH;
+    }
+    ExpressionTree rec = ASTHelpers.getReceiver(tree);
+    if (rec == null) {
+      return Description.NO_MATCH;
+    }
+    if (!ASSERT_THAT.matches(rec, state)) {
+      return Description.NO_MATCH;
+    }
+    ExpressionTree arg = getOnlyElement(((MethodInvocationTree) rec).getArguments());
+    if (!GET_OR_DEFAULT_MATCHER.matches(arg, state)) {
+      return Description.NO_MATCH;
+    }
+    MethodInvocationTree argMethodInvocationTree = (MethodInvocationTree) arg;
+    ExpressionTree defaultVal = argMethodInvocationTree.getArguments().get(1);
+    ExpressionTree expectedVal = getOnlyElement(tree.getArguments());
+    Match match = areValuesSame(defaultVal, expectedVal, state);
+    switch (match) {
+      case UNKNOWN:
+        return Description.NO_MATCH;
+      case DIFFERENT:
+        return describeMatch(
+            tree,
+            SuggestedFix.builder()
+                .replace(
+                    argMethodInvocationTree,
+                    state.getSourceForNode(ASTHelpers.getReceiver(argMethodInvocationTree)))
+                .replace(
+                    state.getEndPosition(rec),
+                    state.getEndPosition(tree.getMethodSelect()),
+                    ".containsEntry")
+                .replace(
+                    tree.getArguments().get(0),
+                    state.getSourceForNode(argMethodInvocationTree.getArguments().get(0))
+                        + ", "
+                        + state.getSourceForNode(tree.getArguments().get(0)))
+                .build());
+      case SAME:
+        return describeMatch(
+            tree,
+            SuggestedFix.builder()
+                .replace(arg, state.getSourceForNode(ASTHelpers.getReceiver(arg)))
+                .replace(
+                    state.getEndPosition(rec),
+                    state.getEndPosition(tree.getMethodSelect()),
+                    ".doesNotContainKey")
+                .replace(
+                    tree.getArguments().get(0),
+                    state.getSourceForNode(argMethodInvocationTree.getArguments().get(0)))
+                .build());
+    }
+    return Description.NO_MATCH;
+  }
+
+  private enum Match {
+    SAME,
+    DIFFERENT,
+    UNKNOWN;
+  }
+
+  /**
+   * Returns {@code Match.SAME} or {@code Match.DIFFERENT} when it can confidently say that both
+   * expressions are same or different, otherwise returns {@code Match.UNKNOWN}.
+   */
+  private static Match areValuesSame(
+      ExpressionTree defaultVal, ExpressionTree expectedVal, VisitorState state) {
+    if (ASTHelpers.sameVariable(defaultVal, expectedVal)) {
+      return Match.SAME;
+    }
+    Object expectedConstVal = ASTHelpers.constValue(expectedVal);
+    Object defaultConstVal = ASTHelpers.constValue(defaultVal);
+    if (expectedConstVal == null || defaultConstVal == null) {
+      return Match.UNKNOWN;
+    }
+    if (Objects.equals(defaultConstVal, expectedConstVal)) {
+      return Match.SAME;
+    }
+    if (!state
+        .getTypes()
+        .isSameType(ASTHelpers.getType(expectedVal), ASTHelpers.getType(defaultVal))) {
+      return Match.UNKNOWN;
+    }
+    return Match.DIFFERENT;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualified.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualified.java
@@ -159,7 +159,7 @@ public final class UnnecessarilyFullyQualified extends BugChecker
       }
       List<TreePath> pathsToFix = getOnlyElement(types.values());
       if (pathsToFix.stream()
-          .anyMatch(path -> findIdent(name.toString(), state, VAL_TYP) != null)) {
+          .anyMatch(path -> findIdent(name.toString(), state.withPath(path), VAL_TYP) != null)) {
         continue;
       }
       SuggestedFix.Builder fixBuilder = SuggestedFix.builder();

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -291,6 +291,7 @@ import com.google.errorprone.bugpatterns.TransientMisuse;
 import com.google.errorprone.bugpatterns.TreeToString;
 import com.google.errorprone.bugpatterns.TruthAssertExpected;
 import com.google.errorprone.bugpatterns.TruthConstantAsserts;
+import com.google.errorprone.bugpatterns.TruthGetOrDefault;
 import com.google.errorprone.bugpatterns.TruthSelfEquals;
 import com.google.errorprone.bugpatterns.TryFailRefactoring;
 import com.google.errorprone.bugpatterns.TryFailThrowable;
@@ -812,6 +813,7 @@ public class BuiltInCheckerSuppliers {
           TreeToString.class,
           TruthAssertExpected.class,
           TruthConstantAsserts.class,
+          TruthGetOrDefault.class,
           TruthIncompatibleType.class,
           TypeEqualsChecker.class,
           TypeNameShadowing.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TruthGetOrDefaultTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TruthGetOrDefaultTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link TruthGetOrDefault} bug pattern.
+ *
+ * @author bhagwani@google.com (Sumit Bhagwani)
+ */
+@RunWith(JUnit4.class)
+public class TruthGetOrDefaultTest {
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(TruthGetOrDefault.class, getClass());
+  private final BugCheckerRefactoringTestHelper testHelper =
+      BugCheckerRefactoringTestHelper.newInstance(new TruthGetOrDefault(), getClass());
+
+  @Test
+  public void testPositiveCases() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  void test() {",
+            "    Map<String, Integer> map = new HashMap<>();",
+            "    // BUG: Diagnostic contains: TruthGetOrDefault",
+            "    assertThat(map.getOrDefault(\"key\",  0)).isEqualTo(0);",
+            "    Integer expectedVal = 0;",
+            "    // BUG: Diagnostic contains: TruthGetOrDefault",
+            "    assertThat(map.getOrDefault(\"key\",  expectedVal)).isEqualTo(expectedVal);",
+            "    Map<String, Long> longMap = new HashMap<>();",
+            "    // BUG: Diagnostic contains: TruthGetOrDefault",
+            "    assertThat(longMap.getOrDefault(\"key\",  0L)).isEqualTo(5L);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testNegativeCases() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  void test() {",
+            "    Map<String, Integer> map = new HashMap<>();",
+            "    Integer expectedVal = 10;",
+            "    assertThat(map.getOrDefault(\"key\",  0)).isEqualTo(expectedVal);",
+            "    assertThat(map.getOrDefault(\"key\",  Integer.valueOf(0)))",
+            "      .isEqualTo(Integer.valueOf(1));",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testFixGeneration() {
+    testHelper
+        .addInputLines(
+            "in/Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  void test() {",
+            "    Map<String, Integer> map = new HashMap<>();",
+            "    assertThat(map.getOrDefault(\"key\",  0)).isEqualTo(1);",
+            "    Map<String, Long> longMap = new HashMap<>();",
+            "    assertThat(longMap.getOrDefault(\"key\",  0L)).isEqualTo(0L);",
+            "    assertThat(longMap.getOrDefault(\"key\",  0L)).isEqualTo(0);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "import static com.google.common.truth.Truth.assertThat;",
+            "import java.util.HashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  void test() {",
+            "    Map<String, Integer> map = new HashMap<>();",
+            "    assertThat(map).containsEntry(\"key\", 1);",
+            "    Map<String, Long> longMap = new HashMap<>();",
+            "    assertThat(longMap).doesNotContainKey(\"key\");",
+            "    assertThat(longMap.getOrDefault(\"key\",  0L)).isEqualTo(0);",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualifiedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualifiedTest.java
@@ -48,7 +48,9 @@ public final class UnnecessarilyFullyQualifiedTest {
   @Test
   public void wouldBeAmbiguous() {
     helper
-        .addInputLines("List.java", "class List {}")
+        .addInputLines(
+            "List.java", //
+            "class List {}")
         .expectUnchanged()
         .addInputLines(
             "Test.java", //
@@ -73,6 +75,29 @@ public final class UnnecessarilyFullyQualifiedTest {
             "interface Test {",
             "  java.util.List foo();",
             "  a.List bar();",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
+
+  @Test
+  public void clashesWithTypeInSuperType() {
+    helper
+        .addInputLines(
+            "A.java", //
+            "package a;",
+            "public interface A {",
+            "  public static class List {}",
+            "}")
+        .expectUnchanged()
+        .addInputLines(
+            "Test.java",
+            "package b;",
+            "import a.A;",
+            "class Test implements A {",
+            "  java.util.List foo() {",
+            "    return null;",
+            "  }",
             "}")
         .expectUnchanged()
         .doTest();

--- a/docs/bugpattern/TruthGetOrDefault.md
+++ b/docs/bugpattern/TruthGetOrDefault.md
@@ -1,0 +1,28 @@
+Expectation of `Truth.assertThat(map.getOrDefault(key,
+defaultValue)).isEqualTo(expectedValue)` is unclear if the `defaultValue` is
+same as `expectedValue`. If the test passes, its hard to say if `map` contained
+`key, expectedValue` as an entry. Most likely, developer intended to verify that
+`map` doesn't contain `'key` or perhaps map `key` isn't mapped to
+`defaultValue`.
+
+Additionally, same assertion can be simplified if `defaultValue` and
+`expectedValue` are different constants to
+`Truth.assertThat(map.get(key)).isEqualTo(expectedValue)`.
+
+That is, prefer this:
+
+```java
+public static void doSomething(Map<String, String> map, String key, String expectedValue) {
+  assertThat(map.get(key)).isEqualTo(expectedValue);
+  assertThat(map).doesNotContainKey(key);
+  assertThat(map).containsEntry(key, expectedValue);
+}
+```
+
+to this:
+
+```java
+public static void doSomething(Map<String, String> map, String key, String defaultValue, String expectedValue) {
+  assertThat(map.getOrDefault(key, defaultValue)).isEqualTo(expectedValue);
+}
+```


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Flag ambiguous usages of Map#getOrDefault in assertThat assertion

RELNOTES: Flag ambiguous usages of Map#getOrDefault in assertThat assertion

ad361606e9549319e90aba7c280cba6818baed11

-------

<p> UnnecessarilyFullyQualified: fix check for clashes.

I never remember that findIdent takes its position from the VisitorState.

00edb3c969c584652a66c6951ff836cffc693178