### PR TITLE
Add more Optional methods to ReturnValueIgnored

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ReturnValueIgnored.java
@@ -204,8 +204,16 @@ public class ReturnValueIgnored extends AbstractReturnValueIgnored {
   private static final Matcher<ExpressionTree> OPTIONAL_METHODS =
       anyOf(
           staticMethod().onClass("java.util.Optional"),
+          instanceMethod().onExactClass("java.util.Optional").named("filter"),
+          instanceMethod().onExactClass("java.util.Optional").named("flatMap"),
+          instanceMethod().onExactClass("java.util.Optional").named("get"),
+          instanceMethod().onExactClass("java.util.Optional").named("isEmpty"),
           instanceMethod().onExactClass("java.util.Optional").named("isPresent"),
-          instanceMethod().onExactClass("java.util.Optional").named("isEmpty"));
+          instanceMethod().onExactClass("java.util.Optional").named("map"),
+          instanceMethod().onExactClass("java.util.Optional").named("or"),
+          instanceMethod().onExactClass("java.util.Optional").named("orElse"),
+          instanceMethod().onExactClass("java.util.Optional").named("orElseGet"),
+          instanceMethod().onExactClass("java.util.Optional").named("orElseThrow"));
 
   /**
    * The return values of {@link java.util.concurrent.TimeUnit} methods should always be checked.

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ReturnValueIgnored.java
@@ -211,21 +211,11 @@ public class ReturnValueIgnored extends AbstractReturnValueIgnored {
                   "isPresent"));
 
   /**
-   * The return values of {@link java.util.Optional} static methods and some instance methods should
-   * always be checked.
+   * The return values of {@link java.util.Optional} methods should always be checked (except for
+   * void-returning ones, which won't be checked by AbstractReturnValueIgnored).
    */
   private static final Matcher<ExpressionTree> MORE_OPTIONAL_METHODS =
-          anyOf(
-                  instanceMethod().onExactClass("java.util.Optional")
-                          .namedAnyOf(
-                                  "filter",
-                                  "flatMap",
-                                  "get",
-                                  "map",
-                                  "or",
-                                  "orElse",
-                                  "orElseGet",
-                                  "orElseThrow"));
+          anyMethod().onClass("java.util.Optional");
 
   /**
    * The return values of {@link java.util.concurrent.TimeUnit} methods should always be checked.

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ReturnValueIgnoredTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ReturnValueIgnoredTest.java
@@ -177,6 +177,7 @@ public class ReturnValueIgnoredTest {
             "    optional.flatMap(v -> Optional.of(v + 1));",
             "    // BUG: Diagnostic contains: ReturnValueIgnored",
             "    optional.get();",
+            "    optional.ifPresent(v -> {});",
             "    // BUG: Diagnostic contains: ReturnValueIgnored",
             "    optional.isPresent();",
             "    // BUG: Diagnostic contains: ReturnValueIgnored",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ReturnValueIgnoredTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ReturnValueIgnoredTest.java
@@ -17,9 +17,12 @@
 package com.google.errorprone.bugpatterns;
 
 import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.util.RuntimeVersion;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import static org.junit.Assume.assumeTrue;
 
 /** @author alexeagle@google.com (Alex Eagle) */
 @RunWith(JUnit4.class)
@@ -169,9 +172,72 @@ public class ReturnValueIgnoredTest {
             "  void optional() {",
             "    Optional<Integer> optional = Optional.of(42);",
             "    // BUG: Diagnostic contains: ReturnValueIgnored",
-            "    optional.isPresent();",
             "    optional.filter(v -> v > 40);",
-            "    optional.map(v -> Integer.toString(v));",
+            "    // BUG: Diagnostic contains: ReturnValueIgnored",
+            "    optional.flatMap(v -> Optional.of(v + 1));",
+            "    // BUG: Diagnostic contains: ReturnValueIgnored",
+            "    optional.get();",
+            "    // BUG: Diagnostic contains: ReturnValueIgnored",
+            "    optional.isPresent();",
+            "    // BUG: Diagnostic contains: ReturnValueIgnored",
+            "    optional.map(v -> v + 1);",
+            "    // BUG: Diagnostic contains: ReturnValueIgnored",
+            "    optional.orElse(40);",
+            "    // BUG: Diagnostic contains: ReturnValueIgnored",
+            "    optional.orElseGet(() -> 40);",
+            "    // BUG: Diagnostic contains: ReturnValueIgnored",
+            "    optional.orElseThrow(() -> new RuntimeException());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void optionalInstanceMethods_jdk9() {
+    assumeTrue(RuntimeVersion.isAtLeast9());
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "class Test {",
+            "  void optional() {",
+            "    Optional<Integer> optional = Optional.of(42);",
+            "    // BUG: Diagnostic contains: ReturnValueIgnored",
+            "    optional.or(() -> Optional.empty());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void optionalInstanceMethods_jdk10() {
+    assumeTrue(RuntimeVersion.isAtLeast10());
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "class Test {",
+            "  void optional() {",
+            "    Optional<Integer> optional = Optional.of(42);",
+            "    // BUG: Diagnostic contains: ReturnValueIgnored",
+            "    optional.orElseThrow();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void optionalInstanceMethods_jdk11() {
+    assumeTrue(RuntimeVersion.isAtLeast11());
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "class Test {",
+            "  void optional() {",
+            "    Optional<Integer> optional = Optional.of(42);",
+            "    // BUG: Diagnostic contains: ReturnValueIgnored",
+            "    optional.isEmpty();",
             "  }",
             "}")
         .doTest();


### PR DESCRIPTION
The return values of almost all `Optional` instance methods, excluding `ifPresent` and `ifPresentOrElse`, should have their return values used.

For cases where you may don't care about the return value, it's better to use `isPresent` and `isEmpty`. For example, instead of:
```java
optional.orElseThrow(() -> ...);
```
Do:
```java
if (optional.isEmpty()) {
    throw ...;
}
```

---

As a motivating example, I had some code that was intended to look like:
```java
if (condition) {
    return getOptional().orElseThrow(...);
}

return ...;
```

But I forgot the `return`, so the code actually looked like:
```java
if (condition) {
    getOptional().orElseThrow(...);
}

return ...;
```

Detecting the unused `Optional` value here would have been useful.