### PR TITLE
Prevent "<no match>" reports by `StronglyTypeTime`

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/StronglyTypeTime.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/StronglyTypeTime.java
@@ -133,7 +133,10 @@ public final class StronglyTypeTime extends BugChecker implements CompilationUni
     }.scan(tree, null);
 
     for (Map.Entry<VarSymbol, TreePath> entry : fields.entrySet()) {
-      state.reportMatch(describeMatch(entry.getValue(), usages.get(entry.getKey()), state));
+      Description description = describeMatch(entry.getValue(), usages.get(entry.getKey()), state);
+      if (description != NO_MATCH) {
+        state.reportMatch(description);
+      }
     }
     return NO_MATCH;
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/StronglyTypeTimeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/StronglyTypeTimeTest.java
@@ -246,6 +246,19 @@ public final class StronglyTypeTimeTest {
   }
 
   @Test
+  public void unusedField_noMatch() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.io.Serializable;",
+            "class Test implements Serializable {",
+            "  private static final long serialVersionUID = 1L;",
+            "}")
+        .expectNoDiagnostics()
+        .doTest();
+  }
+
+  @Test
   public void whenJodaAndJavaInstantUsed_fullyQualifiesName() {
     refactoringHelper
         .addInputLines(


### PR DESCRIPTION
This fix prevents reports such as the following, which are hard to debug for users:
```
[INFO] /path/to/some/File.java: [<no match>] <no match>
    (see <no match>)
```