### PR TITLE
Disallowing extension of Throwable

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassExtendsThrowable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassExtendsThrowable.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.Tree;
+
+/**
+ * Bug checker to detect usage of {@code extends throwable;}.
+ */
+@BugPattern(
+        name = "ClassExtendsThrowable",
+        summary = "Class should not extend throwable. Extend Exception or RuntimeException instead.",
+        severity = SeverityLevel.WARNING)
+public class ClassExtendsThrowable extends BugChecker implements ClassTreeMatcher {
+
+
+        @Override
+        public Description matchClass(ClassTree tree, VisitorState state) {
+
+                // Gets whatever the class is an extension of
+                Tree extendsClause = tree.getExtendsClause();
+
+                if (extendsClause == null) {
+                        // Doesn't extend anything, can't possibly be a violation.
+                        return Description.NO_MATCH;
+                } else if (extendsClause.toString().equals("Throwable")) {
+                        return buildDescription(tree).build();
+                }
+                return Description.NO_MATCH;
+        }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassExtendsThrowable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassExtendsThrowable.java
@@ -29,7 +29,7 @@ import com.sun.source.tree.Tree;
  */
 @BugPattern(
         name = "ClassExtendsThrowable",
-        summary = "Class should not extend throwable. Extend Exception or RuntimeException instead.",
+        summary = "Bad practise to extend throwable, extend Exception, Error, or RuntimeException instead.",
         severity = SeverityLevel.WARNING)
 public class ClassExtendsThrowable extends BugChecker implements ClassTreeMatcher {
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ClassExtendsThrowableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ClassExtendsThrowableTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** {@link ClassCanBeStatic}Test */
+@RunWith(JUnit4.class)
+public class ClassExtendsThrowableTest {
+
+    private final CompilationTestHelper compilationHelper =
+            CompilationTestHelper.newInstance(ClassExtendsThrowable.class, getClass());
+
+    @Test
+    public void testPositiveCases() {
+        compilationHelper.addSourceFile("ClassExtendsThrowablePositiveCases.java").doTest();
+    }
+
+    @Test
+    public void testNegativeCases() {
+        compilationHelper.addSourceFile("ClassExtendsThrowableNegativeCases.java").doTest();
+    }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ClassExtendsThrowableNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ClassExtendsThrowableNegativeCases.java
@@ -16,6 +16,8 @@
 
 package com.google.errorprone.bugpatterns.testdata;
 
+import java.util.List;
+
 // Exception extends Throwable but should be accepted.
 public class ClassExtendsThrowableNegativeCases extends Exception{
 
@@ -29,4 +31,12 @@ public class ClassExtendsThrowableNegativeCases extends Exception{
 
     // Error extends Throwable but should be accepted.
     private class ExtendException extends Error {}
+
+    // Class for testing extending other classes.
+    public class ClassToExtend  {}
+
+    // Extending an arbitrary class, should be accepted.
+    public class ExtendArbitraryClass extends ClassToExtend {}
 }
+
+

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ClassExtendsThrowableNegativeCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ClassExtendsThrowableNegativeCases.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+// Exception extends Throwable but should be accepted.
+public class ClassExtendsThrowableNegativeCases extends Exception{
+
+    public int ClassExtendsThrowablePositiveCases()    {
+        return 0;
+    }
+
+    public int test(int ignore)    {
+        return ignore;
+    }
+
+    // Error extends Throwable but should be accepted.
+    private class ExtendException extends Error {}
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ClassExtendsThrowablePositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ClassExtendsThrowablePositiveCases.java
@@ -16,7 +16,7 @@
 
 package com.google.errorprone.bugpatterns.testdata;
 
-// BUG: Diagnostic contains: Class should not extend throwable. Extend Exception or RuntimeException instead.
+// BUG: Diagnostic contains: Bad practise to extend throwable, extend Exception, Error, or RuntimeException instead.
 public class ClassExtendsThrowablePositiveCases extends Throwable{
 
     public int ClassExtendsThrowablePositiveCases()    {
@@ -27,7 +27,7 @@ public class ClassExtendsThrowablePositiveCases extends Throwable{
         return ignore;
     }
 
-    // BUG: Diagnostic contains: Class should not extend throwable. Extend Exception or RuntimeException instead.
+    // BUG: Diagnostic contains: Bad practise to extend throwable, extend Exception, Error, or RuntimeException instead.
     private class extendThrowable extends Throwable {
         private int ignore;
     }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ClassExtendsThrowablePositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ClassExtendsThrowablePositiveCases.java
@@ -16,7 +16,7 @@
 
 package com.google.errorprone.bugpatterns.testdata;
 
-// BUG: Diagnostic contains: ClassExtendsThrowable
+// BUG: Diagnostic contains: Class should not extend throwable. Extend Exception or RuntimeException instead.
 public class ClassExtendsThrowablePositiveCases extends Throwable{
 
     public int ClassExtendsThrowablePositiveCases()    {
@@ -27,7 +27,7 @@ public class ClassExtendsThrowablePositiveCases extends Throwable{
         return ignore;
     }
 
-    // BUG: Diagnostic contains: ClassExtendsThrowable
+    // BUG: Diagnostic contains: Class should not extend throwable. Extend Exception or RuntimeException instead.
     private class extendThrowable extends Throwable {
         private int ignore;
     }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ClassExtendsThrowablePositiveCases.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/testdata/ClassExtendsThrowablePositiveCases.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.testdata;
+
+// BUG: Diagnostic contains: ClassExtendsThrowable
+public class ClassExtendsThrowablePositiveCases extends Throwable{
+
+    public int ClassExtendsThrowablePositiveCases()    {
+        return 0;
+    }
+
+    public int test(int ignore)   {
+        return ignore;
+    }
+
+    // BUG: Diagnostic contains: ClassExtendsThrowable
+    private class extendThrowable extends Throwable {
+        private int ignore;
+    }
+}

--- a/docs/bugpattern/ClassExtendsThrowable.md
+++ b/docs/bugpattern/ClassExtendsThrowable.md
@@ -1,0 +1,11 @@
+A class should not be an extension of the Throwable type. 
+It violates the principle of least surprise in that systems 
+should behave as most users expect it to. Extend Exception 
+or Error instead.
+
+The following example would trigger the check, warning the user of the usage of `extends Throwable`
+```java
+    public class ClassExtendsThrowable extends Throwable{
+        public int returnsZero(){return 0;}
+    }
+```


### PR DESCRIPTION
A small check warning users when extending throwable. Should close #167. 