### PR TITLE
Make MemoizeConstantVisitorStateLookups check suppressible

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/MemoizeConstantVisitorStateLookups.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MemoizeConstantVisitorStateLookups.java
@@ -42,7 +42,6 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
-import com.sun.source.util.TreeScanner;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
@@ -157,9 +156,9 @@ public class MemoizeConstantVisitorStateLookups extends BugChecker
     }
   }
 
-  private static ImmutableList<CallSite> findConstantLookups(ClassTree tree, VisitorState state) {
+  private ImmutableList<CallSite> findConstantLookups(ClassTree tree, VisitorState state) {
     ImmutableList.Builder<CallSite> result = ImmutableList.builder();
-    new TreeScanner<Void, Void>() {
+    new SuppressibleTreePathScanner<Void, Void>(state) {
       @Override
       public Void visitMethodInvocation(MethodInvocationTree tree, Void unused) {
         if (CONSTANT_LOOKUP.matches(tree, state)) {
@@ -186,7 +185,7 @@ public class MemoizeConstantVisitorStateLookups extends BugChecker
           }
         }
       }
-    }.scan(tree, null);
+    }.scan(state.getPath(), null);
     return result.build();
   }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MemoizeConstantVisitorStateLookupsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MemoizeConstantVisitorStateLookupsTest.java
@@ -164,7 +164,7 @@ public class MemoizeConstantVisitorStateLookupsTest {
   }
 
   @Test
-  public void testSuppressWarnings() {
+  public void respectSuppressWarnings() {
     compilationTestHelper
         .addSourceLines(
             "Test.java",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MemoizeConstantVisitorStateLookupsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MemoizeConstantVisitorStateLookupsTest.java
@@ -162,4 +162,31 @@ public class MemoizeConstantVisitorStateLookupsTest {
         .expectUnchanged()
         .doTest();
   }
+
+  @Test
+  public void testSuppressWarnings() {
+    compilationTestHelper
+        .addSourceLines(
+            "Test.java",
+            "import com.google.errorprone.VisitorState;",
+            "import com.sun.tools.javac.code.Type;",
+            "import com.sun.tools.javac.util.Name;",
+            "class Test {",
+            "  @SuppressWarnings(\"MemoizeConstantVisitorStateLookups\")",
+            "  public Test(VisitorState state) {",
+            "    Name className = state.getName(\"java.lang.Class\");",
+            "  }",
+            "  @SuppressWarnings(\"MemoizeConstantVisitorStateLookups\")",
+            "  public void testMethod(VisitorState state) {",
+            "    Name className = state.getName(\"java.lang.Class\");",
+            "  }",
+            "  @SuppressWarnings(\"MemoizeConstantVisitorStateLookups\")",
+            "  class InnerClass {",
+            "    void innerMethod(VisitorState state) {",
+            "      Name className = state.getName(\"java.lang.Class\");",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
It's nice to be able to suppress this check, e.g., while you're initially prototyping a checker.  I based my fix on the fix for #1650; hope it's the right approach.