### PR TITLE
refactor: refactor bad smell ToArrayCallWithZeroLengthArrayArgument

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
@@ -97,7 +97,7 @@ public class ErrorProneOptions {
     DEFAULT, // whatever is specified in the @BugPattern annotation
     OFF,
     WARN,
-    ERROR;
+    ERROR
   }
 
   @AutoValue

--- a/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneOptions.java
@@ -97,7 +97,7 @@ public class ErrorProneOptions {
     DEFAULT, // whatever is specified in the @BugPattern annotation
     OFF,
     WARN,
-    ERROR
+    ERROR;
   }
 
   @AutoValue
@@ -202,7 +202,7 @@ public class ErrorProneOptions {
   }
 
   public String[] getRemainingArgs() {
-    return remainingArgs.toArray(new String[remainingArgs.size()]);
+    return remainingArgs.toArray(new String[0]);
   }
 
   public ImmutableMap<String, Severity> getSeverityMap() {


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## ToArrayCallWithZeroLengthArrayArgument
The performance of the empty array version is the same, and sometimes even better, compared
to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or
synchronized collection as a data race is possible between the <code>size</code> and <code>toArray</code>
calls. This may result in extra <code>null</code>s at the end of the array if the collection was concurrently
shrunk during the operation.</p>
See https://shipilev.net/blog/2016/arrays-wisdom-ancients/ for more details.

<!-- fingerprint:-980296465 -->
# Repairing Code Style Issues
* ToArrayCallWithZeroLengthArrayArgument (1)