### PR TITLE
StatementSwitchToExpressionSwitch: handle empty statement blocks

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/StatementSwitchToExpressionSwitch.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StatementSwitchToExpressionSwitch.java
@@ -122,7 +122,7 @@ public final class StatementSwitchToExpressionSwitch extends BugChecker
 
       List<? extends StatementTree> statements = caseTree.getStatements();
       CaseFallThru caseFallThru = CaseFallThru.MAYBE_FALLS_THRU;
-      if (statements.isEmpty()) {
+      if (statements == null || statements.isEmpty()) {
         // If the code for this case is just an empty block, then it must fall thru
         caseFallThru = CaseFallThru.DEFINITELY_DOES_FALL_THRU;
         // Can group with the next case (unless this is the last case)

--- a/core/src/test/java/com/google/errorprone/bugpatterns/StatementSwitchToExpressionSwitchTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/StatementSwitchToExpressionSwitchTest.java
@@ -1017,6 +1017,23 @@ public final class StatementSwitchToExpressionSwitchTest {
   }
 
   @Test
+  public void emptySwitchCases_noMatch() {
+    assumeTrue(RuntimeVersion.isAtLeast14());
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void foo(int value) { ",
+            "    switch (value) {",
+            "      case 0 -> {}",
+            "      default -> {}",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void dynamicWithThrowableDuringInitializationFromMethod_noMatch() {
     assumeTrue(RuntimeVersion.isAtLeast14());
     helper


### PR DESCRIPTION
Fixes #3638.