### PR TITLE
Introduce `Refaster.concatLiterals`

### DIFF
--- a/core/src/main/java/com/google/errorprone/refaster/Refaster.java
+++ b/core/src/main/java/com/google/errorprone/refaster/Refaster.java
@@ -227,4 +227,66 @@ public class Refaster {
   public static void emitComment(String literal) {
     throw new UnsupportedOperationException();
   }
+
+  /**
+   * Indicates that Refaster should attempt to concatenate the given expressions, joining literals
+   * if possible.
+   *
+   * <p>For example, instead of writing
+   *
+   * <pre><code>
+   * {@literal @}AfterTemplate void exampleConcatLiterals(boolean b, String msg, Object o) {
+   *     Preconditions.checkArgument(b, msg + "%s", o);
+   *  }
+   * </code></pre>
+   *
+   * <p>you could write
+   *
+   * <pre><code>
+   * {@literal @}AfterTemplate String exampleConcatLiterals(boolean b, String msg, Object o) {
+   *    Preconditions.checkArgument(b, Refaster.concatLiterals(msg, "%s"), o);
+   * }
+   * </code></pre>
+   *
+   * Since the plus operator is left-associative, the first or second operand must be a string to
+   * ensure that all operands are string-concatenated. (E.g., if the first two operands were
+   * numerical, addition would be performed.) This method enforces that the first operand is a
+   * string. For the other case, see {@link #concatLiterals(Object, String)}.
+   *
+   * @see #concatLiterals(Object, String)
+   */
+  public static String concatLiterals(String str, Object... expressions) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Indicates that Refaster should attempt to concatenate the given expressions, joining literals
+   * if possible.
+   *
+   * <p>For example, instead of writing
+   *
+   * <pre><code>
+   * {@literal @}AfterTemplate void exampleConcatLiterals(boolean b, String msg, Object o) {
+   *     Preconditions.checkArgument(b, msg + "%s", o1);
+   *  }
+   * </code></pre>
+   *
+   * <p>you could write
+   *
+   * <pre><code>
+   * {@literal @}AfterTemplate String exampleConcatLiterals(boolean b, String msg, Object o) {
+   *    Preconditions.checkArgument(b, Refaster.concatLiterals(msg, "%s"), o);
+   * }
+   * </code></pre>
+   *
+   * Since the plus operator is left-associative, the first or second operand must be a string to
+   * ensure that all operands are string-concatenated. (E.g., if the first two operands were
+   * numerical, addition would be performed.) This method enforces that the second operand is a
+   * string. For the other case, see {@link #concatLiterals(String, Object...)}.
+   *
+   * @see #concatLiterals(String, Object...)
+   */
+  public static String concatLiterals(Object o, String str) {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/com/google/errorprone/refaster/UConcatLiterals.java
+++ b/core/src/main/java/com/google/errorprone/refaster/UConcatLiterals.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.errorprone.refaster;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.sun.source.tree.LiteralTree;
+import com.sun.source.tree.TreeVisitor;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.tree.TreeMaker;
+import java.util.ArrayList;
+import java.util.List;
+
+/** {@code UExpression} that tries to concatenate literals. */
+@AutoValue
+public abstract class UConcatLiterals extends UExpression {
+  public static UConcatLiterals create(UExpression... expressions) {
+    return create(ImmutableList.copyOf(expressions));
+  }
+
+  public static AutoValue_UConcatLiterals create(Iterable<? extends UExpression> expressions) {
+    return new AutoValue_UConcatLiterals(ImmutableList.copyOf(expressions));
+  }
+
+  abstract ImmutableList<UExpression> expressions();
+
+  @Override
+  public JCExpression inline(Inliner inliner) throws CouldNotResolveImportException {
+    TreeMaker treeMaker = inliner.maker();
+    return mergeAdjacentLiterals(inliner.inlineList(expressions()), treeMaker).stream()
+        .reduce((e1, e2) -> treeMaker.Binary(JCTree.Tag.PLUS, e1, e2))
+        .orElseGet(() -> treeMaker.Literal(""));
+  }
+
+  private List<JCExpression> mergeAdjacentLiterals(
+      List<JCExpression> inlinedExpressions, TreeMaker treeMaker) {
+    List<JCExpression> mergedExpressions = new ArrayList<>();
+
+    for (JCExpression expr : inlinedExpressions) {
+      concatOrAppendExpression(mergedExpressions, expr, treeMaker);
+    }
+
+    return mergedExpressions;
+  }
+
+  private static void concatOrAppendExpression(
+      List<JCExpression> expressions, JCExpression next, TreeMaker treeMaker) {
+    if (expressions.isEmpty() || !(next instanceof LiteralTree)) {
+      expressions.add(next);
+    } else {
+      int prevIndex = expressions.size() - 1;
+      JCExpression prev = expressions.get(prevIndex);
+      if (!(prev instanceof LiteralTree)
+          || prev.getKind() != Kind.STRING_LITERAL && next.getKind() != Kind.STRING_LITERAL) {
+        expressions.add(next);
+      } else {
+        expressions.set(
+            prevIndex, treeMaker.Literal(literalAsString(prev) + literalAsString(next)));
+      }
+    }
+  }
+
+  private static String literalAsString(Object expr) {
+    return ((LiteralTree) expr).getValue().toString();
+  }
+
+  @Override
+  public <R, D> R accept(TreeVisitor<R, D> visitor, D data) {
+    throw new UnsupportedOperationException("concatLiterals should not appear in an @BeforeTemplate");
+  }
+
+  @Override
+  public Kind getKind() {
+    return Kind.OTHER;
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
@@ -149,6 +149,16 @@ public class TemplateIntegrationTest extends CompilerBasedTest {
   }
 
   @Test
+  public void concatLiterals() throws IOException {
+    runTest("ConcatLiteralsTemplate");
+  }
+
+  @Test
+  public void concatLiteralsWithRepeated() throws IOException {
+    runTest("ConcatLiteralsTemplateWithRepeated");
+  }
+
+  @Test
   public void repeated() throws IOException {
     runTest("VarargTemplate");
   }

--- a/core/src/test/java/com/google/errorprone/refaster/TemplatingTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/TemplatingTest.java
@@ -242,6 +242,28 @@ public class TemplatingTest extends CompilerBasedTest {
   }
 
   @Test
+  public void concatLiterals() {
+    compile(
+            "import com.google.errorprone.refaster.Refaster;",
+            "class ConcatLiteralsExample {",
+            "  public boolean example(String str) {",
+            "    return str.contains(Refaster.concatLiterals(\"foo\", \"bar\"));",
+            "  }",
+            "}");
+    assertThat(UTemplater.createTemplate(context, getMethodDeclaration("example")))
+        .isEqualTo(
+            ExpressionTemplate.create(
+                ImmutableMap.of("str", UClassType.create("java.lang.String")),
+                UMethodInvocation.create(
+                    UMemberSelect.create(
+                        UFreeIdent.create("str"),
+                        "contains",
+                        UMethodType.create(UPrimitiveType.BOOLEAN, UClassType.create("java.lang.CharSequence"))),
+                    UConcatLiterals.create(ULiteral.stringLit("foo"), ULiteral.stringLit("bar"))),
+                UPrimitiveType.BOOLEAN));
+  }
+
+  @Test
   public void unary() {
     compile(
         "import java.util.Arrays;",

--- a/core/src/test/java/com/google/errorprone/refaster/UConcatLiteralsTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/UConcatLiteralsTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2021 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.SerializableTester;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link UConcatLiterals}. */
+@RunWith(JUnit4.class)
+public class UConcatLiteralsTest extends AbstractUTreeTest {
+  @Test
+  public void equality() {
+    new EqualsTester()
+        .addEqualityGroup(
+            UConcatLiterals.create(
+                ImmutableList.of(
+                    ULiteral.stringLit("foo"), ULiteral.stringLit("bar"), UFreeIdent.create("y"))))
+        .addEqualityGroup(
+            UConcatLiterals.create(
+                ImmutableList.of(
+                    ULiteral.stringLit("foo"), UFreeIdent.create("y"), ULiteral.stringLit("bar"))))
+        .addEqualityGroup(
+            UConcatLiterals.create(
+                ImmutableList.of(
+                    ULiteral.stringLit("foo"),
+                    ULiteral.stringLit("bar"),
+                    UFreeIdent.create("x"),
+                    ULiteral.stringLit("baz"),
+                    UFreeIdent.create("y"),
+                    UFreeIdent.create("z"),
+                    ULiteral.stringLit("foo2"),
+                    ULiteral.intLit(5),
+                    UFreeIdent.create("a"))))
+        .testEquals();
+  }
+
+  @Test
+  public void serialization() {
+    SerializableTester.reserializeAndAssert(
+        UConcatLiterals.create(
+            ImmutableList.of(
+                ULiteral.stringLit("foo"),
+                ULiteral.charLit('t'),
+                UFreeIdent.create("x"),
+                ULiteral.stringLit("baz"),
+                UFreeIdent.create("y"),
+                UFreeIdent.create("z"),
+                ULiteral.stringLit("foo2"),
+                ULiteral.booleanLit(true),
+                ULiteral.intLit(5),
+                UFreeIdent.create("a"))));
+  }
+
+  @Test
+  public void inlineEmptyExpression() {
+    UConcatLiterals tree = UConcatLiterals.create();
+
+    assertInlines("\"\"", tree);
+  }
+
+  @Test
+  public void inlineString() {
+    UConcatLiterals tree = UConcatLiterals.create(ULiteral.stringLit("foo"));
+
+    assertInlines("\"foo\"", tree);
+  }
+
+  @Test
+  public void inlineTwoStrings() {
+    UConcatLiterals tree =
+        UConcatLiterals.create(
+            ImmutableList.of(ULiteral.stringLit("foo"), ULiteral.stringLit("bar")));
+
+    assertInlines("\"foobar\"", tree);
+  }
+
+  @Test
+  public void inlineStringWithChar() {
+    UConcatLiterals tree =
+        UConcatLiterals.create(ImmutableList.of(ULiteral.stringLit("foo"), ULiteral.charLit('t')));
+
+    assertInlines("\"foot\"", tree);
+  }
+
+  @Test
+  public void inlineCharWithString() {
+    UConcatLiterals tree =
+        UConcatLiterals.create(ImmutableList.of(ULiteral.charLit('f'), ULiteral.stringLit("oot")));
+
+    assertInlines("\"foot\"", tree);
+  }
+
+  @Test
+  public void inlineStringWithInt() {
+    UConcatLiterals tree =
+        UConcatLiterals.create(ImmutableList.of(ULiteral.stringLit("foo "), ULiteral.intLit(5)));
+
+    assertInlines("\"foo 5\"", tree);
+  }
+
+  @Test
+  public void inlineWithIntWithString() {
+    UConcatLiterals tree =
+        UConcatLiterals.create(ImmutableList.of(ULiteral.intLit(6), ULiteral.stringLit("foo")));
+
+    assertInlines("\"6foo\"", tree);
+  }
+
+  @Test
+  public void inlineWithDoubleWithString() {
+    UConcatLiterals tree =
+        UConcatLiterals.create(
+            ImmutableList.of(ULiteral.doubleLit(12.11), ULiteral.stringLit("foo")));
+
+    assertInlines("\"12.11foo\"", tree);
+  }
+
+  @Test
+  public void inlineWithLongWithString() {
+    UConcatLiterals tree =
+        UConcatLiterals.create(ImmutableList.of(ULiteral.longLit(102L), ULiteral.stringLit("foo")));
+
+    assertInlines("\"102foo\"", tree);
+  }
+
+  @Test
+  public void inlineWithBooleanInBetween() {
+    UConcatLiterals tree =
+        UConcatLiterals.create(
+            ImmutableList.of(
+                ULiteral.stringLit("foo"), ULiteral.booleanLit(true), ULiteral.stringLit("bar")));
+
+    assertInlines("\"footruebar\"", tree);
+  }
+
+  @Test
+  public void inlineWithIdentInBetween() {
+    UConcatLiterals tree =
+        UConcatLiterals.create(
+            ImmutableList.of(
+                ULiteral.stringLit("foo"), UFreeIdent.create("y"), ULiteral.stringLit("bar")));
+
+    bind(new UFreeIdent.Key("y"), parseExpression("y"));
+
+    assertInlines("\"foo\" + y + \"bar\"", tree);
+  }
+
+  @Test
+  public void inlineWithTrailingIdent() {
+    UConcatLiterals tree =
+        UConcatLiterals.create(
+            ImmutableList.of(
+                ULiteral.stringLit("foo"), ULiteral.stringLit("bar"), UFreeIdent.create("y")));
+
+    bind(new UFreeIdent.Key("y"), parseExpression("y"));
+
+    assertInlines("\"foobar\" + y", tree);
+  }
+
+  @Test
+  public void inlineWithTrailingIdentLiteral() {
+    UConcatLiterals tree =
+        UConcatLiterals.create(
+            ImmutableList.of(
+                ULiteral.stringLit("foo"), ULiteral.stringLit("bar"), UFreeIdent.create("y")));
+
+    bind(new UFreeIdent.Key("y"), parseExpression("\"baz\""));
+
+    assertInlines("\"foobarbaz\"", tree);
+  }
+
+  @Test
+  public void inlineWithStringsAndIdents() {
+    UConcatLiterals tree =
+        UConcatLiterals.create(
+            ImmutableList.of(
+                ULiteral.stringLit("foo"),
+                ULiteral.stringLit("bar"),
+                UFreeIdent.create("x"),
+                ULiteral.stringLit("baz"),
+                UFreeIdent.create("y"),
+                UFreeIdent.create("z"),
+                ULiteral.stringLit("foo2 "),
+                ULiteral.stringLit("bar2 "),
+                UFreeIdent.create("a")));
+
+    bind(new UFreeIdent.Key("x"), parseExpression("x"));
+    bind(new UFreeIdent.Key("y"), parseExpression("y"));
+    bind(new UFreeIdent.Key("z"), parseExpression("z"));
+    bind(new UFreeIdent.Key("a"), parseExpression("\"baz2\""));
+
+    assertInlines("\"foobar\" + x + \"baz\" + y + z + \"foo2 bar2 baz2\"", tree);
+  }
+
+  @Test
+  public void inlineLiteralsAndIdents() {
+    UConcatLiterals tree =
+        UConcatLiterals.create(
+            ImmutableList.of(
+                ULiteral.stringLit("foo "),
+                ULiteral.stringLit("bar "),
+                UFreeIdent.create("x"),
+                ULiteral.stringLit(" baz "),
+                ULiteral.charLit('t'),
+                UFreeIdent.create("y"),
+                ULiteral.intLit(5),
+                ULiteral.stringLit("foo2 "),
+                UFreeIdent.create("z")));
+
+    bind(new UFreeIdent.Key("x"), parseExpression("false"));
+    bind(new UFreeIdent.Key("y"), parseExpression("y"));
+    bind(new UFreeIdent.Key("z"), parseExpression("\"bar2\""));
+
+    assertInlines("\"foo bar false baz t\" + y + \"5foo2 bar2\"", tree);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/input/ConcatLiteralsTemplateExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/input/ConcatLiteralsTemplateExample.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+import autovalue.shaded.com.google.common.common.base.Preconditions;
+
+/** Test data for {@code ConcatLiteralsTemplate} refactoring. */
+public class ConcatLiteralsTemplateExample {
+  public void positive(Boolean cond, Object o) {
+    Preconditions.checkArgument(cond, "message " + o);
+  }
+
+  public void negative(Boolean cond, Object o, String msg) {
+    Preconditions.checkArgument(cond, msg + o);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/input/ConcatLiteralsTemplateWithRepeatedExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/input/ConcatLiteralsTemplateWithRepeatedExample.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+/** Test data for {@code ConcatLiteralsTemplate} refactoring. */
+public class ConcatLiteralsTemplateWithRepeatedExample {
+  public void example(String s) {
+    String result1 = String.format("%s%s%s%s", "baz", s, "foo", "bar");
+    String result2 = String.format("%s%s%s%s", s, "foo", "bar", "baz");
+    String result3 = String.format("%s%s%s%s", s, s, s, s);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/output/ConcatLiteralsTemplateExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/output/ConcatLiteralsTemplateExample.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+import autovalue.shaded.com.google.common.common.base.Preconditions;
+
+/** Test data for {@code ConcatLiteralsTemplate} refactoring. */
+public class ConcatLiteralsTemplateExample {
+  public void positive(Boolean cond, Object o) {
+    Preconditions.checkArgument(cond, "message %s", o);
+  }
+
+  public void negative(Boolean cond, Object o, String msg) {
+    Preconditions.checkArgument(cond, msg + "%s", o);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/output/ConcatLiteralsTemplateWithRepeatedExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/output/ConcatLiteralsTemplateWithRepeatedExample.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+/** Test data for {@code ConcatLiteralsTemplate} refactoring. */
+public class ConcatLiteralsTemplateWithRepeatedExample {
+  public void example(String s) {
+    String result1 = "baz" + s + "foobar";
+    String result2 = s + "foobarbaz";
+    String result3 = s + s + s + s;
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/template/ConcatLiteralsTemplate.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/template/ConcatLiteralsTemplate.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata.template;
+
+import autovalue.shaded.com.google.common.common.base.Preconditions;
+import com.google.errorprone.refaster.Refaster;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+
+public class ConcatLiteralsTemplate {
+  @BeforeTemplate
+  public void before(boolean b, String msg, Object o) {
+    Preconditions.checkArgument(b, msg + o);
+  }
+
+  @AfterTemplate
+  public void after(boolean b, String msg, Object o) {
+    Preconditions.checkArgument(b, Refaster.concatLiterals(msg, "%s"), o);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/template/ConcatLiteralsTemplateWithRepeated.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/template/ConcatLiteralsTemplateWithRepeated.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata.template;
+
+import com.google.errorprone.refaster.Refaster;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.Repeated;
+
+public class ConcatLiteralsTemplateWithRepeated {
+  @BeforeTemplate
+  public String before(@Repeated String strings) {
+    return String.format("%s%s%s%s", Refaster.asVarargs(strings));
+  }
+
+  @AfterTemplate
+  public String after(@Repeated String strings) {
+    return Refaster.concatLiterals(strings);
+  }
+}


### PR DESCRIPTION
Introduce `Refaster.concatLiterals`

This new Refaster operator can be used in `@AfterTemplate` methods to
request that its operands are concatenated. Literals will be merged
while other operands are joined using the `+` operator.

The PR seems big, but it consists mainly of tests.
The actual code is concise.

Fixes #1496.

CC: @PhilippWendler