### PR TITLE
Add `getSymbols(Predicate, LookupKind)` compatibility method

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/ErrorProneScope.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ErrorProneScope.java
@@ -48,6 +48,11 @@ public final class ErrorProneScope {
     return (Iterable<Symbol>) invoke(getSymbols, maybeAsFilter(predicate));
   }
 
+  @SuppressWarnings("unchecked") // reflection
+  public Iterable<Symbol> getSymbols(Predicate<Symbol> predicate, LookupKind lookupKind) {
+    return (Iterable<Symbol>) invoke(getSymbolsLookupKind, maybeAsFilter(predicate), lookupKind);
+  }
+
   public boolean anyMatch(Predicate<Symbol> predicate) {
     return (boolean) invoke(anyMatch, maybeAsFilter(predicate));
   }
@@ -74,6 +79,8 @@ public final class ErrorProneScope {
       getImpl("getSymbolsByName", Name.class, Predicate.class, LookupKind.class);
 
   private static final Method getSymbols = getImpl("getSymbols", Predicate.class);
+
+  private static final Method getSymbolsLookupKind = getImpl("getSymbols", Predicate.class, LookupKind.class);
 
   private static Method getImpl(String name, Class<?>... parameters) {
     return FILTER_CLASS != null


### PR DESCRIPTION
Add a compatibility helper method for `getSymbols(Predicate<Symbol>, LookupKind)`.

**Context:**
In [gradle-baseline](https://github.com/palantir/gradle-baseline#baseline-error-prone-checks), we maintain our own set of error-prone rules and ran into similar JDK 17 compatibility problems as mentioned in https://github.com/google/error-prone/issues/2330.

However for our custom rules, we also need a compatibility helper for `getSymbols(Predicate, LookupKind)`. For now, we work around this by copying parts of the `ErrorProneScope` class ([PR](https://github.com/palantir/gradle-baseline/pull/1936)) but ideally we could reuse the existing helper and wouldn't have to maintain our own fork of this class.