### PR TITLE
ImmutableMemberCollection: support field-level `@SuppressWarnings`

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ImmutableMemberCollection.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ImmutableMemberCollection.java
@@ -125,6 +125,7 @@ public final class ImmutableMemberCollection extends BugChecker implements Class
         classTree.getMembers().stream()
             .filter(member -> PRIVATE_FINAL_VAR_MATCHER.matches(member, state))
             .filter(member -> !EXCLUSIONS.matches(member, state))
+            .filter(member -> !isSuppressed(member))
             .map(VariableTree.class::cast)
             .flatMap(varTree -> stream(isReplaceable(varTree, state)))
             .collect(toImmutableMap(ReplaceableVar::symbol, var -> var));

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ImmutableMemberCollectionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ImmutableMemberCollectionTest.java
@@ -48,6 +48,23 @@ public final class ImmutableMemberCollectionTest {
   }
 
   @Test
+  public void setInitConstructor_notMutatedButSuppressed_doesNothing() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "import java.util.List;",
+            "class Test {",
+            "  @SuppressWarnings(\"ImmutableMemberCollection\")",
+            "  private final List<String> myList;",
+            "  Test(List<String> myList) {",
+            "    this.myList = myList;",
+            "  }",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
+
+  @Test
   public void listInitConstructor_notMutated_replacesTypeWithImmutableList() {
     refactoringHelper
         .addInputLines(


### PR DESCRIPTION
Currently `@SuppressWarnings("ImmutableMemberCollection")` works at the class level but not the field level, which isn't very intuitive; this change resolves that.