### PR TITLE
MOE Sync 2020-05-26

### DIFF
--- a/annotations/src/main/java/com/google/errorprone/annotations/RestrictedApi.java
+++ b/annotations/src/main/java/com/google/errorprone/annotations/RestrictedApi.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
-// TODO(bangert): Allow restricting entire classes.
+// TODO(b/157082874): Allow restricting entire classes.
 /**
  * Restrict this method to callsites with a whitelist annotation.
  *

--- a/core/src/test/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionUndefinedEqualityTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/collectionincompatibletype/CollectionUndefinedEqualityTest.java
@@ -56,4 +56,19 @@ public final class CollectionUndefinedEqualityTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void treeMap_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Collection;",
+            "import java.util.TreeMap;",
+            "class Test {",
+            "  boolean foo(TreeMap<Collection<Integer>, Integer> xs, Collection<Integer> x) {",
+            "    return xs.containsKey(x);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a TODO(bug) for restricting entire classes with @RestrictedApi

f4839a6574cd9ea0cbf867a6a50e6e2f9a1c344c

-------

<p> CollectionUndefinedEquality: exempt collection-like-things that don't rely on equality.

I thought of TreeMap and IdentityHash{Set,Map}. Do any more come to mind?

e4e1dd5d5c6ad8ccd3460aacd2b5764082985535