### PR TITLE
Avoid ambiguous imports with `@UseImportPolicy(STATIC_IMPORT_ALWAYS)`

### DIFF
--- a/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
@@ -374,4 +374,9 @@ public class TemplateIntegrationTest extends CompilerBasedTest {
   public void typeArgumentsMethodInvocation() throws IOException {
     runTest("TypeArgumentsMethodInvocationTemplate");
   }
+
+  @Test
+  public void staticImportClash() throws IOException {
+    runTest("StaticImportClashTemplate");
+  }
 }

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/input/StaticImportClashTemplateExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/input/StaticImportClashTemplateExample.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+import static java.util.Collections.reverseOrder;
+
+import java.util.Comparator;
+
+/** Test data for {@code StaticImportClashTemplate}. */
+public class StaticImportClashTemplate {
+  Comparator<Integer> example() {
+    return reverseOrder();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/output/StaticImportClashTemplateExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/output/StaticImportClashTemplateExample.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+import static java.util.Collections.reverseOrder;
+
+import java.util.Comparator;
+
+/** Test data for {@code StaticImportClashTemplate}. */
+public class StaticImportClashTemplate {
+  Comparator<Integer> example() {
+    return Comparator.reverseOrder();
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/template/StaticImportClashTemplate.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/template/StaticImportClashTemplate.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.errorprone.refaster.testdata.template;
+
+import static java.util.Comparator.reverseOrder;
+
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Collections;
+import java.util.Comparator;
+
+/** Example template that may cause a static import clash. */
+final class StaticImportClashTemplate<T extends Comparable<? super T>> {
+  @BeforeTemplate
+  Comparator<T> before() {
+    return Collections.reverseOrder();
+  }
+
+  @AfterTemplate
+  @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+  Comparator<T> after() {
+    return reverseOrder();
+  }
+}


### PR DESCRIPTION
These changes prevent Refaster rules from introducing a static import that
conflicts with an existing static import. Without these changes the new test
case fails with the following error:

```
com/google/errorprone/refaster/testdata/StaticImportClashTemplate.java:27: error: reference to reverseOrder is ambiguous
    return reverseOrder();
           ^
  both method <T>reverseOrder() in java.util.Comparator and method <T>reverseOrder() in java.util.Collections match
```