### PR TITLE
Fix `package-info.java` identification on Windows

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/PackageInfo.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PackageInfo.java
@@ -24,6 +24,7 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.CompilationUnitTree;
+import java.io.File;
 
 /** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
@@ -37,7 +38,7 @@ public class PackageInfo extends BugChecker implements CompilationUnitTreeMatche
       return NO_MATCH;
     }
     String name = tree.getSourceFile().getName();
-    int idx = name.lastIndexOf('/');
+    int idx = name.lastIndexOf(File.separatorChar);
     if (idx != -1) {
       name = name.substring(idx + 1);
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PackageInfo.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PackageInfo.java
@@ -23,8 +23,8 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
 import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.CompilationUnitTree;
-import java.io.File;
 
 /** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
 @BugPattern(
@@ -37,8 +37,8 @@ public class PackageInfo extends BugChecker implements CompilationUnitTreeMatche
     if (tree.getSourceFile() == null) {
       return NO_MATCH;
     }
-    String name = tree.getSourceFile().getName();
-    int idx = name.lastIndexOf(File.separatorChar);
+    String name = ASTHelpers.getFileName(tree);
+    int idx = name.lastIndexOf('/');
     if (idx != -1) {
       name = name.substring(idx + 1);
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualified.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualified.java
@@ -44,6 +44,7 @@ import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.PackageSymbol;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.util.Position;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -189,7 +190,7 @@ public final class UnnecessarilyFullyQualified extends BugChecker
 
   private static boolean isPackageInfo(CompilationUnitTree tree) {
     String name = tree.getSourceFile().getName();
-    int idx = name.lastIndexOf('/');
+    int idx = name.lastIndexOf(File.separatorChar);
     if (idx != -1) {
       name = name.substring(idx + 1);
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualified.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualified.java
@@ -32,6 +32,7 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.ImportTree;
@@ -44,7 +45,6 @@ import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.PackageSymbol;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.util.Position;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -189,8 +189,8 @@ public final class UnnecessarilyFullyQualified extends BugChecker
   }
 
   private static boolean isPackageInfo(CompilationUnitTree tree) {
-    String name = tree.getSourceFile().getName();
-    int idx = name.lastIndexOf(File.separatorChar);
+    String name = ASTHelpers.getFileName(tree);
+    int idx = name.lastIndexOf('/');
     if (idx != -1) {
       name = name.substring(idx + 1);
     }


### PR DESCRIPTION
A colleague using Windows reported the issue discussed in #1652, even though we use (a fork of) Error Prone 2.7.1, which contains a fix for said issue.

The problem appears to be that `UnnecessarilyFullyQualified` looks for a forward slash in `compilationUnitTree.getSourceFile().getName()`, though `FileObject#getName()` says:
```java
    /**
     * Returns a user-friendly name for this file object.  The exact
     * value returned is not specified but implementations should take
     * care to preserve names as given by the user.  For example, if
     * the user writes the filename {@code "BobsApp\Test.java"} on
     * the command line, this method should return {@code
     * "BobsApp\Test.java"} whereas the {@linkplain #toUri toUri}
     * method might return {@code
     * file:///C:/Documents%20and%20Settings/UncleBob/BobsApp/Test.java}.
     *
     * @return a user-friendly name
     */
```

I found a similar bit of code in the `PackageInfo` check. This change replaces the forward slash with `File.separatorChar`. An alternative (presumably slightly less performant) fix is to rely on `FileObject#toUri` instead. Let me know if you prefer that approach.

I'll update our fork with this change and ask my colleague to test the fix.