### PR TITLE
implement FormatString for Java 15 String#formatted

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatString.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatString.java
@@ -17,6 +17,7 @@
 package com.google.errorprone.bugpatterns.formatstring;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static com.google.errorprone.matchers.method.MethodMatchers.instanceMethod;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugPattern;
@@ -24,6 +25,7 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -33,14 +35,38 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
 @BugPattern(name = "FormatString", summary = "Invalid printf-style format string", severity = ERROR)
 public class FormatString extends BugChecker implements MethodInvocationTreeMatcher {
 
+  private static final Matcher<ExpressionTree> FORMATTED_METHOD = instanceMethod().onExactClass("java.lang.String").named("formatted");
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, final VisitorState state) {
-    ImmutableList<ExpressionTree> args = FormatStringUtils.formatMethodArguments(tree, state);
-    if (args.isEmpty()) {
-      return Description.NO_MATCH;
-    }
+    ImmutableList<ExpressionTree> args;
     MethodSymbol sym = ASTHelpers.getSymbol(tree);
     if (sym == null) {
+      return Description.NO_MATCH;
+    }
+
+    if (FORMATTED_METHOD.matches(tree, state)) {
+      /*
+         Java 15 and greater supports the formatted method on an instance of string. If found
+         then use the string value as the pattern and all-of-the arguments and send directly to
+         the validate method.
+       */
+      ExpressionTree receiver = ASTHelpers.getReceiver(tree);
+      if (receiver == null) {
+        // an unqualified call to 'formatted', possibly inside the definition
+        // of java.lang.String
+        return Description.NO_MATCH;
+      }
+      args =
+          ImmutableList.<ExpressionTree>builder()
+              .add(receiver)
+              .addAll(tree.getArguments())
+              .build();
+
+    } else {
+      args = FormatStringUtils.formatMethodArguments(tree, state);
+    }
+    if (args.isEmpty()) {
       return Description.NO_MATCH;
     }
     FormatStringValidation.ValidationResult result =

--- a/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringTest.java
@@ -365,4 +365,47 @@ public class FormatStringTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void stringFormattedNegativeCase() {
+    assumeTrue(RuntimeVersion.isAtLeast15());
+    compilationHelper
+            .addSourceLines(
+                    "Test.java",
+                    "class Test {",
+                    "  void f() {",
+                    "    \"%s %s\".formatted(\"foo\", \"baz\");",
+                    "  }",
+                    "}")
+            .doTest();
+  }
+
+  @Test
+  public void stringFormattedPositiveCase() {
+    assumeTrue(RuntimeVersion.isAtLeast15());
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void f() {",
+            "    // BUG: Diagnostic contains: missing argument for format specifier",
+            "    \"%s %s %s\".formatted(\"foo\", \"baz\");",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void nonConstantStringFormattedNegativeCase() {
+    assumeTrue(RuntimeVersion.isAtLeast15());
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void f(String f) {",
+            "    f.formatted(\"foo\", \"baz\");",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
Here is an initial pass at an implementation for java 15 and up String.formatted

What I'm doing here is detecting early that this is a formatted call on a string instance and just grabbing the value and all of the arguments and sending them directly to a new validate method.

The old validate method is renamed prepareAndValidate and does the work of extracting the pattern and arguments from the argument this for your traditional String#format calls

fixes #2726