### PR TITLE
Rename class to match filename

### DIFF
--- a/core/src/test/java/com/google/errorprone/refaster/testdata/template/UnnecessaryLambdaParens.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/template/UnnecessaryLambdaParens.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class UnnecessaryLambdaParen<T> {
+public class UnnecessaryLambdaParens<T> {
   @BeforeTemplate
   Optional<T> last(Stream<T> stream) {
     return stream.map((x) -> x).collect(Collectors.reducing((a, b) -> b));


### PR DESCRIPTION
The name of this public class should match the filename. 