### PR TITLE
MOE Sync 2020-05-14

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/ImportOrderParser.java
+++ b/check_api/src/main/java/com/google/errorprone/ImportOrderParser.java
@@ -36,6 +36,8 @@ public class ImportOrderParser {
         return ImportOrganizer.ANDROID_STATIC_FIRST_ORGANIZER;
       case "android-static-last":
         return ImportOrganizer.ANDROID_STATIC_LAST_ORGANIZER;
+      case "idea":
+        return ImportOrganizer.IDEA_ORGANIZER;
       default:
         throw new IllegalStateException("Unknown import order: '" + importOrder + "'");
     }

--- a/check_api/src/main/java/com/google/errorprone/VisitorState.java
+++ b/check_api/src/main/java/com/google/errorprone/VisitorState.java
@@ -264,7 +264,7 @@ public class VisitorState {
   }
 
   public void reportMatch(Description description) {
-    if (description == null || description == Description.NO_MATCH) {
+    if (description == Description.NO_MATCH) {
       return;
     }
     // TODO(cushon): creating Descriptions with the default severity and updating them here isn't

--- a/check_api/src/main/java/com/google/errorprone/VisitorState.java
+++ b/check_api/src/main/java/com/google/errorprone/VisitorState.java
@@ -264,7 +264,7 @@ public class VisitorState {
   }
 
   public void reportMatch(Description description) {
-    if (description == Description.NO_MATCH) {
+    if (description == null || description == Description.NO_MATCH) {
       return;
     }
     // TODO(cushon): creating Descriptions with the default severity and updating them here isn't

--- a/check_api/src/main/java/com/google/errorprone/VisitorState.java
+++ b/check_api/src/main/java/com/google/errorprone/VisitorState.java
@@ -264,6 +264,9 @@ public class VisitorState {
   }
 
   public void reportMatch(Description description) {
+    if (description == null || description == Description.NO_MATCH) {
+      return;
+    }
     // TODO(cushon): creating Descriptions with the default severity and updating them here isn't
     // ideal (we could forget to do the update), so consider removing severity from Description.
     // Instead, there could be another method on the listener that took a description and a

--- a/check_api/src/main/java/com/google/errorprone/apply/IdeaImportOrganizer.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/IdeaImportOrganizer.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.apply;
+
+import static com.google.common.collect.ImmutableSortedSet.toImmutableSortedSet;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Organizes imports based on the default format provided by IntelliJ IDEA.
+ *
+ * <p>This groups the imports into three groups, each delimited by a newline:
+ *
+ * <ol>
+ *   <li>Non-static, non-{@code java.*}, non-{@code javax.*} imports.
+ *   <li>{@code javax.*} and {@code java.*} imports, with {@code javax.*} imports ordered first.
+ *   <li>Static imports.
+ * </ol>
+ */
+public class IdeaImportOrganizer implements ImportOrganizer {
+
+  private static final String JAVA_PREFIX = "java.";
+
+  private static final String JAVAX_PREFIX = "javax.";
+
+  @Override
+  public OrganizedImports organizeImports(List<Import> imports) {
+    Map<PackageType, ImmutableSortedSet<Import>> partitioned =
+        imports.stream()
+            .collect(
+                Collectors.groupingBy(
+                    IdeaImportOrganizer::getPackageType,
+                    TreeMap::new,
+                    toImmutableSortedSet(IdeaImportOrganizer::compareImport)));
+
+    return new OrganizedImports()
+        .addGroups(
+            partitioned,
+            ImmutableList.of(PackageType.NON_STATIC, PackageType.JAVAX_JAVA, PackageType.STATIC));
+  }
+
+  private static int compareImport(Import a, Import b) {
+    if (a.isStatic() || b.isStatic()) {
+      return a.getType().compareTo(b.getType());
+    } else if (a.getType().startsWith(JAVA_PREFIX) && b.getType().startsWith(JAVAX_PREFIX)) {
+      return 1;
+    } else if (a.getType().startsWith(JAVAX_PREFIX) && b.getType().startsWith(JAVA_PREFIX)) {
+      return -1;
+    } else {
+      return a.getType().compareTo(b.getType());
+    }
+  }
+
+  private static PackageType getPackageType(Import anImport) {
+    if (anImport.isStatic()) {
+      return PackageType.STATIC;
+    } else if (anImport.getType().startsWith(JAVA_PREFIX)) {
+      return PackageType.JAVAX_JAVA;
+    } else if (anImport.getType().startsWith(JAVAX_PREFIX)) {
+      return PackageType.JAVAX_JAVA;
+    } else {
+      return PackageType.NON_STATIC;
+    }
+  }
+
+  private enum PackageType {
+    JAVAX_JAVA,
+    NON_STATIC,
+    STATIC
+  }
+}

--- a/check_api/src/main/java/com/google/errorprone/apply/ImportOrganizer.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/ImportOrganizer.java
@@ -89,6 +89,20 @@ public interface ImportOrganizer {
   ImportOrganizer ANDROID_STATIC_LAST_ORGANIZER =
       new AndroidImportOrganizer(StaticOrder.STATIC_LAST);
 
+  /**
+   * An {@link ImportOrganizer} that organizes imports based on the default format provided by
+   * IntelliJ IDEA.
+   *
+   * <p>This groups the imports into three groups, each delimited by a newline:
+   *
+   * <ol>
+   *   <li>Non-static, non-{@code java.*}, non-{@code javax.*} imports.
+   *   <li>{@code javax.*} and {@code java.*} imports, with {@code javax.*} imports ordered first.
+   *   <li>Static imports.
+   * </ol>
+   */
+  ImportOrganizer IDEA_ORGANIZER = new IdeaImportOrganizer();
+
   /** Represents an import. */
   @AutoValue
   abstract class Import {

--- a/check_api/src/main/java/com/google/errorprone/apply/PatchFileDestination.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/PatchFileDestination.java
@@ -59,17 +59,13 @@ public final class PatchFileDestination implements FileDestination {
       List<String> originalLines = LINE_SPLITTER.splitToList(oldSource);
 
       Patch<String> diff = DiffUtils.diff(originalLines, LINE_SPLITTER.splitToList(newSource));
-      String relativePath = relativize(sourceFilePath);
+      String relativePath = baseDir.relativize(sourceFilePath).toString();
       List<String> unifiedDiff =
           DiffUtils.generateUnifiedDiff(relativePath, relativePath, originalLines, diff, 2);
 
       String diffString = Joiner.on("\n").join(unifiedDiff) + "\n";
       diffByFile.put(sourceFilePath.toUri(), diffString);
     }
-  }
-
-  private String relativize(Path sourceFilePath) {
-    return baseDir.relativize(sourceFilePath).toString();
   }
 
   public String patchFile(URI uri) {

--- a/check_api/src/main/java/com/google/errorprone/scanner/Scanner.java
+++ b/check_api/src/main/java/com/google/errorprone/scanner/Scanner.java
@@ -121,9 +121,6 @@ public class Scanner extends TreePathScanner<Void, VisitorState> {
   }
 
   protected void reportMatch(Description description, VisitorState state) {
-    if (description == null || description == Description.NO_MATCH) {
-      return;
-    }
     state.reportMatch(description);
   }
 

--- a/check_api/src/test/java/com/google/errorprone/apply/IdeaImportOrganizerTest.java
+++ b/check_api/src/test/java/com/google/errorprone/apply/IdeaImportOrganizerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.apply;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.stream.Stream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** {@link IdeaImportOrganizer}Test */
+@RunWith(JUnit4.class)
+public class IdeaImportOrganizerTest {
+
+  private static final ImmutableList<ImportOrganizer.Import> IMPORTS =
+      Stream.of(
+              "import com.android.blah",
+              "import android.foo",
+              "import java.ping",
+              "import javax.pong",
+              "import unknown.fred",
+              "import unknown.barney",
+              "import net.wilma",
+              "import static com.android.blah.blah",
+              "import static android.foo.bar",
+              "import static java.ping.pong",
+              "import static javax.pong.ping",
+              "import static unknown.fred.flintstone",
+              "import static net.wilma.flintstone")
+          .map(ImportOrganizer.Import::importOf)
+          .collect(toImmutableList());
+
+  @Test
+  public void testStaticLastOrdering() {
+    IdeaImportOrganizer organizer = new IdeaImportOrganizer();
+    ImportOrganizer.OrganizedImports organized = organizer.organizeImports(IMPORTS);
+    assertThat(organized.asImportBlock())
+        .isEqualTo(
+            "import android.foo;\n"
+                + "import com.android.blah;\n"
+                + "import net.wilma;\n"
+                + "import unknown.barney;\n"
+                + "import unknown.fred;\n"
+                + "\n"
+                + "import javax.pong;\n"
+                + "import java.ping;\n"
+                + "\n"
+                + "import static android.foo.bar;\n"
+                + "import static com.android.blah.blah;\n"
+                + "import static java.ping.pong;\n"
+                + "import static javax.pong.ping;\n"
+                + "import static net.wilma.flintstone;\n"
+                + "import static unknown.fred.flintstone;\n");
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/BigDecimalLiteralDouble.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BigDecimalLiteralDouble.java
@@ -86,7 +86,7 @@ public class BigDecimalLiteralDouble extends BugChecker implements NewClassTreeM
     if (literalNumber == null) {
       return Description.NO_MATCH;
     }
-    Double literal = literalNumber.doubleValue();
+    double literal = literalNumber.doubleValue();
 
     // Strip off 'd', 'f' suffixes and _ separators from the source.
     String literalString = state.getSourceForNode(arg).replaceAll("[_dDfF]", "");

--- a/core/src/main/java/com/google/errorprone/bugpatterns/FallThrough.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FallThrough.java
@@ -31,6 +31,7 @@ import com.google.errorprone.util.Reachability;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.SwitchTree;
 import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.util.Position;
 import java.util.regex.Pattern;
 
 /** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
@@ -61,12 +62,12 @@ public class FallThrough extends BugChecker implements SwitchTreeMatcher {
       // reported an error if that statement wasn't reachable, and the answer is
       // independent of any preceding statements.
       boolean completes = Reachability.canCompleteNormally(getLast(caseTree.stats));
+      int endPos = caseEndPosition(state, caseTree);
+      if (endPos == Position.NOPOS) {
+        break;
+      }
       String comments =
-          state
-              .getSourceCode()
-              .subSequence(caseEndPosition(state, caseTree), next.getStartPosition())
-              .toString()
-              .trim();
+          state.getSourceCode().subSequence(endPos, next.getStartPosition()).toString().trim();
       if (completes && !FALL_THROUGH_PATTERN.matcher(comments).find()) {
         state.reportMatch(
             buildDescription(next)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectOnConstructorOfAbstractClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/inject/InjectOnConstructorOfAbstractClass.java
@@ -45,7 +45,7 @@ import com.sun.source.tree.MethodTree;
 @BugPattern(
     name = "InjectOnConstructorOfAbstractClass",
     summary =
-        "Constructors on abstract classes are never directly @Injected, only the constructors"
+        "Constructors on abstract classes are never directly @Inject'ed, only the constructors"
             + " of their subclasses can be @Inject'ed.",
     severity = WARNING)
 public class InjectOnConstructorOfAbstractClass extends BugChecker implements MethodTreeMatcher {

--- a/core/src/main/java/com/google/errorprone/refaster/RefasterRule.java
+++ b/core/src/main/java/com/google/errorprone/refaster/RefasterRule.java
@@ -38,7 +38,6 @@ import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
-import javax.annotation.Nullable;
 import javax.tools.JavaFileManager;
 
 /**
@@ -111,7 +110,6 @@ public abstract class RefasterRule<M extends TemplateMatch, T extends Template<M
 
   abstract ImmutableList<T> beforeTemplates();
 
-  @Nullable
   abstract ImmutableList<T> afterTemplates();
 
   @Override

--- a/core/src/test/java/com/google/errorprone/CommandLineFlagTest.java
+++ b/core/src/test/java/com/google/errorprone/CommandLineFlagTest.java
@@ -74,7 +74,7 @@ public class CommandLineFlagTest {
   @BugPattern(
       name = "WarningChecker",
       summary = "Checker that flags all return statements as warnings",
-      explanation = "Checker that flags all return statements as warningss",
+      explanation = "Checker that flags all return statements as warnings",
       severity = WARNING)
   public static class WarningChecker extends BugChecker implements ReturnTreeMatcher {
     @Override

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ComparableAndComparatorTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ComparableAndComparatorTest.java
@@ -30,8 +30,12 @@ public class ComparableAndComparatorTest {
       CompilationTestHelper.newInstance(ComparableAndComparator.class, getClass());
 
   @Test
-  public void testCases() {
+  public void positive() {
     compilationHelper.addSourceFile("ComparableAndComparatorPositiveCases.java").doTest();
+  }
+
+  @Test
+  public void negative() {
     compilationHelper.addSourceFile("ComparableAndComparatorNegativeCases.java").doTest();
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/HidingFieldTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/HidingFieldTest.java
@@ -36,8 +36,10 @@ public class HidingFieldTest {
 
   @Test
   public void testHidingFieldPositiveCases() {
-    compilationHelper.addSourceFile("HidingFieldPositiveCases1.java").doTest();
-    compilationHelper.addSourceFile("HidingFieldPositiveCases2.java").doTest();
+    compilationHelper
+        .addSourceFile("HidingFieldPositiveCases1.java")
+        .addSourceFile("HidingFieldPositiveCases2.java")
+        .doTest();
   }
 
   @Test

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/StronglyTypeTimeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/StronglyTypeTimeTest.java
@@ -246,6 +246,19 @@ public final class StronglyTypeTimeTest {
   }
 
   @Test
+  public void unusedField_noMatch() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.io.Serializable;",
+            "class Test implements Serializable {",
+            "  private static final long serialVersionUID = 1L;",
+            "}")
+        .expectNoDiagnostics()
+        .doTest();
+  }
+
+  @Test
   public void whenJodaAndJavaInstantUsed_fullyQualifiesName() {
     refactoringHelper
         .addInputLines(

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <javac.version>9+181-r4173-1</javac.version>
     <autoservice.version>1.0-rc6</autoservice.version>
     <autovalue.version>1.7</autovalue.version>
-    <junit.version>4.13-beta-1</junit.version>
+    <junit.version>4.13</junit.version>
     <dataflow.version>3.1.2</dataflow.version>
     <mockito.version>2.25.0</mockito.version>
     <compile.testing.version>0.18</compile.testing.version>

--- a/test_helpers/src/main/java/com/google/errorprone/BugCheckerRefactoringTestHelper.java
+++ b/test_helpers/src/main/java/com/google/errorprone/BugCheckerRefactoringTestHelper.java
@@ -16,6 +16,7 @@
 
 package com.google.errorprone;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
@@ -140,6 +141,8 @@ public class BugCheckerRefactoringTestHelper {
   private boolean allowBreakingChanges = false;
   private String importOrder = "static-first";
 
+  private boolean run = false;
+
   private BugCheckerRefactoringTestHelper(BugChecker refactoringBugChecker, Class<?> clazz) {
     this.refactoringBugChecker = refactoringBugChecker;
     this.fileManager = new ErrorProneInMemoryFileManager(clazz);
@@ -186,6 +189,8 @@ public class BugCheckerRefactoringTestHelper {
   }
 
   public void doTest(TestMode testMode) {
+    checkState(!run, "doTest should only be called once");
+    this.run = true;
     for (Map.Entry<JavaFileObject, JavaFileObject> entry : sources.entrySet()) {
       try {
         runTestOnPair(entry.getKey(), entry.getValue(), testMode);

--- a/test_helpers/src/main/java/com/google/errorprone/CompilationTestHelper.java
+++ b/test_helpers/src/main/java/com/google/errorprone/CompilationTestHelper.java
@@ -16,12 +16,12 @@
 
 package com.google.errorprone;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.fail;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
@@ -80,6 +80,8 @@ public class CompilationTestHelper {
   private boolean checkWellFormed = true;
   private LookForCheckNameInDiagnostic lookForCheckNameInDiagnostic =
       LookForCheckNameInDiagnostic.YES;
+
+  private boolean run = false;
 
   private CompilationTestHelper(ScannerSupplier scannerSupplier, String checkName, Class<?> clazz) {
     this.fileManager = new ErrorProneInMemoryFileManager(clazz);
@@ -276,7 +278,9 @@ public class CompilationTestHelper {
 
   /** Performs a compilation and checks that the diagnostics and result match the expectations. */
   public void doTest() {
-    Preconditions.checkState(!sources.isEmpty(), "No source files to compile");
+    checkState(!sources.isEmpty(), "No source files to compile");
+    checkState(!run, "doTest should only be called once");
+    this.run = true;
     Result result = compile();
     for (Diagnostic<? extends JavaFileObject> diagnostic : diagnosticHelper.getDiagnostics()) {
       if (diagnostic.getCode().contains("error.prone.crash")) {

--- a/test_helpers/src/test/java/com/google/errorprone/BugCheckerRefactoringTestHelperTest.java
+++ b/test_helpers/src/test/java/com/google/errorprone/BugCheckerRefactoringTestHelperTest.java
@@ -18,6 +18,7 @@ package com.google.errorprone;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
@@ -257,5 +258,13 @@ public class BugCheckerRefactoringTestHelperTest {
       SuggestedFix fix = SuggestedFix.builder().addImport("java.util.ArrayList").build();
       return describeMatch(tree, fix);
     }
+  }
+
+  @Test
+  public void onlyCallDoTestOnce() {
+    helper.addInputLines("Test.java", "public class Test {}").expectUnchanged().doTest();
+    IllegalStateException expected =
+        assertThrows(IllegalStateException.class, () -> helper.doTest());
+    assertThat(expected).hasMessageThat().contains("doTest");
   }
 }

--- a/test_helpers/src/test/java/com/google/errorprone/CompilationTestHelperTest.java
+++ b/test_helpers/src/test/java/com/google/errorprone/CompilationTestHelperTest.java
@@ -550,4 +550,12 @@ public class CompilationTestHelperTest {
         .expectResult(Result.ERROR)
         .doTest();
   }
+
+  @Test
+  public void onlyCallDoTestOnce() {
+    compilationHelper.addSourceLines("Test.java", "public class Test {}").doTest();
+    IllegalStateException expected =
+        assertThrows(IllegalStateException.class, () -> compilationHelper.doTest());
+    assertThat(expected).hasMessageThat().contains("doTest");
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> fix typo

Fixes #1590

4386471667379840c5f4b50bb68897b805d54131

-------

<p> skip unnecessary boxing

Fixes this warning:

Fixes #1558

90197b0344b29f2f879b41def7c55723bb4f4951

-------

<p> Minor fix to FallThrough to skip generated/mutated AST nodes
(e.g. Lombok)

Fixes #1573

1534bae6b3422be39ac82a65068e3c0bb151e859

-------

<p> Make summary of InjectOnConstructorOfAbstractClass consistent

The first sentence says @Injected and the second one says @Inject'ed.

Change the first one to @Inject'ed so it's consistent.

Change-Id: Id2ab8908a608288739af33cddc902f94707b057a

Fixes #1491

08397375c07ccea59a679ea4a8901413abde020f

-------

<p> Drop `@Nullable` from `RefasterRule#afterTemplates()`

This property is never null and the caller unconditionally dereferences

Fixes #1606

87d4fe5fbe0e001fc3cb79d7aedf6bf5438234c6

-------

<p> Handle `NO_MATCH` in `VisitorState#reportMatch` instead of `Scanner

This fix prevents reports such as the following, which are hard to debug
for users:
```
[INFO] /path/to/some/File.java: [<no match>] <no match>
   (see <no match>)

Fixes #1609

5fdc31e61c2975ac93bbacbba5416cdefa1b9e88

-------

<p> Update junit dependency to 4.13

Fixes #1591

df17a5141f44146deb91a4718aa123b52ffcea25

-------

<p> Inline a helper method

Closes https://github.com/google/error-prone/pull/1325

2946131ec99327a3c7175d5ea282833512f8e94e

-------

<p> Add IntelliJ IDEA ImportOrganizer

Many projects use the default import ordering provided by IntelliJ IDEA.
In order to apply Error Prone without adjusting this ordering, one can

Fixes #1208

deea2cf2d72ec38893106536f8f414c5a579d939

-------

<p> Prevent accidental re-use of CompilationTestHelper and BugCheckerRefactoringTestHelper instances

See e.g. https://github.com/google/error-prone/pull/1313

2c5708c357f9d4f6b4b2a61588fe2f162bcc5b71

-------

<p> Don't handle nulls in VisitorState#reportMatch.

37eeca46f6078a09ec1e0db0b75c0ba95483bbae

-------

<p> Breaks mockito (d'oh)

882fc471b12b67b83588594fecc3fa4b300e8641