### PR TITLE
Fix edge case in NonCanonicalType

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/NonCanonicalType.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NonCanonicalType.java
@@ -122,6 +122,7 @@ public final class NonCanonicalType extends BugChecker implements MemberSelectTr
   private static String getNonCanonicalName(ExpressionTree tree) {
     switch (tree.getKind()) {
       case IDENTIFIER:
+      case PARAMETERIZED_TYPE:
         return getSymbol(tree).getQualifiedName().toString();
       case MEMBER_SELECT:
         MemberSelectTree memberSelectTree = (MemberSelectTree) tree;
@@ -133,7 +134,7 @@ public final class NonCanonicalType extends BugChecker implements MemberSelectTr
             + "."
             + memberSelectTree.getIdentifier();
       default:
-        throw new AssertionError();
+        throw new AssertionError(tree.getKind());
     }
   }
 }


### PR DESCRIPTION
This check was throwing an `AssertionError` on a project I contribute to.

```java
  static <T> EventChannel<T> createAsync(
      final Class<T> channelInterface,
      final ExecutorService executor,
      final ChannelExceptionHandler exceptionHandler,
      final MetricsSystem metricsSystem) {
    return create(
        channelInterface, new AsyncEventDeliverer<>(executor, exceptionHandler, metricsSystem));
  }
```

A few debugging prints showed me that the tree kind was `PARAMETERIZED_TYPE` which was unhandled:

```
Kind: PARAMETERIZED_TYPE
Tree: tech.pegasys.teku.infrastructure.events.AsyncEventDeliverer<T>
```

This fix is to handle that case. I added `tree.getKind()` to the exception message in case this happens again.

Fixes #3532.