### PR TITLE
Fix `-XepDisableAllWarnings` flag when passed on its own

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/scanner/ScannerSupplier.java
+++ b/check_api/src/main/java/com/google/errorprone/scanner/ScannerSupplier.java
@@ -143,7 +143,8 @@ public abstract class ScannerSupplier implements Supplier<Scanner> {
         && errorProneOptions.getFlags().isEmpty()
         && !errorProneOptions.isEnableAllChecksAsWarnings()
         && !errorProneOptions.isDropErrorsToWarnings()
-        && !errorProneOptions.isDisableAllChecks()) {
+        && !errorProneOptions.isDisableAllChecks()
+        && !errorProneOptions.isDisableAllWarnings()) {
       return this;
     }
 


### PR DESCRIPTION
Without this change, the flag would not work when passed as the single Error Prone argument.  Not sure how to add a regression test for this, but the fix works locally.