### PR TITLE
Bump more deps.

### DIFF
--- a/check_api/pom.xml
+++ b/check_api/pom.xml
@@ -86,7 +86,7 @@
       <!-- BSD New (3 clause) -->
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
+      <version>2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -172,28 +172,28 @@
       <!-- Apache 2.0 -->
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>5.0.1</version>
+      <version>5.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <!-- Apache 2.0 -->
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-assistedinject</artifactId>
-      <version>5.0.1</version>
+      <version>5.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <!-- Apache 2.0 -->
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-servlet</artifactId>
-      <version>5.0.1</version>
+      <version>5.1.0</version>
       <scope>test</scope>
     </dependency>
       <!-- Apache 2.0 -->
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-testlib</artifactId>
-      <version>5.0.1</version>
+      <version>5.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -290,7 +290,7 @@
       <!-- Apache 2.0 -->
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.1.73.Final</version>
+      <version>5.0.0.Alpha2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This is *almost* everything surfaced by a command like the one I used for some of our libraries, as in CL 348090041:

```
( for F in $(find -name pom.xml); do ( mvn org.codehaus.mojo:versions-maven-plugin:2.8.1:update-properties org.codehaus.mojo:versions-maven-plugin:2.8.1:use-latest-releases -f $F -DgenerateBackupPoms=false ); done )
```

Note that this covers *dependencies* but not *plugins*.

Note also that I had to revert some updates because of breakages:

- EasyMock
- Hamcrest
- test-parameter-injector because it transitively updated protobuf
- conceivably other things that I've forgotten