### PR TITLE
PreferJavaTimeOverload: don't flag methods on Reactor's Flux type

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -332,6 +332,13 @@
     </dependency>
     <dependency>
       <!-- Apache 2.0 -->
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-core</artifactId>
+      <version>3.3.9.RELEASE</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <!-- Apache 2.0 -->
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>3.9.0</version>

--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverload.java
@@ -125,7 +125,8 @@ public final class PreferJavaTimeOverload extends BugChecker
           // any static method under org.assertj.*
           staticMethod()
               .onClass((type, state) -> type.toString().startsWith("org.assertj."))
-              .withAnyName());
+              .withAnyName(),
+          instanceMethod().onDescendantOf("reactor.core.publisher.Flux").withAnyName());
 
   private static final Matcher<ExpressionTree> JAVA_DURATION_DECOMPOSITION_MATCHER =
       instanceMethod()

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverloadTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/PreferJavaTimeOverloadTest.java
@@ -451,4 +451,33 @@ public class PreferJavaTimeOverloadTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void reactor() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import reactor.core.publisher.Flux;",
+            "public class TestClass {",
+            "  public void testFluxBuffer() {",
+            "    Flux.empty().buffer(1);",
+            "  }",
+            "  public void testFluxCache() {",
+            "    Flux.empty().cache(1);",
+            "  }",
+            "  public void testFluxReplay() {",
+            "    Flux.empty().replay(1);",
+            "  }",
+            "  public void testFluxSkip() {",
+            "    Flux.empty().skip(1);",
+            "  }",
+            "  public void testFluxTake() {",
+            "    Flux.empty().take(1);",
+            "  }",
+            "  public void testFluxWindow() {",
+            "    Flux.empty().window(1);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
For example, one can either a buffer up to a [certain number of values](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#buffer-int-) or for a [certain amount of time](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html#buffer-java.time.Duration-); the latter operation is not always a suitable alternative to the former. Similar arguments apply to the cache, replay, skip, take, and window operations.

I'm not sure whether [Reactor](https://projectreactor.io/) is used inside Google, but I hope that this library is deemed sufficiently popular to meet the threshold for inclusion.