### PR TITLE
MOE Sync 2020-06-02

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/MutablePublicArray.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MutablePublicArray.java
@@ -28,11 +28,11 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
-import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.VariableTree;
-import com.sun.tools.javac.tree.JCTree.JCLiteral;
 import com.sun.tools.javac.tree.JCTree.JCNewArray;
+import java.util.Objects;
 import javax.lang.model.element.Modifier;
 
 /** Check for public static final declaration of Arrays. */
@@ -73,12 +73,8 @@ public class MutablePublicArray extends BugChecker implements VariableTreeMatche
     }
     JCNewArray newArray = (JCNewArray) initializer;
     if (!newArray.getDimensions().isEmpty()) {
-      return newArray.getDimensions().stream()
-          .allMatch(
-              jcExpression -> {
-                JCLiteral literal = (JCLiteral) jcExpression;
-                return literal.getKind() == Kind.INT_LITERAL && (Integer) literal.getValue() > 0;
-              });
+      return !newArray.getDimensions().stream()
+          .allMatch(e -> Objects.equals(0, ASTHelpers.constValue(e, Integer.class)));
     }
     // For in line array initializer.
     return newArray.getInitializers() != null && !newArray.getInitializers().isEmpty();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MutablePublicArrayTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MutablePublicArrayTest.java
@@ -181,4 +181,22 @@ public class MutablePublicArrayTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void i1645() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  public static final int zero = 0;",
+            "  public static final int one = 1;",
+            "  public static final long[] z1 = new long[zero];",
+            "  public static final long[][] z2 = new long[zero][zero];",
+            "  // BUG: Diagnostic contains: MutablePublicArray",
+            "  public static final long[] o1 = new long[one];",
+            "  // BUG: Diagnostic contains: MutablePublicArray",
+            "  public static final long[][] o2 = new long[one][zero];",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/RestrictedApiCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/RestrictedApiCheckerTest.java
@@ -160,9 +160,9 @@ public class RestrictedApiCheckerTest {
             "class Testcase {",
             "  @WhitelistWithWarning",
             "  void foo(RestrictedApiMethods m) {",
-            "    // BUG: Diagnostic contains: [RestrictedApi]",
+            "    // BUG: Diagnostic contains: lorem",
             "    m.restrictedMethod();",
-            "    // BUG: Diagnostic contains: [RestrictedApi]",
+            "    // BUG: Diagnostic contains: lorem",
             "    m.accept(m::restrictedMethod);",
             "  }",
             "}")

--- a/core/src/test/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpressionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/StaticQualifiedUsingExpressionTest.java
@@ -158,4 +158,32 @@ public class StaticQualifiedUsingExpressionTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void qualified() {
+    refactoringHelper
+        .addInputLines(
+            "C.java",
+            "class C {",
+            " static Object x;",
+            " void f() {",
+            "   Object x = this.x;",
+            " }",
+            " void g() {",
+            "   Object y = this.x;",
+            " }",
+            "}")
+        .addOutputLines(
+            "C.java",
+            "class C {",
+            " static Object x;",
+            " void f() {",
+            "   Object x = C.x;",
+            " }",
+            " void g() {",
+            "   Object y = x;",
+            " }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix a CCE in MutablePublicArray

Fixes https://github.com/google/error-prone/issues/1645

c23ae182443dc7d4c04b2d19598509ef4fe074b8

-------

<p> Use the more supported kind of TreeScanner in SuggestedFixes

dbbc9d22518f236d7febf697e0a4f36280c5bffc

-------

<p> Fix qualification of fields that clash with locals in StaticQualifiedUsingExpression

bf4276f39579ba276392376987ffe7e6c15c90c9

-------

<p> Change the way we test warning level output, look for the same output ("lorem") but at a non-error severity.

a0586361b01002803e9319db11c0e3b18c83d287