### PR TITLE
Generate patch also when replacements overlap

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/apply/SourceFile.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/SourceFile.java
@@ -197,12 +197,14 @@ public class SourceFile {
           repl.endPosition(),
           sourceBuilder.length());
 
-      // Write the unmodified content leading up to this change
-      newContent.append(sourceBuilder, positionInOriginal, repl.startPosition());
-      // And the modified content for this change
-      newContent.append(repl.replaceWith());
-      // Then skip everything from source between start and end
-      positionInOriginal = repl.endPosition();
+      if (repl.startPosition() >= positionInOriginal) {
+        // Write the unmodified content leading up to this change
+        newContent.append(sourceBuilder, positionInOriginal, repl.startPosition());
+        // And the modified content for this change
+        newContent.append(repl.replaceWith());
+        // Then skip everything from source between start and end
+        positionInOriginal = repl.endPosition();
+      }
     }
     // Flush out any remaining content after the final change
     newContent.append(sourceBuilder, positionInOriginal, sourceBuilder.length());


### PR DESCRIPTION
If two checkers produce overlapping changes it would throw an exception when doing `StringBuffer.append()` with the end result that no patch file would be generated at all.

This fix makes use of the last end location and will drop replacements ahead of it, ensuring that it gets output.

The situation where I ran into this issue was using both `MathRoundIntLong` and `LongFloatConversion` checkers which wanted to alter the same location.

Example:
```
import java.awt.*;

    public void doStuff(long val1, long val2, int val3) {
        // long to float conversion implicit https://errorprone.info/bugpattern/LongFloatConversion
        Color temp =  new Color(Math.round(val1), Math.round(val2), Math.round(val3));
    }
```