### PR TITLE
Handle diagnostics without source

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -1309,8 +1309,9 @@ public class SuggestedFixes {
     boolean warningInSameCompilationUnit = false;
     for (Diagnostic<? extends JavaFileObject> diagnostic : diagnosticListener.getDiagnostics()) {
       warningIsError |= diagnostic.getCode().equals("compiler.err.warnings.and.werror");
-      boolean diagnosticInSameCompilationUnit =
-          diagnostic.getSource().toUri().equals(modifiedFileUri);
+      JavaFileObject diagnosticSource = diagnostic.getSource();
+      boolean diagnosticInSameCompilationUnit = diagnosticSource == null
+              || diagnosticSource.toUri().equals(modifiedFileUri);
       switch (diagnostic.getKind()) {
         case ERROR:
           ++countErrors;

--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -1310,6 +1310,7 @@ public class SuggestedFixes {
     for (Diagnostic<? extends JavaFileObject> diagnostic : diagnosticListener.getDiagnostics()) {
       warningIsError |= diagnostic.getCode().equals("compiler.err.warnings.and.werror");
       JavaFileObject diagnosticSource = diagnostic.getSource();
+      // If the source's origin is unknown, assume that new diagnostics are due to a modification.
       boolean diagnosticInSameCompilationUnit = diagnosticSource == null
               || diagnosticSource.toUri().equals(modifiedFileUri);
       switch (diagnostic.getKind()) {


### PR DESCRIPTION
In some cases, compiler diagnostics may not have an associated source,
and for testing whether suggested fixes compile these should be treated
as originating from the same compilation unit of the suggested fix.

Fixes #1873