### PR TITLE
[UnusedMethod] exempt @MethodSource with qualified method names

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedMethodTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedMethodTest.java
@@ -223,4 +223,56 @@ public final class UnusedMethodTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void qualifiedMethodSource() {
+    helper
+        .addSourceLines(
+            "MethodSource.java",
+            "package org.junit.jupiter.params.provider;",
+            "public @interface MethodSource {",
+            "  String[] value();",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "import java.util.stream.Stream;",
+            "import org.junit.jupiter.params.provider.MethodSource;",
+            "class Test {",
+            "  @MethodSource(\"Test#parameters\")",
+            "  void test() {}",
+            "",
+            "",
+            "  private static Stream<String> parameters() {",
+            "    return Stream.of();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nestedQualifiedMethodSource() {
+    helper
+        .addSourceLines(
+            "MethodSource.java",
+            "package org.junit.jupiter.params.provider;",
+            "public @interface MethodSource {",
+            "  String[] value();",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "import java.util.stream.Stream;",
+            "import org.junit.jupiter.params.provider.MethodSource;",
+            "class Test {",
+            "  // @Nested",
+            "  public class NestedTest {",
+            "    @MethodSource(\"Test#parameters\")",
+            "    void test() {}",
+            "  }",
+            "",
+            "  private static Stream<String> parameters() {",
+            "    return Stream.of();",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
As mentioned in [the JUnit 5 docs](https://junit.org/junit5/docs/current/api/org.junit.jupiter.params/org/junit/jupiter/params/provider/MethodSource.html), the value within `@MethodSource` can be a fully-qualified name. This updates the code to handle this fact and adds some tests to try to flex it. The particular case we were hitting is the one with the `@Nested` test class using a parameter method in its parent.

