### PR TITLE
Clarify Maven configuration

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,7 +46,7 @@ Edit your `pom.xml` file to add settings to the maven-compiler-plugin:
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.10.1</version>
         <configuration>
           <source>8</source>
           <target>8</target>
@@ -73,10 +73,26 @@ Edit your `pom.xml` file to add settings to the maven-compiler-plugin:
   </build>
 ```
 
-Add the following `--add-exports` and `add-opens` flags to
-[.mvn/jvm.config](https://maven.apache.org/configure.html#mvn-jvm-config-file)
-file which are required on JDK 16 and newer due to
-[JEP 396: Strongly Encapsulate JDK Internals by Default](https://openjdk.java.net/jeps/396):
+On JDK 16 and newer, additional flags are required due to
+[JEP 396: Strongly Encapsulate JDK Internals by Default](https://openjdk.java.net/jeps/396).
+
+If your `maven-compiler-plugin` uses an external executable, e.g. because `<fork>` is `true` or because the `maven-toolchains-plugin` is enabled,
+add the following under `compilerArgs` in the configuration above:
+
+```xml
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+```
+
+Otherwise, add the following to the [.mvn/jvm.config](https://maven.apache.org/configure.html#mvn-jvm-config-file) file:
 
 ```
 --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED


### PR DESCRIPTION
The current way of using `.mvn/jvm.config` only works if the `maven-compiler-plugin` doesn't use an external executable.
The [previous](https://github.com/google/error-prone/pull/2788/files#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56) way of using `compilerArgs` only works if the `maven-compiler-plugin` *does* use an external executable.

So both ways should be documented, such that users can select the way that works for their Maven setup.
Also note that setting `fork` to `true` is just one way to get the `maven-compiler-plugin` to use an external executable. Enabling the `maven-toolchains-plugin` is another.

PS: not sure whether I should create an issue for this, or if this can go under https://github.com/google/error-prone/issues/2786?