### PR TITLE
Fix some Error Prone and Infer analysis findings

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/RefactoringCollection.java
+++ b/check_api/src/main/java/com/google/errorprone/RefactoringCollection.java
@@ -202,7 +202,7 @@ class RefactoringCollection implements DescriptionListener.Factory {
     }
   }
 
-  private final class DelegatingDescriptionListener implements DescriptionListener {
+  private static final class DelegatingDescriptionListener implements DescriptionListener {
     final DescriptionBasedDiff base;
     final DescriptionListener listener;
 

--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -209,8 +209,9 @@ public class SuggestedFixes {
       }
       // walk the map of all modifiers, and accumulate a list of new modifiers to insert
       // beside an existing modifier
-      for (Modifier mod : modifierPositions.keySet()) {
-        int p = modifierPositions.get(mod);
+      for (Map.Entry<Modifier,Integer> ent : modifierPositions.entrySet()) {
+        Modifier mod = ent.getKey();
+        int p = ent.getValue();
         if (p == -1) {
           modifiersToWrite.add(mod);
         } else if (!modifiersToWrite.isEmpty()) {

--- a/check_api/src/main/java/com/google/errorprone/matchers/ChildMultiMatcher.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/ChildMultiMatcher.java
@@ -69,7 +69,7 @@ public abstract class ChildMultiMatcher<T extends Tree, N extends Tree>
 
   @AutoValue
   abstract static class MatchResult<T extends Tree> {
-    public abstract List<T> matchingNodes();
+    public abstract ImmutableList<T> matchingNodes();
 
     public abstract boolean matches();
 

--- a/check_api/src/main/java/com/google/errorprone/matchers/MultiMatcher.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/MultiMatcher.java
@@ -49,7 +49,7 @@ public interface MultiMatcher<T extends Tree, N extends Tree> extends Matcher<T>
      * The list of nodes which matched the MultiMatcher's expectations (could be empty if the match
      * type was ALL and there were no child nodes). Only sensical if {@link #matches()} is true.
      */
-    public abstract List<N> matchingNodes();
+    public abstract ImmutableList<N> matchingNodes();
 
     public final N onlyMatchingNode() {
       return getOnlyElement(matchingNodes());

--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -370,7 +370,7 @@ public class ASTHelpers {
     if (path != null) {
       do {
         path = path.getParentPath();
-      } while (path != null && !(klass.isInstance(path.getLeaf())));
+      } while (path != null && !klass.isInstance(path.getLeaf()));
     }
     return path;
   }


### PR DESCRIPTION
A run of [errorprone/infer/fsb](https://console.muse.dev/result/TomMD/error-prone/01EPDEX1PQZ98ACKBRCZAQY0K2?tab=results) shows some basic hygienic things - I fixed a few in this PR:

* UnnecessaryParentheses
* AutovalueImmutableFields
* ClassCanBeStatic
* Inefficient keyset iterator

Analysis of this branch [shows the above issues are fixed](https://console.muse.dev/result/TomMD/error-prone/01EPDFTBPHQ5RCCZF5M93489JP).  I'm open to any preferences or guidelines on tech debt PRs (ex. bundled or individual PRs).

More generally google/error-prone pull requests don't have much in the way of a CI pipeline (just CLA, build) and at least no public facing run of tools including of Error Prone itself.  I've cofounded a group to make running these tools is easier and with zero configuration required. Is there interest in running analysis tools on PRs?  It seems public results from Google's internal processes is unlikely, we could install Muse on this repository to benefit the non-Google contributors.  New bugs are fed back as PR comments but otherwise nothing changes, so in the normal case there is no distraction or mental overhead.

Thoughts?  Is there desire to beef up the CI pipeline and encourage more contributions from the public?