### PR TITLE
MOE Sync 2020-06-09

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/DoNotCallChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DoNotCallChecker.java
@@ -56,28 +56,48 @@ public class DoNotCallChecker extends BugChecker
   // If your method cannot be annotated with @DoNotCall (e.g., it's a JDK or thirdparty method),
   // then add it to this Map with an explanation.
   private static final ImmutableMap<Matcher<ExpressionTree>, String> THIRD_PARTY_METHODS =
-      ImmutableMap.of(
-          staticMethod()
-              .onClass("org.junit.Assert")
-              .named("assertEquals")
-              .withParameters("double", "double"),
-          "This method always throws java.lang.AssertionError. Use assertEquals("
-              + "expected, actual, delta) to compare floating-point numbers",
-          staticMethod()
-              .onClass("org.junit.Assert")
-              .named("assertEquals")
-              .withParameters("java.lang.String", "double", "double"),
-          "This method always throws java.lang.AssertionError. Use assertEquals("
-              + "String, expected, actual, delta) to compare floating-point numbers",
-          instanceMethod()
-              .onExactClass("java.sql.Date")
-              .namedAnyOf(
-                  "getHours", "getMinutes", "getSeconds", "setHours", "setMinutes", "setSeconds"),
-          "The hour/minute/second getters and setters on java.sql.Date are guaranteed to throw"
-              + " IllegalArgumentException because java.sql.Date does not have a time"
-              + " component.",
-          instanceMethod().onExactClass("java.sql.Date").named("toInstant"),
-          "sqlDate.toInstant() is not supported. Did you mean to call toLocalDate() instead?");
+      new ImmutableMap.Builder<Matcher<ExpressionTree>, String>()
+          .put(
+              staticMethod()
+                  .onClass("org.junit.Assert")
+                  .named("assertEquals")
+                  .withParameters("double", "double"),
+              "This method always throws java.lang.AssertionError. Use assertEquals("
+                  + "expected, actual, delta) to compare floating-point numbers")
+          .put(
+              staticMethod()
+                  .onClass("org.junit.Assert")
+                  .named("assertEquals")
+                  .withParameters("java.lang.String", "double", "double"),
+              "This method always throws java.lang.AssertionError. Use assertEquals("
+                  + "String, expected, actual, delta) to compare floating-point numbers")
+          .put(
+              instanceMethod()
+                  .onExactClass("java.sql.Date")
+                  .namedAnyOf(
+                      "getHours",
+                      "getMinutes",
+                      "getSeconds",
+                      "setHours",
+                      "setMinutes",
+                      "setSeconds"),
+              "The hour/minute/second getters and setters on java.sql.Date are guaranteed to throw"
+                  + " IllegalArgumentException because java.sql.Date does not have a time"
+                  + " component.")
+          .put(
+              instanceMethod().onExactClass("java.sql.Date").named("toInstant"),
+              "sqlDate.toInstant() is not supported. Did you mean to call toLocalDate() instead?")
+          .put(
+              instanceMethod()
+                  .onExactClass("java.util.concurrent.ThreadLocalRandom")
+                  .named("setSeed"),
+              "ThreadLocalRandom does not support setting a seed.")
+          .put(
+              instanceMethod()
+                  .onExactClass("java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock")
+                  .named("newCondition"),
+              "ReadLocks do not support conditions.")
+          .build();
 
   private static final String DO_NOT_CALL = "com.google.errorprone.annotations.DoNotCall";
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/IdentityHashMapBoxingTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/IdentityHashMapBoxingTest.java
@@ -16,6 +16,7 @@
 
 package com.google.errorprone.bugpatterns;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,7 +29,7 @@ public class IdentityHashMapBoxingTest {
       CompilationTestHelper.newInstance(IdentityHashMapBoxing.class, getClass());
 
   @Test
-  public void testPositiveCases() {
+  public void testConstructorPositiveCases() {
     compilationHelper
         .addSourceLines(
             "Test.java",
@@ -50,7 +51,7 @@ public class IdentityHashMapBoxingTest {
   }
 
   @Test
-  public void testNegativeCases() {
+  public void testConstructorNegativeCases() {
     compilationHelper
         .addSourceLines(
             "Test.java",
@@ -64,6 +65,71 @@ public class IdentityHashMapBoxingTest {
             "    Map<String, Long> map4 = new IdentityHashMap<>();",
             "    Map<String, Object> map5 = new IdentityHashMap<>();",
             "    Map<Object, String> map6 = new IdentityHashMap<>();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testMapsPositiveCases_flagOn() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.collect.Maps;",
+            "import java.util.IdentityHashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  void test() {",
+            "    // BUG: Diagnostic contains: IdentityHashMapBoxing",
+            "    Map<Integer, String> map1 = Maps.newIdentityHashMap();",
+            "    // BUG: Diagnostic contains: IdentityHashMapBoxing",
+            "    Map<Float, String> map2 = Maps.newIdentityHashMap();",
+            "    // BUG: Diagnostic contains: IdentityHashMapBoxing",
+            "    Map<Double, String> map3 = Maps.newIdentityHashMap();",
+            "    // BUG: Diagnostic contains: IdentityHashMapBoxing",
+            "    Map<Long, String> map4 = Maps.newIdentityHashMap();",
+            "  }",
+            "}")
+        .setArgs(ImmutableList.of("-XepOpt:IdentityHashMapBoxing:checkMapsNewIHM=true"))
+        .doTest();
+  }
+
+  @Test
+  public void testMapsPositiveCases_flagOff() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.collect.Maps;",
+            "import java.util.IdentityHashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  void test() {",
+            "    Map<Integer, String> map1 = Maps.newIdentityHashMap();",
+            "    Map<Float, String> map2 = Maps.newIdentityHashMap();",
+            "    Map<Double, String> map3 = Maps.newIdentityHashMap();",
+            "    Map<Long, String> map4 = Maps.newIdentityHashMap();",
+            "  }",
+            "}")
+        .setArgs(ImmutableList.of("-XepOpt:IdentityHashMapBoxing:checkMapsNewIHM=false"))
+        .doTest();
+  }
+
+  @Test
+  public void testMapsNegativeCases() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.common.collect.Maps;",
+            "import java.util.IdentityHashMap;",
+            "import java.util.Map;",
+            "class Test {",
+            "  void test() {",
+            "    Map<String, Integer> map1 = Maps.newIdentityHashMap();",
+            "    Map<String, Float> map2 = Maps.newIdentityHashMap();",
+            "    Map<String, Double> map3 = Maps.newIdentityHashMap();",
+            "    Map<String, Long> map4 = Maps.newIdentityHashMap();",
+            "    Map<String, Object> map5 = Maps.newIdentityHashMap();",
+            "    Map<Object, String> map6 = Maps.newIdentityHashMap();",
             "  }",
             "}")
         .doTest();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/JdkObsoleteTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/JdkObsoleteTest.java
@@ -325,6 +325,22 @@ public class JdkObsoleteTest {
   }
 
   @Test
+  public void javaUtilDate_allowedApis() {
+    testHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.time.Instant;",
+            "import java.util.Date;",
+            "class Test {",
+            "  public void doSomething(Date date) {",
+            "    Instant instant = date.toInstant();",
+            "    Date date2 = Date.from(instant);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void navigableMapInheritedMethod() {
     testHelper
         .addSourceLines(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't fire JdkObsolete for Date.from(Instant) or date.toInstant(), as these are often needed for interoping with a legacy API.

Fixes https://github.com/google/error-prone/issues/1672

0e9c50d2f5a1fa7ac5e06ab07c27a546c6957baf

-------

<p> Ban calls to java.sql.Date that are guaranteed to throw a runtime exception.

518105dfbf02545b9b44854b20136821877d8925

-------

<p> Add java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock.newCondition() and java.util.concurrent.ThreadLocalRandom.setSeed() to the DoNotCall checker.

a8385536d69872e25390c88ac5b733498bd82601

-------

<p> Flag IdentityHashMap construction with boxed types using Maps.newIdentityHashMap

913c49f9a77a7b50dccc8083d4bcc56e135ac0b3