### PR TITLE
Bump caffeine version to 2.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <dataflow.version>3.1.2</dataflow.version>
     <mockito.version>2.25.0</mockito.version>
     <compile.testing.version>0.18</compile.testing.version>
-    <caffeine.version>2.7.0</caffeine.version>
+    <caffeine.version>2.8.0</caffeine.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
It's currently the version checked in Google, so let's use it here too.