### PR TITLE
Update to use dataflow framework 3.6.0.

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/dataflow/DataFlow.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/DataFlow.java
@@ -99,17 +99,21 @@ public final class DataFlow {
                   final TreePath methodPath = key.methodPath();
                   final UnderlyingAST ast;
                   ClassTree classTree = null;
+                  MethodTree method = null;
                   for (Tree parent : methodPath) {
                     if (parent instanceof ClassTree) {
                       classTree = (ClassTree) parent;
                       break;
                     }
+                    if (parent instanceof MethodTree) {
+                      method = (MethodTree) parent;
+                      break;
+                    }
                   }
                   if (methodPath.getLeaf() instanceof LambdaExpressionTree) {
-                    MethodTree method = TreeUtils.enclosingMethod(methodPath);
                     ast = new UnderlyingAST.CFGLambda((LambdaExpressionTree) methodPath.getLeaf(), classTree, method);
                   } else if (methodPath.getLeaf() instanceof MethodTree) {
-                    MethodTree method = (MethodTree) methodPath.getLeaf();
+                    method = (MethodTree) methodPath.getLeaf();
                     ast = new UnderlyingAST.CFGMethod(method, classTree);
                   } else {
                     // must be an initializer per findEnclosingMethodOrLambdaOrInitializer

--- a/check_api/src/main/java/com/google/errorprone/dataflow/DataFlow.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/DataFlow.java
@@ -45,7 +45,6 @@ import org.checkerframework.shaded.dataflow.analysis.TransferFunction;
 import org.checkerframework.shaded.dataflow.cfg.CFGBuilder;
 import org.checkerframework.shaded.dataflow.cfg.ControlFlowGraph;
 import org.checkerframework.shaded.dataflow.cfg.UnderlyingAST;
-import org.checkerframework.shaded.javacutil.TreeUtils;
 
 /**
  * Provides a wrapper around {@link org.checkerframework.shaded.dataflow.analysis.Analysis}.

--- a/check_api/src/main/java/com/google/errorprone/dataflow/DataFlow.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/DataFlow.java
@@ -99,22 +99,21 @@ public final class DataFlow {
                   final TreePath methodPath = key.methodPath();
                   final UnderlyingAST ast;
                   ClassTree classTree = null;
-                  MethodTree method = null;
+                  MethodTree methodTree = null;
                   for (Tree parent : methodPath) {
+                    if (parent instanceof MethodTree) {
+                      methodTree = (MethodTree) parent;
+                    }
                     if (parent instanceof ClassTree) {
                       classTree = (ClassTree) parent;
                       break;
                     }
-                    if (parent instanceof MethodTree) {
-                      method = (MethodTree) parent;
-                      break;
-                    }
                   }
                   if (methodPath.getLeaf() instanceof LambdaExpressionTree) {
-                    ast = new UnderlyingAST.CFGLambda((LambdaExpressionTree) methodPath.getLeaf(), classTree, method);
+                    ast = new UnderlyingAST.CFGLambda((LambdaExpressionTree) methodPath.getLeaf(), classTree, methodTree);
                   } else if (methodPath.getLeaf() instanceof MethodTree) {
-                    method = (MethodTree) methodPath.getLeaf();
-                    ast = new UnderlyingAST.CFGMethod(method, classTree);
+                    methodTree = (MethodTree) methodPath.getLeaf();
+                    ast = new UnderlyingAST.CFGMethod(methodTree, classTree);
                   } else {
                     // must be an initializer per findEnclosingMethodOrLambdaOrInitializer
                     ast = new UnderlyingAST.CFGStatement(methodPath.getLeaf(), classTree);

--- a/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/AbstractNullnessPropagationTransfer.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/AbstractNullnessPropagationTransfer.java
@@ -29,8 +29,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.checkerframework.shaded.dataflow.analysis.ConditionalTransferResult;
+import org.checkerframework.shaded.dataflow.analysis.ForwardTransferFunction;
 import org.checkerframework.shaded.dataflow.analysis.RegularTransferResult;
-import org.checkerframework.shaded.dataflow.analysis.TransferFunction;
 import org.checkerframework.shaded.dataflow.analysis.TransferInput;
 import org.checkerframework.shaded.dataflow.analysis.TransferResult;
 import org.checkerframework.shaded.dataflow.cfg.UnderlyingAST;
@@ -125,7 +125,7 @@ import org.checkerframework.shaded.dataflow.cfg.node.WideningConversionNode;
  * @author cpovirk@google.com (Chris Povirk)
  */
 abstract class AbstractNullnessPropagationTransfer
-    implements TransferFunction<Nullness, AccessPathStore<Nullness>> {
+    implements ForwardTransferFunction<Nullness, AccessPathStore<Nullness>> {
   @Override
   public AccessPathStore<Nullness> initialStore(
       UnderlyingAST underlyingAST, List<LocalVariableNode> parameters) {

--- a/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/NullnessPropagationTransfer.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/NullnessPropagationTransfer.java
@@ -90,6 +90,7 @@ import javax.annotation.Nullable;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeVariable;
 import org.checkerframework.shaded.dataflow.analysis.Analysis;
+import org.checkerframework.shaded.dataflow.analysis.ForwardAnalysisImpl;
 import org.checkerframework.shaded.dataflow.cfg.CFGBuilder;
 import org.checkerframework.shaded.dataflow.cfg.ControlFlowGraph;
 import org.checkerframework.shaded.dataflow.cfg.UnderlyingAST;
@@ -832,7 +833,7 @@ class NullnessPropagationTransfer extends AbstractNullnessPropagationTransfer
               /*assumeAssertionsDisabled=*/ false,
               javacEnv);
       Analysis<Nullness, AccessPathStore<Nullness>, NullnessPropagationTransfer> analysis =
-          new Analysis<>(this);
+          new ForwardAnalysisImpl<>(this);
       analysis.performAnalysis(cfg);
       return analysis.getValue(initializerPath.getLeaf());
     } finally {

--- a/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/TrustingNullnessAnalysis.java
+++ b/check_api/src/main/java/com/google/errorprone/dataflow/nullnesspropagation/TrustingNullnessAnalysis.java
@@ -32,6 +32,7 @@ import com.sun.tools.javac.util.Context;
 import java.io.Serializable;
 import javax.lang.model.element.ElementKind;
 import org.checkerframework.shaded.dataflow.analysis.Analysis;
+import org.checkerframework.shaded.dataflow.analysis.ForwardAnalysisImpl;
 import org.checkerframework.shaded.dataflow.cfg.CFGBuilder;
 import org.checkerframework.shaded.dataflow.cfg.ControlFlowGraph;
 import org.checkerframework.shaded.dataflow.cfg.UnderlyingAST;
@@ -116,7 +117,7 @@ public final class TrustingNullnessAnalysis implements Serializable {
           .setCompilationUnit(fieldDeclPath.getCompilationUnit());
 
       Analysis<Nullness, AccessPathStore<Nullness>, TrustingNullnessPropagation> analysis =
-          new Analysis<>(nullnessPropagation);
+          new ForwardAnalysisImpl<>(nullnessPropagation);
       analysis.performAnalysis(cfg);
       return analysis.getValue(initializer);
     } finally {

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <autoservice.version>1.0-rc6</autoservice.version>
     <autovalue.version>1.7</autovalue.version>
     <junit.version>4.13</junit.version>
-    <dataflow.version>3.1.2</dataflow.version>
+    <dataflow.version>3.6.0</dataflow.version>
     <mockito.version>2.25.0</mockito.version>
     <compile.testing.version>0.18</compile.testing.version>
     <caffeine.version>2.8.0</caffeine.version>


### PR DESCRIPTION
Adapt to the API change in version 3.5.0 and use the latest dataflow framework version 3.6.0:

The Dataflow Framework supports backward analysis.

Dataflow Framework: Analysis is now an interface.  Added AbstractAnalysis,
ForwardAnalysis, ForwardTransferFunction, ForwardAnalysisImpl,
BackwardAnalysis, BackwardTransferFunction, and BackwardAnalysisImpl.
To adapt existing code:
 * `extends Analysis<V, S, T>` => `extends ForwardAnalysisImpl<V, S, T>`
 * `implements TransferFunction<V, S>` => `implements ForwardTransferFunction<V, S>`

In addition, the method signature of `CFGLambda` changed from
`public CFGLambda(LambdaExpressionTree lambda)` to
`public CFGLambda(LambdaExpressionTree lambda, ClassTree classTree, MethodTree method)`

