### PR TITLE
Drop `@Nullable` from `RefasterRule#afterTemplates()`

### DIFF
--- a/core/src/main/java/com/google/errorprone/refaster/RefasterRule.java
+++ b/core/src/main/java/com/google/errorprone/refaster/RefasterRule.java
@@ -38,7 +38,6 @@ import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
-import javax.annotation.Nullable;
 import javax.tools.JavaFileManager;
 
 /**
@@ -111,7 +110,6 @@ public abstract class RefasterRule<M extends TemplateMatch, T extends Template<M
 
   abstract ImmutableList<T> beforeTemplates();
 
-  @Nullable
   abstract ImmutableList<T> afterTemplates();
 
   @Override


### PR DESCRIPTION
This property is never null and the caller unconditionally dereferences it.