### PR TITLE
Fix Finalize bugpattern to match protected finalize()

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/Finalize.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Finalize.java
@@ -27,7 +27,7 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.MethodTree;
-import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import java.util.Set;
 import javax.lang.model.element.Modifier;
 
 /** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
@@ -45,8 +45,8 @@ public class Finalize extends BugChecker implements MethodTreeMatcher {
     if (!isVoidType(getType(tree.getReturnType()), state)) {
       return NO_MATCH;
     }
-    MethodSymbol sym = getSymbol(tree);
-    if (!sym.getModifiers().contains(Modifier.PUBLIC)) {
+    Set<Modifier> modifiers = getSymbol(tree).getModifiers();
+    if (!modifiers.contains(Modifier.PROTECTED) && !modifiers.contains(Modifier.PUBLIC)) {
       return NO_MATCH;
     }
     return describeMatch(tree);

--- a/core/src/test/java/com/google/errorprone/bugpatterns/FinalizeTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/FinalizeTest.java
@@ -34,7 +34,7 @@ public class FinalizeTest {
             "Test.java",
             "class Test {",
             "  // BUG: Diagnostic contains: Do not override finalize",
-            "  public void finalize() {}",
+            "  protected void finalize() {}",
             "  interface A {",
             "    // BUG: Diagnostic contains: Do not override finalize",
             "    void finalize();",


### PR DESCRIPTION
Object#finalize() is protected, but the Finalize bugpattern would only find overridden PUBLIC finalizers. Fix it to look for protected methods too. The example finalizer in the Object#finalize() javadocs is protected, previously it would not be matched.

https://docs.oracle.com/javase/9/docs/api/java/lang/Object.html#finalize--