### PR TITLE
MOE Sync 2020-05-05

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -1067,11 +1067,15 @@ public class ASTHelpers {
     return types.isSubtype(types.erasure(s), types.erasure(t));
   }
 
-  /** Returns true if {@code t} is a subtype of Exception but not a subtype of RuntimeException. */
+  /**
+   * Returns true if {@code t} is a subtype of Throwable but not a subtype of RuntimeException or
+   * Error.
+   */
   public static boolean isCheckedExceptionType(Type t, VisitorState state) {
     Symtab symtab = state.getSymtab();
-    return isSubtype(t, symtab.exceptionType, state)
-        && !isSubtype(t, symtab.runtimeExceptionType, state);
+    return isSubtype(t, symtab.throwableType, state)
+        && !isSubtype(t, symtab.runtimeExceptionType, state)
+        && !isSubtype(t, symtab.errorType, state);
   }
 
   /** Returns true if {@code erasure(s)} is castable to {@code erasure(t)}. */


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> ASTHelpers.isCheckedExceptionType: match with definition in JLS 11.11.1:

"... the checked exception classes are Throwable and all its subclasses other than RuntimeException and its subclasses and Error and its subclasses."

2a06364d09b43a6dd0a1a5186f0e898d85c5f77f