### PR TITLE
Exempt `Immutable` from `UnnecessarilyFullyQualified`

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualified.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualified.java
@@ -62,7 +62,7 @@ public final class UnnecessarilyFullyQualified extends BugChecker
 
   private static final ImmutableSet<String> EXEMPTED_NAMES =
       ImmutableSet.of(
-          "Annotation");
+          "Annotation", "Immutable");
 
   @Override
   public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualifiedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualifiedTest.java
@@ -162,4 +162,36 @@ public final class UnnecessarilyFullyQualifiedTest {
             "package b;")
         .doTest();
   }
+
+  @Test
+  public void immutables() {
+    CompilationTestHelper.newInstance(UnnecessarilyFullyQualified.class, getClass())
+        .addSourceLines(
+            "org/immutables/value/Value.java",
+            "package org.immutables.value;",
+            "",
+            "public @interface Value {",
+            "  @interface Immutable {}",
+            "}")
+        .addSourceLines(
+            "a/Value.java",
+            "package a;",
+            "",
+            "public @interface Value {",
+            "  String value();",
+            "}")
+        .addSourceLines(
+            "test/Test.java",
+            "package test;",
+            "",
+            "import a.Value;",
+            "",
+            "final class Test {",
+            "  Test(@Value(\"test\") String value) {}",
+            "",
+            "  @org.immutables.value.Value.Immutable",
+            "  abstract class AbstractType {}",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
`UnnecessarilyFullyQualified` flags the usage of fully qualified `@Value.Immutable` annotation from Immutables. We prefer the fully qualified name when `@Value` from `spring-beans` is used. So we need to suppress it in those cases.

```java
import org.springframework.beans.factory.annotation.Value;

final class Demo { 
  Demo(@Value("some.property") String property) {}

  @SuppressWarnings("UnnecessarilyFullyQualified" /* Direct `@Immutable` import is confusing. */)
  @org.immutables.value.Value.Immutable
  abstract class AbstractType {}
}
```

The following report is generated without the suppression:

```
java.lang.AssertionError: Saw unexpected error on line 8. All errors:
/test/Test.java:8: warning: [UnnecessarilyFullyQualified] This fully qualified name is unambiguous to the compiler if imported.
  @org.immutables.value.Value.Immutable
                             ^
    (see https://errorprone.info/bugpattern/UnnecessarilyFullyQualified)
  Did you mean '@Immutable'?
```

However, using `@Immutable` can be confusing as there are many `@Immutable` annotations, e.g. `javax.annotation.concurrent.Immutable`, `com.google.errorprone.annotations.Immutable`, `org.hibernate.annotations.Immutable`, etc. For that reason, I think it makes sense to add `Immutable` to exempted names.