### PR TITLE
Add support for specifying exemptPrefixes/exemptNames for UnusedVariable via flags

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedMethodTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedMethodTest.java
@@ -14,6 +14,7 @@
 
 package com.google.errorprone.bugpatterns;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
@@ -102,10 +103,18 @@ public final class UnusedMethodTest {
             "Unuseds.java",
             "package unusedvars;",
             "class ExemptedByName {",
-            "  private void unused1(int a, int unusedParam) {",
+            "  private void unused1(" +
+            "     int a, int unusedParam, " +
+            "     int customUnused1, int customUnused2, " +
+            "     int prefixUnused1Param, int prefixUnused2Param" +
+            "  ) {",
             "    int unusedLocal = a;",
             "  }",
             "}")
+        .setArgs(
+            "-XepOpt:Unused:exemptNames=customUnused1,customUnused2",
+            "-XepOpt:Unused:exemptPrefixes=prefixunused1,prefixunused2"
+        )
         .doTest();
   }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedVariableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedVariableTest.java
@@ -436,7 +436,15 @@ public class UnusedVariableTest {
             "  private int unusedInt;",
             "  private static final int UNUSED_CONSTANT = 5;",
             "  private int ignored;",
+            "  private int customUnused1;",
+            "  private int customUnused2;",
+            "  private int prefixUnused1Field;",
+            "  private int prefixUnused2Field;",
             "}")
+        .setArgs(
+            "-XepOpt:Unused:exemptNames=customUnused1,customUnused2",
+            "-XepOpt:Unused:exemptPrefixes=prefixunused1,prefixunused2"
+        )
         .doTest();
   }
 


### PR DESCRIPTION
In some cases projects have conventions about use of custom arguments/variables that are not meant to be deleted even if unused. One of such examples could be keeping an ORMs `Session session` argument in the method arguments signifying that the method happens within the boundaries of provided session and is doing calls to the underlying datastore.

This PR would allow to provide custom values for exemptPrefixes and exemptNames via error-prone flags.