### PR TITLE
MOE Sync 2020-05-17

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
@@ -56,6 +56,7 @@ public class ErrorProneOptions {
   private static final String ENABLE_ALL_CHECKS = "-XepAllDisabledChecksAsWarnings";
   private static final String IGNORE_SUPPRESSION_ANNOTATIONS = "-XepIgnoreSuppressionAnnotations";
   private static final String DISABLE_ALL_CHECKS = "-XepDisableAllChecks";
+  private static final String DISABLE_ALL_WARNINGS = "-XepDisableAllWarnings";
   private static final String IGNORE_UNKNOWN_CHECKS_FLAG = "-XepIgnoreUnknownCheckNames";
   private static final String DISABLE_WARNINGS_IN_GENERATED_CODE_FLAG =
       "-XepDisableWarningsInGeneratedCode";
@@ -75,7 +76,8 @@ public class ErrorProneOptions {
             || option.equals(ENABLE_ALL_CHECKS)
             || option.equals(DISABLE_ALL_CHECKS)
             || option.equals(IGNORE_SUPPRESSION_ANNOTATIONS)
-            || option.equals(COMPILING_TEST_ONLY_CODE);
+            || option.equals(COMPILING_TEST_ONLY_CODE)
+            || option.equals(DISABLE_ALL_WARNINGS);
     return isSupported ? 0 : -1;
   }
 
@@ -156,6 +158,7 @@ public class ErrorProneOptions {
   private final ImmutableMap<String, Severity> severityMap;
   private final boolean ignoreUnknownChecks;
   private final boolean disableWarningsInGeneratedCode;
+  private final boolean disableAllWarnings;
   private final boolean dropErrorsToWarnings;
   private final boolean enableAllChecksAsWarnings;
   private final boolean disableAllChecks;
@@ -171,6 +174,7 @@ public class ErrorProneOptions {
       ImmutableList<String> remainingArgs,
       boolean ignoreUnknownChecks,
       boolean disableWarningsInGeneratedCode,
+      boolean disableAllWarnings,
       boolean dropErrorsToWarnings,
       boolean enableAllChecksAsWarnings,
       boolean disableAllChecks,
@@ -184,6 +188,7 @@ public class ErrorProneOptions {
     this.remainingArgs = remainingArgs;
     this.ignoreUnknownChecks = ignoreUnknownChecks;
     this.disableWarningsInGeneratedCode = disableWarningsInGeneratedCode;
+    this.disableAllWarnings = disableAllWarnings;
     this.dropErrorsToWarnings = dropErrorsToWarnings;
     this.enableAllChecksAsWarnings = enableAllChecksAsWarnings;
     this.disableAllChecks = disableAllChecks;
@@ -209,6 +214,10 @@ public class ErrorProneOptions {
 
   public boolean disableWarningsInGeneratedCode() {
     return disableWarningsInGeneratedCode;
+  }
+
+  public boolean isDisableAllWarnings() {
+    return disableAllWarnings;
   }
 
   public boolean isDropErrorsToWarnings() {
@@ -241,6 +250,7 @@ public class ErrorProneOptions {
 
   private static class Builder {
     private boolean ignoreUnknownChecks = false;
+    private boolean disableAllWarnings = false;
     private boolean disableWarningsInGeneratedCode = false;
     private boolean dropErrorsToWarnings = false;
     private boolean enableAllChecksAsWarnings = false;
@@ -298,6 +308,13 @@ public class ErrorProneOptions {
       this.dropErrorsToWarnings = dropErrorsToWarnings;
     }
 
+    public void setDisableAllWarnings(boolean disableAllWarnings) {
+      severityMap.entrySet().stream()
+          .filter(e -> e.getValue() == Severity.WARN)
+          .forEach(e -> e.setValue(Severity.OFF));
+      this.disableAllWarnings = disableAllWarnings;
+    }
+
     public void setEnableAllChecksAsWarnings(boolean enableAllChecksAsWarnings) {
       // Checks manually disabled before this flag are reset to warning-level
       severityMap.entrySet().stream()
@@ -330,6 +347,7 @@ public class ErrorProneOptions {
           remainingArgs,
           ignoreUnknownChecks,
           disableWarningsInGeneratedCode,
+          disableAllWarnings,
           dropErrorsToWarnings,
           enableAllChecksAsWarnings,
           disableAllChecks,
@@ -394,6 +412,9 @@ public class ErrorProneOptions {
           break;
         case COMPILING_TEST_ONLY_CODE:
           builder.setTestOnlyTarget(true);
+          break;
+        case DISABLE_ALL_WARNINGS:
+          builder.setDisableAllWarnings(true);
           break;
         default:
           if (arg.startsWith(SEVERITY_PREFIX)) {

--- a/check_api/src/main/java/com/google/errorprone/RefactoringCollection.java
+++ b/check_api/src/main/java/com/google/errorprone/RefactoringCollection.java
@@ -179,6 +179,7 @@ class RefactoringCollection implements DescriptionListener.Factory {
           throw new UncheckedIOException(e);
         }
       }
+      Files.createDirectories(patchFilePatch.getParent());
       Files.write(patchFilePatch, patchFile.getBytes(UTF_8), APPEND, CREATE);
     }
   }

--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -1175,7 +1175,7 @@ public class SuggestedFixes {
         // recompiles to avoid infinite recursion.
         continue;
       }
-      if ((key.equals("-source") || key.equals("-target")) && originalOptions.isSet("--release")) {
+      if (SOURCE_TARGET_OPTIONS.contains(key) && originalOptions.isSet("--release")) {
         // javac does not allow -source and -target to be specified explicitly when --release is,
         // but does add them in response to passing --release. Here we invert that operation.
         continue;
@@ -1233,6 +1233,9 @@ public class SuggestedFixes {
     }
     return true;
   }
+
+  private static final ImmutableSet<String> SOURCE_TARGET_OPTIONS =
+      ImmutableSet.of("-source", "--source", "-target", "--target");
 
   /** Create a plausible URI to use in {@link #compilesWithFix}. */
   @VisibleForTesting

--- a/check_api/src/main/java/com/google/errorprone/scanner/ScannerSupplier.java
+++ b/check_api/src/main/java/com/google/errorprone/scanner/ScannerSupplier.java
@@ -166,6 +166,11 @@ public abstract class ScannerSupplier implements Supplier<Scanner> {
           .forEach(c -> severities.put(c.canonicalName(), SeverityLevel.WARNING));
     }
 
+    if (errorProneOptions.isDisableAllWarnings()) {
+      getAllChecks().values().stream()
+          .filter(c -> c.defaultSeverity() == SeverityLevel.WARNING)
+          .forEach(c -> disabled.add(c.canonicalName()));
+    }
     if (errorProneOptions.isDisableAllChecks()) {
       getAllChecks().values().stream()
           .filter(c -> c.disableable())

--- a/check_api/src/test/java/com/google/errorprone/ErrorProneOptionsTest.java
+++ b/check_api/src/test/java/com/google/errorprone/ErrorProneOptionsTest.java
@@ -162,6 +162,13 @@ public class ErrorProneOptionsTest {
   }
 
   @Test
+  public void recognizesDisableAllWarnings() {
+    ErrorProneOptions options =
+        ErrorProneOptions.processArgs(new String[] {"-XepDisableAllWarnings"});
+    assertThat(options.isDisableAllWarnings()).isTrue();
+  }
+
+  @Test
   public void recognizesVisitSuppressedCode() {
     ErrorProneOptions options =
         ErrorProneOptions.processArgs(new String[] {"-XepIgnoreSuppressionAnnotations"});

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CanBeStaticAnalyzer.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CanBeStaticAnalyzer.java
@@ -69,23 +69,27 @@ public class CanBeStaticAnalyzer extends TreeScanner {
   public void visitIdent(JCTree.JCIdent tree) {
     // check for unqualified references to instance members (fields and methods) declared
     // in an enclosing scope
-    if (tree.sym.isStatic()) {
+    Symbol sym = tree.sym;
+    if (sym == null) {
+      // return;
+    }
+    if (sym.isStatic()) {
       return;
     }
-    switch (tree.sym.getKind()) {
+    switch (sym.getKind()) {
       case TYPE_PARAMETER:
         // declaring a class as non-static just to access a type parameter is silly -
         // why not just re-declare the type parameter instead of capturing it?
         // TODO(cushon): consider making the suggestion anyways, maybe with a fix?
         // fall through
       case FIELD:
-        if (!isOwnedBy(tree.sym, owner, state.getTypes())) {
+        if (!isOwnedBy(sym, owner, state.getTypes())) {
           canPossiblyBeStatic = false;
         }
         break;
       case METHOD:
-        if (!isOwnedBy(tree.sym, owner, state.getTypes())) {
-          outerReferences.add((MethodSymbol) tree.sym);
+        if (!isOwnedBy(sym, owner, state.getTypes())) {
+          outerReferences.add((MethodSymbol) sym);
         }
         break;
       case CLASS:

--- a/core/src/main/java/com/google/errorprone/bugpatterns/CanBeStaticAnalyzer.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/CanBeStaticAnalyzer.java
@@ -71,7 +71,7 @@ public class CanBeStaticAnalyzer extends TreeScanner {
     // in an enclosing scope
     Symbol sym = tree.sym;
     if (sym == null) {
-      // return;
+      return;
     }
     if (sym.isStatic()) {
       return;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DefaultPackage.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DefaultPackage.java
@@ -18,6 +18,7 @@ package com.google.errorprone.bugpatterns;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
+import com.google.common.io.Files;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
@@ -51,6 +52,10 @@ public final class DefaultPackage extends BugChecker implements CompilationUnitT
       return Description.NO_MATCH;
     }
     if (tree.getPackageName() != null) {
+      return Description.NO_MATCH;
+    }
+    // module-info.* is a special file name so whitelisting it.
+    if (Files.getNameWithoutExtension(ASTHelpers.getFileName(tree)).equals("module-info")) {
       return Description.NO_MATCH;
     }
     return describeMatch(tree);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByUtils.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/threadsafety/GuardedByUtils.java
@@ -44,7 +44,7 @@ public class GuardedByUtils {
   static ImmutableSet<String> getGuardValues(Tree tree, VisitorState state) {
     Symbol sym = getSymbol(tree);
     if (sym == null) {
-      return null;
+      return ImmutableSet.of();
     }
     return getAnnotationValueAsStrings(sym);
   }

--- a/core/src/main/java/com/google/errorprone/refaster/Inliner.java
+++ b/core/src/main/java/com/google/errorprone/refaster/Inliner.java
@@ -24,6 +24,7 @@ import com.google.errorprone.SubContext;
 import com.google.errorprone.refaster.Bindings.Key;
 import com.google.errorprone.refaster.UTypeVar.TypeWithExpression;
 import com.google.errorprone.util.ASTHelpers;
+import com.google.errorprone.util.RuntimeVersion;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
@@ -228,9 +229,22 @@ public final class Inliner {
     sym.type = typeVar;
     typeVarCache.put(var.getName(), typeVar);
     // Any recursive uses of var will point to the same TypeVar object generated above.
-    typeVar.bound = var.getUpperBound().inline(this);
+    setUpperBound(typeVar, var.getUpperBound().inline(this));
     typeVar.lower = var.getLowerBound().inline(this);
     return typeVar;
+  }
+
+  private static void setUpperBound(TypeVar typeVar, Type bound) {
+    try {
+      // https://bugs.openjdk.java.net/browse/JDK-8193367
+      if (RuntimeVersion.isAtLeast13()) {
+        TypeVar.class.getMethod("setUpperBound", Type.class).invoke(typeVar, bound);
+      } else {
+        TypeVar.class.getField("bound").set(typeVar, bound);
+      }
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError(e.getMessage(), e);
+    }
   }
 
   Type inlineTypeVar(UTypeVar var) throws CouldNotResolveImportException {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ArrayFillIncompatibleTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ArrayFillIncompatibleTypeTest.java
@@ -16,7 +16,10 @@
 
 package com.google.errorprone.bugpatterns;
 
+import static org.junit.Assume.assumeFalse;
+
 import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.util.RuntimeVersion;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,6 +33,7 @@ public class ArrayFillIncompatibleTypeTest {
 
   @Test
   public void testPrimitiveBoxingIntoObject() {
+    assumeFalse(RuntimeVersion.isAtLeast12()); // https://bugs.openjdk.java.net/browse/JDK-8028563
     compilationHelper
         .addSourceLines(
             "Test.java",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ClassCanBeStaticTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ClassCanBeStaticTest.java
@@ -358,4 +358,23 @@ public class ClassCanBeStaticTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void labelledBreak() {
+    compilationHelper
+        .addSourceLines(
+            "A.java",
+            "public class A {",
+            "  // BUG: Diagnostic contains:",
+            "  class Inner {",
+            "    void f() {",
+            "      OUTER:",
+            "      while (true) {",
+            "        break OUTER;",
+            "      }",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/DefaultPackageTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/DefaultPackageTest.java
@@ -16,6 +16,8 @@
 
 package com.google.errorprone.bugpatterns;
 
+import static org.junit.Assume.assumeTrue;
+
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.util.RuntimeVersion;
 import org.junit.Test;
@@ -87,6 +89,18 @@ public class DefaultPackageTest {
             "T.java", //
             "package a;",
             "class T {};")
+        .doTest();
+  }
+
+  @Test
+  public void moduleInfo() {
+    assumeTrue(RuntimeVersion.isAtLeast9());
+
+    compilationHelper
+        .addSourceLines(
+            "module-info.java", //
+            "module testmodule {",
+            "}")
         .doTest();
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/EqualsIncompatibleTypeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/EqualsIncompatibleTypeTest.java
@@ -16,7 +16,10 @@
 
 package com.google.errorprone.bugpatterns;
 
+import static org.junit.Assume.assumeFalse;
+
 import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.util.RuntimeVersion;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,6 +48,7 @@ public class EqualsIncompatibleTypeTest {
 
   @Test
   public void testPrimitiveBoxingIntoObject() {
+    assumeFalse(RuntimeVersion.isAtLeast12()); // https://bugs.openjdk.java.net/browse/JDK-8028563
     compilationHelper
         .addSourceLines(
             "Test.java",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnoredTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnoredTest.java
@@ -39,6 +39,7 @@ public class FutureReturnValueIgnoredTest {
     compilationHelper.addSourceFile("FutureReturnValueIgnoredNegativeCases.java").doTest();
   }
 
+
   @Test
   public void testClassAnnotationButCanIgnoreReturnValue() {
     compilationHelper

--- a/core/src/test/java/com/google/errorprone/bugpatterns/inject/testdata/MoreThanOneScopeAnnotationOnClassPositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/inject/testdata/MoreThanOneScopeAnnotationOnClassPositiveCases.java
@@ -26,14 +26,14 @@ public class MoreThanOneScopeAnnotationOnClassPositiveCases {
   /** Class has two scope annotations */
   @Singleton
   @SessionScoped
-  // BUG: Diagnostic contains: @Singleton(), @SessionScoped().
+  // BUG: Diagnostic contains:
   class TestClass1 {}
 
   /** Class has three annotations, two of which are scope annotations. */
   @Singleton
   @SuppressWarnings("foo")
   @SessionScoped
-  // BUG: Diagnostic contains: @Singleton(), @SessionScoped().
+  // BUG: Diagnostic contains:
   class TestClass2 {}
 
   @Scope
@@ -42,6 +42,6 @@ public class MoreThanOneScopeAnnotationOnClassPositiveCases {
   @Singleton
   @CustomScope
   @SessionScoped
-  // BUG: Diagnostic contains: @Singleton(), @CustomScope(), @SessionScoped().
+  // BUG: Diagnostic contains:
   class TestClass3 {}
 }

--- a/examples/maven/pom.xml
+++ b/examples/maven/pom.xml
@@ -47,6 +47,8 @@
               <artifactId>error_prone_core</artifactId>
               <version>2.3.5-SNAPSHOT</version>
             </path>
+            <!-- Add any other annotation processors here,
+                 even if they are also on the project dependency classpath. -->
           </annotationProcessorPaths>
         </configuration>
       </plugin>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't flag module-info.java for not having default package

RELNOTES: Don't flag module-info.java for not having default package

7be2c43796341d9998bb79883d7f2a455d5a1631

-------

<p> Initial support for JDK versions through 13

see https://github.com/google/error-prone/issues/1106

8de8a63c1f697232129dc1353f7d4df6deb5ab51

-------

<p> Ignore hanging return values when invoking a graph method in graphVerify chain.

d7e78195779771f39d5db2199cba661bcdc809f0

-------

<p> GuardedByUtils: return empty set instead of null

Fixes #1110

8f054065e0cd08d775d9a198ab3b31d19bee1f31

-------

<p> Add a note about other annotation processors to the maven example

Fixes #1187

544b2b7cd8299820ee42c7a298c61db88d14eca5

-------

<p> Add -XepDisableAllWarnings flag

This flag turns off all WARNING-level checks, while leaving on those at ERROR level. This is useful for those who want to compile with -Werror but don't want any EP WARNING-level issue to block the build. Individual WARNING level checks can still be set to ERROR level as desired.

Fixes #785

0202733a42b5d3b1a9d403890bcc50aa16046109

-------

<p> Add a null-check in CanBeStatic

JDK 12 changes the representation of labelled breaks to use an identifier for
the label (instead of just a name), and the identifier doesn't have a symbol.

Fixes #1111

12e2544b69aa3c3a1ff560faf480ac05cf227038

-------

<p> Fix typo

RELNOTES: N/A

161dfb36cc4df927ee9f8dd0ea170d30d2107456

-------

<p> Create parent directory before writing patch file

We may choose to place the generated `error-prone.patch` file in a
subdirectory of the base which might not already exist. For example, we
may wish to place it in target/patches instead of the base directory.

Fixes #1070

1d36bc0551178183956ec7bfd42c456e11cdea43