### PR TITLE
fix java.util.Date link in UndefinedEquals.md

### DIFF
--- a/docs/bugpattern/UndefinedEquals.md
+++ b/docs/bugpattern/UndefinedEquals.md
@@ -69,4 +69,4 @@ TIP: `java.util.Date` is a legacy, bug-prone API. Prefer `java.time.Instant` or
 [`SparseArray`]: https://developer.android.com/reference/android/util/SparseArray
 [`Queue`]: http://docs.oracle.com/javase/8/docs/api/java/util/Queue.html
 [`CharSequence`]: http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html
-[`Date`]: http://docs.oracle.com/javase/8/docs/api/java/util/Date.html
+[`java.util.Date`]: http://docs.oracle.com/javase/8/docs/api/java/util/Date.html


### PR DESCRIPTION
ran into this while reviewing https://github.com/apache/fineract/pull/1099/ and found link was broken in doc

BTW it's not super clear what the recommendation is here... our project just switched to using `compareTo()` instead of `equals()` but what you're really saying here is that `jul.Date` is just screwed anyway? If switching `equals()` usages to `compareTo()` seems valid, would it worthwhile mentioning this in the doc?