### PR TITLE
UnusedMethod: add additional exempting method annotations

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedMethod.java
@@ -78,15 +78,25 @@ public final class UnusedMethod extends BugChecker implements CompilationUnitTre
 
   private static final ImmutableSet<String> EXEMPTING_METHOD_ANNOTATIONS =
       ImmutableSet.of(
+          "com.fasterxml.jackson.annotation.JsonCreator",
           "com.google.inject.Provides",
           "com.google.inject.Inject",
           "com.google.inject.multibindings.ProvidesIntoMap",
           "com.google.inject.multibindings.ProvidesIntoSet",
           "javax.annotation.PreDestroy",
           "javax.annotation.PostConstruct",
-          "javax.persistence.PostLoad",
           "javax.inject.Inject",
-          "org.testng.annotations.DataProvider");
+          "javax.persistence.PostLoad",
+          "org.aspectj.lang.annotation.Pointcut",
+          "org.aspectj.lang.annotation.Before",
+          "org.springframework.context.annotation.Bean",
+          "org.testng.annotations.AfterClass",
+          "org.testng.annotations.AfterMethod",
+          "org.testng.annotations.BeforeClass",
+          "org.testng.annotations.BeforeMethod",
+          "org.testng.annotations.DataProvider",
+          "org.junit.AfterClass",
+          "org.junit.BeforeClass");
 
   /** The set of types exempting a type that is extending or implementing them. */
   private static final ImmutableSet<String> EXEMPTING_SUPER_TYPES = ImmutableSet.of();
@@ -176,7 +186,7 @@ public final class UnusedMethod extends BugChecker implements CompilationUnitTre
           return false;
         }
         // Assume the method is called if annotated with a called-reflectively annotation.
-        if (exemptedByAnnotation(tree.getModifiers().getAnnotations(), state)) {
+        if (exemptedByAnnotation(tree.getModifiers().getAnnotations())) {
           return false;
         }
         // Skip constructors and special methods.
@@ -307,8 +317,7 @@ public final class UnusedMethod extends BugChecker implements CompilationUnitTre
    * Looks at the list of {@code annotations} and see if there is any annotation which exists {@code
    * exemptingAnnotations}.
    */
-  private static boolean exemptedByAnnotation(
-      List<? extends AnnotationTree> annotations, VisitorState state) {
+  private static boolean exemptedByAnnotation(List<? extends AnnotationTree> annotations) {
     for (AnnotationTree annotation : annotations) {
       Type annotationType = getType(annotation);
       if (annotationType == null) {


### PR DESCRIPTION
While there, drop an unused parameter from a private method.