### PR TITLE
ClassCanBeStatic: Exclude JUnit `@Nested` classes

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -1041,7 +1041,9 @@ public class ASTHelpers {
    * though they are.
    */
   private static final ImmutableSet<String> ANNOTATIONS_CONSIDERED_KEEP =
-      ImmutableSet.of("org.apache.beam.sdk.transforms.DoFn.ProcessElement");
+      ImmutableSet.of(
+          "org.apache.beam.sdk.transforms.DoFn.ProcessElement",
+          "org.junit.jupiter.api.Nested");
 
   private static final String USED_REFLECTIVELY = "UsedReflectively";
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassCanBeStatic.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassCanBeStatic.java
@@ -43,6 +43,7 @@ import javax.lang.model.element.NestingKind;
     tags = {StandardTags.STYLE, StandardTags.PERFORMANCE})
 public class ClassCanBeStatic extends BugChecker implements ClassTreeMatcher {
 
+  private static final String JUNIT_NESTED_ANNOTATION = "org.junit.jupiter.api.Nested";
   private static final String REFASTER_ANNOTATION =
       "com.google.errorprone.refaster.annotation.BeforeTemplate";
 
@@ -75,6 +76,9 @@ public class ClassCanBeStatic extends BugChecker implements ClassTreeMatcher {
       return NO_MATCH;
     }
     if (CanBeStaticAnalyzer.referencesOuter(tree, currentClass, state)) {
+      return NO_MATCH;
+    }
+    if (hasAnnotation(currentClass, JUNIT_NESTED_ANNOTATION, state)) {
       return NO_MATCH;
     }
     if (tree.getMembers().stream().anyMatch(m -> hasAnnotation(m, REFASTER_ANNOTATION, state))) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassCanBeStatic.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassCanBeStatic.java
@@ -43,7 +43,6 @@ import javax.lang.model.element.NestingKind;
     tags = {StandardTags.STYLE, StandardTags.PERFORMANCE})
 public class ClassCanBeStatic extends BugChecker implements ClassTreeMatcher {
 
-  private static final String JUNIT_NESTED_ANNOTATION = "org.junit.jupiter.api.Nested";
   private static final String REFASTER_ANNOTATION =
       "com.google.errorprone.refaster.annotation.BeforeTemplate";
 
@@ -78,7 +77,7 @@ public class ClassCanBeStatic extends BugChecker implements ClassTreeMatcher {
     if (CanBeStaticAnalyzer.referencesOuter(tree, currentClass, state)) {
       return NO_MATCH;
     }
-    if (hasAnnotation(currentClass, JUNIT_NESTED_ANNOTATION, state)) {
+    if (ASTHelpers.shouldKeep(tree)) {
       return NO_MATCH;
     }
     if (tree.getMembers().stream().anyMatch(m -> hasAnnotation(m, REFASTER_ANNOTATION, state))) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ClassCanBeStaticTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ClassCanBeStaticTest.java
@@ -401,4 +401,28 @@ public class ClassCanBeStaticTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void junitNestedClass() {
+    compilationHelper
+        .addSourceLines(
+            "Nested.java",
+            "package org.junit.jupiter.api;",
+            "import java.lang.annotation.ElementType;",
+            "import java.lang.annotation.Retention;",
+            "import java.lang.annotation.RetentionPolicy;",
+            "import java.lang.annotation.Target;",
+            "@Target(ElementType.TYPE)",
+            "@Retention(RetentionPolicy.RUNTIME)",
+            "public @interface Nested {}")
+        .addSourceLines(
+            "A.java",
+            "import org.junit.jupiter.api.Nested;",
+            "public class A {",
+            "  @Nested class Inner {",
+            "    void f() {}",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
Exclude inner classes annotated with JUnit's `@Nested` annotation from the `ClassCanBeStatic` check. JUnit requires them to not be `static`.

From the [JUnit docs](https://junit.org/junit5/docs/current/user-guide/#writing-tests-nested):

> Only non-static nested classes (i.e. inner classes) can serve as `@Nested` test classes.

Fixes #956.