### PR TITLE
Document -XepDisableAllWarnings

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -35,7 +35,16 @@ There are also a few blanket severity-changing flags:
 *   `-XepAllErrorsAsWarnings`
 *   `-XepAllDisabledChecksAsWarnings`
 *   `-XepDisableAllChecks`
+*   `-XepDisableAllWarnings`
 *   `-XepDisableWarningsInGeneratedCode` : Disables warnings in classes annotated with @javax.annotation.Generated
+
+With any of the blanket flags, you can pass additional flags afterward to
+tweak the level of individual checks.  E.g., this flag combination disables
+all checks except for ReferenceEquality:
+
+```bash
+-XepDisableAllChecks -Xep:ReferenceEquality:ERROR
+```
 
 Additionally, you can completely exclude certain paths
 from any Error Prone checking via the `-XepExcludedPaths` flag.  The


### PR DESCRIPTION
Now that #785 has landed, briefly document the existence of the `-XepDisableAllWarnings` flag.  Also describe briefly how the blanket flags can be combined with flags to enable/disable individual checks (slightly redundant but I think users will find it helpful).