### PR TITLE
UnnecessarilyFullyQualified: handle `java.lang` and inconsistent import usages

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualifiedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualifiedTest.java
@@ -28,6 +28,30 @@ public final class UnnecessarilyFullyQualifiedTest {
       BugCheckerRefactoringTestHelper.newInstance(UnnecessarilyFullyQualified.class, getClass());
 
   @Test
+  public void javaLang() {
+    helper
+        .addInputLines(
+            "Test.java",
+            "public class Test {",
+            "  @java.lang.Deprecated",
+            "  public java.lang.String foo(java.lang.String s) {",
+            "    java.lang.Integer i = 1;",
+            "    return s;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "public class Test {",
+            "  @Deprecated",
+            "  public String foo(String s) {",
+            "    Integer i = 1;",
+            "    return s;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void singleUse() {
     helper
         .addInputLines(
@@ -78,6 +102,28 @@ public final class UnnecessarilyFullyQualifiedTest {
             "  a.List bar();",
             "}")
         .expectUnchanged()
+        .doTest();
+  }
+
+  @Test
+  public void inconsistentImportUsage() {
+    helper
+        .addInputLines(
+            "Test.java",
+            "import java.util.List;",
+            "public class Test {",
+            "  public java.util.List foo(List list) {",
+            "    return list;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.util.List;",
+            "public class Test {",
+            "  public List foo(List list) {",
+            "    return list;",
+            "  }",
+            "}")
         .doTest();
   }
 


### PR DESCRIPTION
This introduces two improvements:
- Where possible `java.lang.SomeType` references are simplified to `SomeType`
  without introducing an associated `import` statement.
- References to `some.package.SomeType` are now also replaced with `SomeType`
  if said type is already imported and referenced by its simple name elsewhere
  in the compilation unit.