### PR TITLE
MOE Sync 2020-05-27

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/AbstractReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AbstractReturnValueIgnored.java
@@ -259,4 +259,5 @@ public abstract class AbstractReturnValueIgnored extends BugChecker
     ExpressionTree receiver = ASTHelpers.getReceiver(invocation);
     return MOCKITO_MATCHER.matches(receiver, state);
   }
+
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/CheckReturnValueTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/CheckReturnValueTest.java
@@ -643,4 +643,5 @@ public class CheckReturnValueTest {
         .withClasspath(CRVTest.class, CheckReturnValueTest.class)
         .doTest();
   }
+
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Exclusion of graphVerify() chain from return ignore value check must be done in AbstractReturnValueIgnored class - since both FutureReturnValueIgnored and CheckReturnValue checker needs to ignore graphVerify chain.

GraphWrapper's start() method returns a Future and is also explicitly marked with @CheckReturnValue : []

faa150e621629249c75d28337d6a6fb05579f171