### PR TITLE
Avoid NPE in `SameNameButDifferent`

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/SameNameButDifferent.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SameNameButDifferent.java
@@ -96,10 +96,13 @@ public final class SameNameButDifferent extends BugChecker implements Compilatio
 
       private void handle(Tree tree) {
         if (tree instanceof IdentifierTree
-            && ((IdentifierTree) tree).getName().contentEquals("Buiilder")) {
+            && ((IdentifierTree) tree).getName().contentEquals("Builder")) {
           return;
         }
         String treeSource = state.getSourceForNode(tree);
+        if (treeSource == null) {
+          return;
+        }
         Symbol symbol = getSymbol(tree);
         if (symbol instanceof ClassSymbol) {
           List<TreePath> treePaths = table.get(treeSource, symbol.type.tsym);
@@ -107,9 +110,7 @@ public final class SameNameButDifferent extends BugChecker implements Compilatio
             treePaths = new ArrayList<>();
             table.put(treeSource, symbol.type.tsym, treePaths);
           }
-          if (state.getEndPosition(tree) != Position.NOPOS) {
-            treePaths.add(getCurrentPath());
-          }
+          treePaths.add(getCurrentPath());
         }
       }
     }.scan(state.getPath(), null);


### PR DESCRIPTION
With this change the check fully skips trees for which the source code is unavailable.

While there, also fix what appears to be a typo: "Buiilder" -> "Builder".

Stack trace of the error avoided by this change:
```
[ERROR] /path/to/some/Class.java:[1,1] An unhandled exception was thrown by the Error Prone static analysis plugin.
     Please report this at https://github.com/google/error-prone/issues/new and include the following:
  
     error-prone version: 2.4.1-SNAPSHOT
     BugPattern: SameNameButDifferent
     Stack Trace:
     java.lang.NullPointerException
  	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:877)
  	at com.google.common.collect.StandardTable.put(StandardTable.java:145)
  	at com.google.common.collect.HashBasedTable.put(HashBasedTable.java:51)
  	at com.google.errorprone.bugpatterns.SameNameButDifferent$1.handle(SameNameButDifferent.java:108)
  	at com.google.errorprone.bugpatterns.SameNameButDifferent$1.visitMemberSelect(SameNameButDifferent.java:66)
  	at com.google.errorprone.bugpatterns.SameNameButDifferent$1.visitMemberSelect(SameNameButDifferent.java:62)
        ... snip ...
```