### PR TITLE
MOE Sync 2020-05-26

### DIFF
--- a/core/src/main/java/com/google/errorprone/refaster/UTemplater.java
+++ b/core/src/main/java/com/google/errorprone/refaster/UTemplater.java
@@ -515,9 +515,11 @@ public class UTemplater extends SimpleTreeVisitor<Tree, Void> {
   public UClassDecl visitClass(ClassTree tree, Void v) {
     ImmutableList.Builder<UMethodDecl> decls = ImmutableList.builder();
     for (MethodTree decl : Iterables.filter(tree.getMembers(), MethodTree.class)) {
-      if (decl.getReturnType() != null) {
-        decls.add(visitMethod(decl, null));
+      if (ASTHelpers.isGeneratedConstructor(decl)) {
+        // skip synthetic constructors
+        continue;
       }
+      decls.add(visitMethod(decl, null));
     }
     return UClassDecl.create(decls.build());
   }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Work around a change to InstanceOfTree in JDK 14

It has a new getter for instanceof patterns, for now we proxy it to handle the
new getter (and the new PatterTree AST node type that it returns) and
unconditionally return `null`. This will require more work to actually support
refaster matches on instanceof patterns.

https://github.com/google/error-prone/issues/1106

bb4f1d9385fb51dce9aeff7d0ecdb139258636b4

-------

<p> Improve handling of synthetic generated constructors in refaster

The return type is a non-null 'void' type in recent JDK versions.

https://github.com/google/error-prone/issues/1106

7b072f7067dbc9136c001434aaa44ac67149a468