### PR TITLE
Fix ForEachIterable error when calling iterator method without 'this'

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ForEachIterable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ForEachIterable.java
@@ -172,14 +172,15 @@ public class ForEachIterable extends BugChecker implements VariableTreeMatcher {
     if (elementType.hasTag(TypeTag.WILDCARD)) {
       elementType = getUpperBound(elementType, state.getTypes());
     }
+    Tree iterableExprNode = getReceiver(tree.getInitializer());
+    String iterableExpr =
+        iterableExprNode != null ? state.getSourceForNode(iterableExprNode) : "this";
     fix.replace(
         startPosition,
         getStartPosition(body),
         String.format(
             "for (%s %s : %s) ",
-            SuggestedFixes.prettyType(state, fix, elementType),
-            replacement,
-            state.getSourceForNode(getReceiver(tree.getInitializer()))));
+            SuggestedFixes.prettyType(state, fix, elementType), replacement, iterableExpr));
     return describeMatch(tree, fix.build());
   }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ForEachIterableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ForEachIterableTest.java
@@ -181,6 +181,42 @@ public class ForEachIterableTest {
   }
 
   @Test
+  public void iteratorMemberMethod() {
+    BugCheckerRefactoringTestHelper.newInstance(new ForEachIterable(), getClass())
+        .addInputLines(
+            "in/Test.java",
+            "import java.util.Iterator;",
+            "import java.lang.Iterable;",
+            "class Test<V> implements Iterable<V> {",
+            "  @Override",
+            "  public Iterator<V> iterator() {",
+            "    return null;",
+            "  }",
+            "  void test() {",
+            "    Iterator<V> iter = iterator();",
+            "    while (iter.hasNext()) {",
+            "      iter.next();",
+            "    }",
+            "  }",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "import java.util.Iterator;",
+            "import java.lang.Iterable;",
+            "class Test<V> implements Iterable<V> {",
+            "  @Override",
+            "  public Iterator<V> iterator() {",
+            "    return null;",
+            "  }",
+            "  void test() {",
+            "    for (V element : this) {",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void negative() {
     CompilationTestHelper.newInstance(ForEachIterable.class, getClass())
         .addSourceLines(


### PR DESCRIPTION
## Problem
The ForEachIterable check will NPE when generating a fix for an instance where the method returning the iterator is a member function, (ie called with `this` as the receiver). This causes `getReceiver` to return null, as expected, but then will trigger a NPE from `state.getSourceForNode`. The other two cases `getReceiver` can return null are for static methods, this will never occur though since the earlier `ITERATOR` matcher does not match static methods.

## PR Contribution
If `getReceiver` returns null then the fix will iterate over 'this' since getReceiver is returning null for `getReceiver(this.iterator())` so in reality should return `this`. The new case, and associated fix, can be seen in the unit test.