### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,15 @@ on:
     branches:
     - master
 
+permissions:
+  contents: read #  to fetch code (actions/checkout)
+
 jobs:
   test:
+    permissions:
+      actions: write #  to cancel/stop running workflows (styfle/cancel-workflow-action)
+      contents: read #  to fetch code (actions/checkout)
+
     name: "JDK ${{ matrix.java }} on ${{ matrix.os }}"
     strategy:
       fail-fast: false
@@ -79,6 +86,9 @@ jobs:
         run: mvn source:jar deploy -B -DskipTests=true -Dinvoker.skip=true -Dmaven.javadoc.skip=true
 
   generate_docs:
+    permissions:
+      contents: write #  for git push
+
     name: 'Generate latest docs'
     needs: test
     if: github.event_name == 'push' && github.repository == 'google/error-prone' && github.ref == 'refs/heads/master'


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.