### PR TITLE
Don't warn if methods annotated @PreDestroy / @PostConstruct are unused

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedMethod.java
@@ -79,6 +79,8 @@ public final class UnusedMethod extends BugChecker implements CompilationUnitTre
           "com.google.inject.Inject",
           "com.google.inject.multibindings.ProvidesIntoMap",
           "com.google.inject.multibindings.ProvidesIntoSet",
+          "javax.annotation.PreDestroy",
+          "javax.annotation.PostConstruct",
           "javax.inject.Inject");
 
   /** The set of types exempting a type that is extending or implementing them. */


### PR DESCRIPTION
Methods annotated with `@PreDestroy` and `@PostConstruct` are managed by Java EE and the Java spec describes "The method [...] MAY be public, protected, package private or private". So I'd argue there shouldn't be are warning for private methods annotated with either of those annotations.

Those two annotations were also mentioned in #1235 

See:
https://docs.oracle.com/javase/8/docs/api/javax/annotation/PostConstruct.html
https://docs.oracle.com/javase/8/docs/api/javax/annotation/PreDestroy.html