### PR TITLE
MissingCasesInEnumSwitch handles case labels with multiple expressions

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingCasesInEnumSwitch.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingCasesInEnumSwitch.java
@@ -26,12 +26,17 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.SwitchTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.util.ASTHelpers;
+import com.google.errorprone.util.RuntimeVersion;
 import com.sun.source.tree.CaseTree;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.SwitchTree;
 import com.sun.tools.javac.code.Type;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.lang.model.element.ElementKind;
 
 /** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
@@ -55,7 +60,7 @@ public class MissingCasesInEnumSwitch extends BugChecker implements SwitchTreeMa
     }
     ImmutableSet<String> handled =
         tree.getCases().stream()
-            .map(CaseTree::getExpression)
+            .flatMap(MissingCasesInEnumSwitch::getExpressions)
             .filter(IdentifierTree.class::isInstance)
             .map(e -> ((IdentifierTree) e).getName().toString())
             .collect(toImmutableSet());
@@ -89,5 +94,17 @@ public class MissingCasesInEnumSwitch extends BugChecker implements SwitchTreeMa
       message.append(String.format(", and %d others", unhandled.size() - numberToShow));
     }
     return message.toString();
+  }
+
+  private static Stream<? extends ExpressionTree> getExpressions(CaseTree caseTree) {
+    try {
+      if (RuntimeVersion.isAtLeast12()) {
+        return ((List<? extends ExpressionTree>) CaseTree.class.getMethod("getExpressions").invoke(caseTree)).stream();
+      } else {
+        return Stream.of(caseTree.getExpression());
+      }
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError(e.getMessage(), e);
+    }
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MissingCasesInEnumSwitchTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MissingCasesInEnumSwitchTest.java
@@ -16,7 +16,10 @@
 
 package com.google.errorprone.bugpatterns;
 
+import static org.junit.Assume.assumeTrue;
+
 import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.util.RuntimeVersion;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -41,6 +44,23 @@ public class MissingCasesInEnumSwitchTest {
             "      case THREE:",
             "        System.err.println(\"found it!\");",
             "        break;",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void testExhaustive_multipleCaseExpressions() {
+    assumeTrue(RuntimeVersion.isAtLeast14());
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  enum Case { ONE, TWO }",
+            "  void m(Case c) {",
+            "    switch (c) {",
+            "      case ONE, TWO -> {}",
             "    }",
             "  }",
             "}")


### PR DESCRIPTION
`MissingCasesInEnumSwitch` does not correctly handle multi-expression case labels in switch expressions. It uses the deprecated `CaseTree#getExpression` method, which only returns the first expression in the case label.

A simple example is shown below:
```
enum Case { ONE, TWO }
void m(Case c) {
  switch (c) {
    case ONE, TWO -> {}
  }
}
```

This code will produce the following error:
```
[MissingCasesInEnumSwitch] Non-exhaustive switch; either add a default or handle the remaining cases: TWO
```

This PR updates `MissingCasesInEnumSwitch` to instead use the non-deprecated `CaseTree#getExpressions` method, which returns all expressions in the case label.

Unfortunately this requires using reflection because the `CaseTree#getExpressions` method was not added until Java 12.