### PR TITLE
intellij project files update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # intellij
 .idea/ant.xml
+/.idea/codestream.xml
 .idea/codeStyleSettings.xml
 .idea/compiler.xml
 .idea/copyright

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 
 # intellij
 .idea/ant.xml
-/.idea/codestream.xml
+.idea/codestream.xml
 .idea/codeStyleSettings.xml
 .idea/compiler.xml
 .idea/copyright

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -13,12 +13,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-    <mapping directory="$USER_HOME$/maven/maven-plugins/maven-shade-plugin" vcs="svn" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>
-


### PR DESCRIPTION
Current versions of Intellij are failing to parse the current vcs.xml file as it has a comment before the optional xml declaration.

![image](https://user-images.githubusercontent.com/217262/148092170-f45c06bc-d79a-40d4-878e-04d146d04648.png)

I've updated that to not complain as well as added another entry for the .gitignore for a common intellij plugin. This should make it easier for contributors to open the project. Currently on a fresh clone you get a dirty vcs.xml file.