### PR TITLE
Make `SuggestedFixes.updateAnnotationArgumentValues` JDK 17-compatible

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -1143,9 +1143,12 @@ public final class SuggestedFixes {
       return SuggestedFix.builder()
           .replace(
               annotation,
-              annotation
-                  .toString()
-                  .replaceFirst("\\(\\)", "(" + parameterPrefix + newArgument(newValues) + ")"));
+              '@'
+                  + annotation.getAnnotationType().toString()
+                  + '('
+                  + parameterPrefix
+                  + newArgument(newValues)
+                  + ')');
     }
     Optional<ExpressionTree> maybeExistingArgument = findArgument(annotation, parameterName);
     if (!maybeExistingArgument.isPresent()) {

--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -1062,7 +1062,7 @@ public final class SuggestedFixes {
       return;
     }
     fixBuilder.merge(
-        updateAnnotationArgumentValues(suppressAnnotationTree, "value", newWarningSet));
+        updateAnnotationArgumentValues(suppressAnnotationTree, "value", newWarningSet, state));
   }
 
   private static List<? extends AnnotationTree> findAnnotationsTree(Tree tree) {
@@ -1137,14 +1137,17 @@ public final class SuggestedFixes {
    * <p>N.B.: {@code newValues} are source-code strings, not string literal values.
    */
   public static SuggestedFix.Builder updateAnnotationArgumentValues(
-      AnnotationTree annotation, String parameterName, Collection<String> newValues) {
+      AnnotationTree annotation,
+      String parameterName,
+      Collection<String> newValues,
+      VisitorState state) {
     if (annotation.getArguments().isEmpty()) {
       String parameterPrefix = parameterName.equals("value") ? "" : (parameterName + " = ");
       return SuggestedFix.builder()
           .replace(
               annotation,
               '@'
-                  + annotation.getAnnotationType().toString()
+                  + state.getSourceForNode(annotation.getAnnotationType())
                   + '('
                   + parameterPrefix
                   + newArgument(newValues)

--- a/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4TestsNotRunWithinEnclosed.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/JUnit4TestsNotRunWithinEnclosed.java
@@ -92,7 +92,8 @@ public final class JUnit4TestsNotRunWithinEnclosed extends BugChecker
                                 getAnnotationWithSimpleName(
                                     classTree.getModifiers().getAnnotations(), "RunWith"),
                                 "value",
-                                ImmutableList.of(junit4 + ".class")))
+                                ImmutableList.of(junit4 + ".class"),
+                                state))
                         .build()));
           }
         }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/SuppressWarningsDeprecated.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/SuppressWarningsDeprecated.java
@@ -67,6 +67,7 @@ public class SuppressWarningsDeprecated extends BugChecker implements Annotation
 
     return describeMatch(
         annotationTree,
-        SuggestedFixes.updateAnnotationArgumentValues(annotationTree, "value", values).build());
+        SuggestedFixes.updateAnnotationArgumentValues(annotationTree, "value", values, state)
+            .build());
   }
 }

--- a/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
+++ b/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
@@ -33,6 +33,7 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.AnnotationTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.LiteralTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
@@ -45,6 +46,7 @@ import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.doctree.LinkTree;
+import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LambdaExpressionTree;
@@ -1210,6 +1212,39 @@ public class SuggestedFixesTest {
             "out/Test.java",
             "public class Test {",
             "  @SuppressWarnings(value=\"KeepMe\") int BEST = 42;",
+            "}")
+        .doTest(TestMode.AST_MATCH);
+  }
+
+  /** A {@link BugChecker} for testing. */
+  @BugPattern(name = "UpdateDoNotCallArgument", summary = "", severity = ERROR)
+  public static final class UpdateDoNotCallArgumentChecker extends BugChecker
+      implements AnnotationTreeMatcher {
+    @Override
+    public Description matchAnnotation(AnnotationTree tree, VisitorState state) {
+      SuggestedFix.Builder fixBuilder =
+          SuggestedFixes.updateAnnotationArgumentValues(tree, "value", ImmutableList.of("\"Danger\""));
+      return describeMatch(tree, fixBuilder.build());
+    }
+  }
+
+  @Test
+  public void updateAnnotationArgumentValues_noArguments() {
+    BugCheckerRefactoringTestHelper refactorTestHelper =
+        BugCheckerRefactoringTestHelper.newInstance(
+            UpdateDoNotCallArgumentChecker.class, getClass());
+    refactorTestHelper
+        .addInputLines(
+            "in/Test.java",
+            "import com.google.errorprone.annotations.DoNotCall;",
+            "public class Test {",
+            "  @DoNotCall void m() {}",
+            "}")
+        .addOutputLines(
+            "out/Test.java",
+            "import com.google.errorprone.annotations.DoNotCall;",
+            "public class Test {",
+            "  @DoNotCall(\"Danger\") void m() {}",
             "}")
         .doTest(TestMode.AST_MATCH);
   }

--- a/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
+++ b/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
@@ -1223,7 +1223,8 @@ public class SuggestedFixesTest {
     @Override
     public Description matchAnnotation(AnnotationTree tree, VisitorState state) {
       SuggestedFix.Builder fixBuilder =
-          SuggestedFixes.updateAnnotationArgumentValues(tree, "value", ImmutableList.of("\"Danger\""));
+          SuggestedFixes.updateAnnotationArgumentValues(
+              tree, "value", ImmutableList.of("\"Danger\""), state);
       return describeMatch(tree, fixBuilder.build());
     }
   }


### PR DESCRIPTION
When running Java 17, `AnnotationTree#toString()` omits parentheses if
the annotation tree does not contain any arguments. With this change
`#updateAnnotationArgumentValues` no longer relies on the unconditional
presence of such parentheses.