### PR TITLE
ImmutableChecker handles null types

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableCheckerTest.java
@@ -16,11 +16,14 @@
 
 package com.google.errorprone.bugpatterns.threadsafety;
 
+import static org.junit.Assume.assumeTrue;
+
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Immutable;
 import com.google.errorprone.annotations.concurrent.LazyInit;
+import com.google.errorprone.util.RuntimeVersion;
 import java.util.Arrays;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -2965,6 +2968,29 @@ public class ImmutableCheckerTest {
             "        return 0;",
             "      }",
             "    });",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void switchExpressionsResultingInGenericTypes_doesNotThrow() {
+    assumeTrue(RuntimeVersion.isAtLeast14());
+    compilationHelper
+        .addSourceLines(
+            "Kind.java",
+            "import com.google.errorprone.annotations.Immutable;",
+            "@Immutable enum Kind { A, B; }")
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Optional;",
+            "import java.util.function.Supplier;",
+            "class Test {",
+            "  Supplier<Optional<String>> test(Kind kind) {",
+            "    return switch (kind) {",
+            "      case A -> Optional::empty;",
+            "      case B -> () -> Optional.of(\"\");",
+            "    };",
             "  }",
             "}")
         .doTest();


### PR DESCRIPTION
`ASTHelpers#getType(ClassTree)` and `ASTHelpers#targetType(VisitorState)` both may return null, which ImmutableChecker did not previously handle safely, which could lead to `NullPointerException` in cases such as switch expressions. This PR handles these potential `null` results more safely.

Fixes #3220 & #3225 