### PR TITLE
MOE Sync 2020-05-08

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -1910,9 +1910,9 @@ public class ASTHelpers {
 
     @Override
     public Void visitMethodInvocation(MethodInvocationTree invocation, Void unused) {
-      MethodSymbol symbol = getSymbol(invocation);
-      if (symbol != null) {
-        getThrownTypes().addAll(symbol.getThrownTypes());
+      Type type = getType(invocation.getMethodSelect());
+      if (type != null) {
+        getThrownTypes().addAll(type.getThrownTypes());
       }
       return super.visitMethodInvocation(invocation, null);
     }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -351,6 +351,11 @@
       <version>1.0.5</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.threeten</groupId>
+      <artifactId>threeten-extra</artifactId>
+      <version>1.5.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/FromTemporalAccessor.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/FromTemporalAccessor.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.matchers.Matchers.anyOf;
+import static com.google.errorprone.matchers.Matchers.isSameType;
+import static com.google.errorprone.matchers.Matchers.packageStartsWith;
+import static com.google.errorprone.matchers.Matchers.staticMethod;
+import static com.google.errorprone.util.ASTHelpers.getReceiverType;
+import static com.google.errorprone.util.ASTHelpers.getType;
+import static com.google.errorprone.util.ASTHelpers.isSameType;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Type;
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.threeten.extra.AmPm;
+import org.threeten.extra.DayOfMonth;
+import org.threeten.extra.DayOfYear;
+import org.threeten.extra.Quarter;
+import org.threeten.extra.YearQuarter;
+import org.threeten.extra.YearWeek;
+
+/**
+ * Bans calls to {@code javaTimeType.from(temporalAmount)} where the call is guaranteed to either:
+ *
+ * <ul>
+ *   <li>throw a {@code DateTimeException} at runtime (e.g., {@code LocalDate.from(month)})
+ *   <li>return the same parameter (e.g., {@code Instant.from(instant)})
+ * </ul>
+ *
+ * @author kak@google.com (Kurt Alfred Kluever)
+ */
+@BugPattern(
+    name = "FromTemporalAccessor",
+    summary =
+        "Certain combinations of javaTimeType.from(TemporalAccessor) will always throw a"
+            + " DateTimeException or return the parameter directly.",
+    explanation =
+        "Not all java.time types can be created via from(TemporalAccessor). For example, you can"
+            + " create a Month from a LocalDate (Month.from(localDate)) because a LocalDate"
+            + " consists of a year, month, and day. However, you cannot create a LocalDate from a"
+            + " Month (since it doesn't have the year or day information). Instead of throwing a"
+            + " DateTimeException at runtime, this checker validates the type transformations at"
+            + " compile time using static type information.",
+    severity = ERROR)
+public final class FromTemporalAccessor extends BugChecker implements MethodInvocationTreeMatcher {
+
+  private static final String TEMPORAL_ACCESSOR = "java.time.temporal.TemporalAccessor";
+
+  private static final Matcher<ExpressionTree> FROM_MATCHER =
+      staticMethod().anyClass().named("from").withParameters(TEMPORAL_ACCESSOR);
+
+  private static final Matcher<ExpressionTree> PACKAGE_MATCHER =
+      anyOf(
+          packageStartsWith("java.time"),
+          packageStartsWith("org.threeten.extra"),
+          packageStartsWith("tck.java.time"));
+
+  private static final ImmutableListMultimap<Matcher<Tree>, Matcher<ExpressionTree>>
+      BAD_VALUE_FROM_KEY =
+          new ImmutableListMultimap.Builder<Matcher<Tree>, Matcher<ExpressionTree>>()
+              .putAll(
+                  makeKey(DayOfWeek.class),
+                  makeValues(
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(Instant.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(LocalDate.class),
+                  makeValues(
+                      Instant.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class))
+              .putAll(
+                  makeKey(LocalDateTime.class),
+                  makeValues(
+                      Instant.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class))
+              .putAll(
+                  makeKey(LocalTime.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(Month.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(MonthDay.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfYear.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(makeKey(OffsetDateTime.class), makeValues())
+              .putAll(
+                  makeKey(OffsetTime.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(Year.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(YearMonth.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      YearWeek.class))
+              .putAll(makeKey(ZonedDateTime.class), makeValues())
+              .putAll(
+                  makeKey(ZoneOffset.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(AmPm.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(DayOfMonth.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(DayOfYear.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      Quarter.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(Quarter.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      YearQuarter.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(YearQuarter.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      YearWeek.class))
+              .putAll(
+                  makeKey(YearWeek.class),
+                  makeValues(
+                      DayOfWeek.class,
+                      Instant.class,
+                      LocalDate.class,
+                      LocalDateTime.class,
+                      LocalTime.class,
+                      Month.class,
+                      MonthDay.class,
+                      OffsetDateTime.class,
+                      OffsetTime.class,
+                      Year.class,
+                      YearMonth.class,
+                      ZonedDateTime.class,
+                      ZoneOffset.class,
+                      AmPm.class,
+                      DayOfMonth.class,
+                      DayOfYear.class,
+                      Quarter.class,
+                      YearQuarter.class))
+              .build();
+
+  private static Matcher<Tree> makeKey(Class<?> keyClass) {
+    return isSameType(keyClass.getName());
+  }
+
+  private static List<Matcher<ExpressionTree>> makeValues(Class<?>... values) {
+    List<Matcher<ExpressionTree>> entries = new ArrayList<>();
+    for (Class<?> value : values) {
+      entries.add(
+          staticMethod().onClass(value.getName()).named("from").withParameters(TEMPORAL_ACCESSOR));
+    }
+    return entries;
+  }
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    // exit early if we're not in a `from(TemporalAccessor)` method
+    // this should be a large performance win since nearly all MITs will short-circuit here
+    if (!FROM_MATCHER.matches(tree, state)) {
+      return Description.NO_MATCH;
+    }
+
+    // exit early if we're inside java.time or ThreeTen-Extra
+    if (PACKAGE_MATCHER.matches(tree, state)) {
+      return Description.NO_MATCH;
+    }
+
+    // exit early if the receiver isn't a java.time or ThreeTen-Extra type
+    String receiverType = getReceiverType(tree).toString();
+    if (!receiverType.startsWith("java.time") && !receiverType.startsWith("org.threeten.extra")) {
+      return Description.NO_MATCH;
+    }
+
+    ExpressionTree arg0 = getOnlyElement(tree.getArguments());
+    Type type0 = getType(arg0);
+    // exit early if the parameter is statically typed as a TemporalAccessor
+    if (isSameType(type0, state.getTypeFromString(TEMPORAL_ACCESSOR), state)) {
+      return Description.NO_MATCH;
+    }
+
+    // prevent `Instant.from(instant)` and similar
+    if (isSameType(getType(tree), type0, state)) {
+      SuggestedFix.Builder builder = SuggestedFix.builder();
+      builder.replace(tree, state.getSourceForNode(arg0));
+      return describeMatch(tree, builder.build());
+    }
+
+    for (Map.Entry<Matcher<Tree>, Matcher<ExpressionTree>> entry : BAD_VALUE_FROM_KEY.entries()) {
+      Matcher<ExpressionTree> fromMatcher = entry.getValue(); // matches Type.from(TemporalAccessor)
+      Matcher<Tree> argumentMatcher = entry.getKey(); // ensures the arg0 is a "bad type"
+      if (fromMatcher.matches(tree, state) && argumentMatcher.matches(arg0, state)) {
+        return describeMatch(tree);
+      }
+    }
+    return Description.NO_MATCH;
+  }
+}

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -422,6 +422,7 @@ import com.google.errorprone.bugpatterns.time.DurationFrom;
 import com.google.errorprone.bugpatterns.time.DurationGetTemporalUnit;
 import com.google.errorprone.bugpatterns.time.DurationTemporalUnit;
 import com.google.errorprone.bugpatterns.time.DurationToLongTimeUnit;
+import com.google.errorprone.bugpatterns.time.FromTemporalAccessor;
 import com.google.errorprone.bugpatterns.time.InstantTemporalUnit;
 import com.google.errorprone.bugpatterns.time.InvalidJavaTimeConstant;
 import com.google.errorprone.bugpatterns.time.JavaDurationGetSecondsGetNano;
@@ -539,6 +540,7 @@ public class BuiltInCheckerSuppliers {
           ForOverrideChecker.class,
           FormatString.class,
           FormatStringAnnotationChecker.class,
+          FromTemporalAccessor.class,
           FunctionalInterfaceMethodChanged.class,
           FuturesGetCheckedIllegalExceptionType.class,
           GetClassOnAnnotation.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/FromTemporalAccessorTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/FromTemporalAccessorTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.errorprone.bugpatterns.time;
+
+import static com.google.common.base.StandardSystemProperty.JAVA_VERSION;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link FromTemporalAccessor}. */
+@RunWith(JUnit4.class)
+public class FromTemporalAccessorTest {
+  private final CompilationTestHelper helper =
+      CompilationTestHelper.newInstance(FromTemporalAccessor.class, getClass());
+
+  @Test
+  public void typeFromTypeIsBad() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            // TODO(kak): Should we just use a wildcard import instead?
+            "import java.time.DayOfWeek;",
+            "import java.time.Instant;",
+            "import java.time.LocalDate;",
+            "import java.time.LocalDateTime;",
+            "import java.time.LocalTime;",
+            "import java.time.Month;",
+            "import java.time.MonthDay;",
+            "import java.time.OffsetDateTime;",
+            "import java.time.OffsetTime;",
+            "import java.time.Year;",
+            "import java.time.YearMonth;",
+            "import java.time.ZonedDateTime;",
+            "import java.time.ZoneOffset;",
+            "public class TestClass {",
+            "  void from(DayOfWeek value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    DayOfWeek.from(value);",
+            "  }",
+            "  void from(Instant value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    Instant.from(value);",
+            "  }",
+            "  void from(LocalDate value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    LocalDate.from(value);",
+            "  }",
+            "  void from(LocalDateTime value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    LocalDateTime.from(value);",
+            "  }",
+            "  void from(LocalTime value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    LocalTime.from(value);",
+            "  }",
+            "  void from(Month value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    Month.from(value);",
+            "  }",
+            "  void from(MonthDay value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    MonthDay.from(value);",
+            "  }",
+            "  void from(OffsetDateTime value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    OffsetDateTime.from(value);",
+            "  }",
+            "  void from(OffsetTime value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    OffsetTime.from(value);",
+            "  }",
+            "  void from(Year value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    Year.from(value);",
+            "  }",
+            "  void from(YearMonth value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    YearMonth.from(value);",
+            "  }",
+            "  void from(ZonedDateTime value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    ZonedDateTime.from(value);",
+            "  }",
+            "  void from(ZoneOffset value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    ZoneOffset.from(value);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeFromTemporalAccessor_knownGood() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.DayOfWeek;",
+            "import java.time.Instant;",
+            "import java.time.LocalDate;",
+            "import java.time.LocalDateTime;",
+            "import java.time.LocalTime;",
+            "import java.time.Month;",
+            "import java.time.MonthDay;",
+            "import java.time.OffsetDateTime;",
+            "import java.time.OffsetTime;",
+            "import java.time.Year;",
+            "import java.time.YearMonth;",
+            "import java.time.ZonedDateTime;",
+            "import java.time.ZoneOffset;",
+            "import java.time.temporal.TemporalAccessor;",
+            "public class TestClass {",
+            "  void from(TemporalAccessor value) {",
+            "    DayOfWeek.from(value);",
+            "    Instant.from(value);",
+            "    LocalDate.from(value);",
+            "    LocalDateTime.from(value);",
+            "    LocalTime.from(value);",
+            "    Month.from(value);",
+            "    MonthDay.from(value);",
+            "    OffsetDateTime.from(value);",
+            "    OffsetTime.from(value);",
+            "    Year.from(value);",
+            "    YearMonth.from(value);",
+            "    ZonedDateTime.from(value);",
+            "    ZoneOffset.from(value);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeFromType_knownGood() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.LocalDate;",
+            "import java.time.Year;",
+            "public class TestClass {",
+            "  void from(LocalDate value) {",
+            "    Year.from(value);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeFromType_threeTenExtra_knownGood() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.LocalTime;",
+            "import org.threeten.extra.AmPm;",
+            "public class TestClass {",
+            "  void from(LocalTime value) {",
+            "    AmPm.from(value);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeFromType_threeTenExtra_self() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import org.threeten.extra.AmPm;",
+            "public class TestClass {",
+            "  void from(AmPm value) {",
+            "    // BUG: Diagnostic contains: Did you mean 'value;'",
+            "    AmPm.from(value);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeFromType_customType() {
+    helper
+        .addSourceLines(
+            "Frobber.java",
+            "import java.time.DateTimeException;",
+            "import java.time.temporal.TemporalAccessor;",
+            "import java.time.temporal.TemporalField;",
+            "public class Frobber implements TemporalAccessor {",
+            "  static Frobber from(TemporalAccessor temporalAccessor) {",
+            "    if (temporalAccessor instanceof Frobber) {",
+            "      return (Frobber) temporalAccessor;",
+            "    }",
+            "    throw new DateTimeException(\"failure\");",
+            "  }",
+            "  @Override public long getLong(TemporalField field) { return 0; }",
+            "  @Override public boolean isSupported(TemporalField field) { return false; }",
+            "}")
+        .addSourceLines(
+            "TestClass.java",
+            "public class TestClass {",
+            "  void from(Frobber value) {",
+            "    Frobber frobber = Frobber.from(value);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeFromType_knownBadConversions() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.LocalDate;",
+            "import java.time.LocalDateTime;",
+            "import org.threeten.extra.Quarter;",
+            "public class TestClass {",
+            "  void from(LocalDate localDate, Quarter quarter) {",
+            "    // BUG: Diagnostic contains: FromTemporalAccessor",
+            "    LocalDateTime.from(localDate);",
+            "    // BUG: Diagnostic contains: FromTemporalAccessor",
+            "    LocalDateTime.from(quarter);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void typeFromType_knownBadConversions_insideJavaTime() {
+    // this test doesn't pass under JDK11 because of modules
+    if (JAVA_VERSION.value().startsWith("1.")) {
+      helper
+          .addSourceLines(
+              "TestClass.java",
+              "package java.time;",
+              "import java.time.LocalDate;",
+              "import java.time.LocalDateTime;",
+              "public class TestClass {",
+              "  void from(LocalDate localDate) {",
+              "    LocalDateTime.from(localDate);",
+              "  }",
+              "}")
+          .doTest();
+    }
+  }
+
+  @Test
+  public void typeFromType_knownBadConversions_insideThreeTenExtra() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "package org.threeten.extra;",
+            "import java.time.LocalDateTime;",
+            "public class TestClass {",
+            "  void from(Quarter quarter) {",
+            "    LocalDateTime.from(quarter);",
+            "  }",
+            "}")
+        .doTest();
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix bug in ASTHelpers#getThrownExceptions.

Generic exceptions weren't being resolved correctly.

2af3583572b4840c1b42db8c3162d1e4f7adcf86

-------

<p> Add FromTemporalAccessor that bans calls to javaTimeType.from(TemporalAccessor) that are guaranteed to throw a runtime exception (based on the static type information).

46e699a05d71e58e63a1fe5a1c0d9c04783ff49c