### PR TITLE
Handle `SuggestedFixes#qualifyStaticImport` method declaration clashes

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -453,18 +453,23 @@ public class SuggestedFixes {
     String name = qualifiedName.substring(qualifiedName.lastIndexOf(".") + 1);
     AtomicBoolean foundConflict = new AtomicBoolean(false);
     new TreeScanner<Void, Void>() {
+      @Override
+      public Void visitMethod(MethodTree method, Void unused) {
+        process(method, method.getName());
+        return super.visitMethod(method, null);
+      }
 
       @Override
       public Void visitIdentifier(IdentifierTree ident, Void unused) {
-        process(ident);
+        process(ident, ident.getName());
         return super.visitIdentifier(ident, null);
       }
 
-      private void process(IdentifierTree ident) {
-        if (!ident.getName().contentEquals(name)) {
+      private void process(Tree tree, Name identifier) {
+        if (!identifier.contentEquals(name)) {
           return;
         }
-        Symbol symbol = getSymbol(ident);
+        Symbol symbol = getSymbol(tree);
         if (symbol == null) {
           return;
         }

--- a/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
+++ b/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
@@ -846,14 +846,47 @@ public class SuggestedFixesTest {
   }
 
   @Test
-  public void qualifyStaticImport_whenNamesClash_usesQualifiedName() {
+  public void qualifyStaticImport_whenIdentifierNamesClash_usesQualifiedName() {
+    BugCheckerRefactoringTestHelper.newInstance(new ReplaceMethodInvocations(), getClass())
+        .addInputLines(
+            "pkg/Lib.java",
+            "package pkg;",
+            "public class Lib {",
+            "  public static void verifyNotNull(int a) {}",
+            " }")
+        .expectUnchanged()
+        .addInputLines(
+            "Test.java",
+            "import static com.google.common.base.Preconditions.checkNotNull;",
+            "import static pkg.Lib.verifyNotNull;",
+            "class Test {",
+            "  void test() {",
+            "    verifyNotNull(2);",
+            "    checkNotNull(1);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import static com.google.common.base.Preconditions.checkNotNull;",
+            "import static pkg.Lib.verifyNotNull;",
+            "import com.google.common.base.Verify;",
+            "class Test {",
+            "  void test() {",
+            "    verifyNotNull(2);",
+            "    Verify.verifyNotNull(1);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void qualifyStaticImport_whenMethodNamesClash_usesQualifiedName() {
     BugCheckerRefactoringTestHelper.newInstance(new ReplaceMethodInvocations(), getClass())
         .addInputLines(
             "Test.java",
             "import static com.google.common.base.Preconditions.checkNotNull;",
             "class Test {",
             "  void test() {",
-            "    verifyNotNull(2);",
             "    checkNotNull(1);",
             "  }",
             "  void verifyNotNull(int a) {}",
@@ -864,7 +897,6 @@ public class SuggestedFixesTest {
             "import com.google.common.base.Verify;",
             "class Test {",
             "  void test() {",
-            "    verifyNotNull(2);",
             "    Verify.verifyNotNull(1);",
             "  }",
             "  void verifyNotNull(int a) {}",


### PR DESCRIPTION
If a class declares a method `m` then statically importing another method `m` does not have the desired effect.