### PR TITLE
Document naming convention for UnusedMethod

### DIFF
--- a/docs/bugpattern/UnusedMethod.md
+++ b/docs/bugpattern/UnusedMethod.md
@@ -5,4 +5,4 @@ the impact on other source files.
 ## Suppression
 
 All false positives can be suppressed by annotating the method with
-`@SuppressWarnings("unused")`.
+`@SuppressWarnings("unused")` or prefixing its name with `unused`.


### PR DESCRIPTION
Closes #2215. Being unaware of this convention, I filed a bug report for what is in fact a feature. So documenting this would be helpful.