### PR TITLE
Support given for enforcing DirectInvocationOnMock :  issue 3396

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/DirectInvocationOnMock.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DirectInvocationOnMock.java
@@ -182,15 +182,24 @@ public final class DirectInvocationOnMock extends BugChecker implements Compilat
               .withParametersOfType(ImmutableList.of(arrayOf(OBJECT_TYPE))));
 
   private static final Matcher<MethodInvocationTree> DO_CALL_REAL_METHOD =
-      allOf(
-          instanceMethod().onDescendantOf("org.mockito.stubbing.Stubber").named("when"),
-          receiverOfInvocation(
-              staticMethod().onClass("org.mockito.Mockito").named("doCallRealMethod")));
+      anyOf(
+          allOf(
+              instanceMethod().onDescendantOf("org.mockito.stubbing.Stubber").named("when"),
+              receiverOfInvocation(
+                  staticMethod().onClass("org.mockito.Mockito").named("doCallRealMethod"))),
+          allOf(
+              instanceMethod().onDescendantOf("org.mockito.BDDMockito.BDDStubber").named("given"),
+              receiverOfInvocation(
+                  staticMethod().onClass("org.mockito.BDDMockito").named("willCallRealMethod"))));
 
-  private static final Matcher<ExpressionTree> WHEN = anyMethod().anyClass().named("when");
+  private static final Matcher<ExpressionTree> WHEN = anyMethod().anyClass().namedAnyOf("when", "given");
 
   private static final Matcher<ExpressionTree> THEN_CALL_REAL_METHOD =
-      instanceMethod()
-          .onDescendantOf("org.mockito.stubbing.OngoingStubbing")
-          .named("thenCallRealMethod");
+      anyOf(
+          instanceMethod()
+              .onDescendantOf("org.mockito.stubbing.OngoingStubbing")
+              .named("thenCallRealMethod"),
+          instanceMethod()
+              .onDescendantOf("org.mockito.BDDMockito.BDDMyOngoingStubbing")
+              .named("willCallRealMethod"));
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/DirectInvocationOnMockTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/DirectInvocationOnMockTest.java
@@ -156,6 +156,23 @@ public final class DirectInvocationOnMockTest {
   }
 
   @Test
+  public void directInvocationOnMock_withinGiven_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import static org.mockito.Mockito.mock;",
+            "import static org.mockito.BDDMockito.given;",
+            "class Test {",
+            "  public Object test() {",
+            "    Test test = mock(Test.class);",
+            "    given(test.test()).willReturn(null);",
+            "    return null;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void directInvocationOnMock_setUpToCallRealMethod_noFinding() {
     helper
         .addSourceLines(
@@ -173,6 +190,23 @@ public final class DirectInvocationOnMockTest {
   }
 
   @Test
+  public void directInvocationOnMock_setUpToCallRealMethodUsingGiven_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import static org.mockito.Mockito.mock;",
+            "import static org.mockito.BDDMockito.given;",
+            "class Test {",
+            "  public Object test() {",
+            "    Test test = mock(Test.class);",
+            "    given(test.test()).willCallRealMethod();",
+            "    return test.test();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void directInvocationOnMock_setUpWithDoCallRealMethod_noFinding() {
     helper
         .addSourceLines(
@@ -183,6 +217,23 @@ public final class DirectInvocationOnMockTest {
             "  public Object test() {",
             "    Test test = mock(Test.class);",
             "    doCallRealMethod().when(test).test();",
+            "    return test.test();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void directInvocationOnMock_setUpWithDoCallRealMethodUsingGiven_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import static org.mockito.Mockito.mock;",
+            "import static org.mockito.BDDMockito.willCallRealMethod;",
+            "class Test {",
+            "  public Object test() {",
+            "    Test test = mock(Test.class);",
+            "    willCallRealMethod().given(test).test();",
             "    return test.test();",
             "  }",
             "}")
@@ -210,6 +261,26 @@ public final class DirectInvocationOnMockTest {
   }
 
   @Test
+  public void directInvocationOnMock_withinCustomGiven_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import static org.mockito.Mockito.mock;",
+            "import org.mockito.BDDMockito.BDDMyOngoingStubbing;",
+            "class Test {",
+            "  public <T> BDDMyOngoingStubbing<T> given(T t) {",
+            "    return org.mockito.BDDMockito.given(t);",
+            "  }",
+            "  public Object test() {",
+            "    Test test = mock(Test.class);",
+            "    given(test.test()).willReturn(null);",
+            "    return null;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void directInvocationOnMock_withinWhenWithCast_noFinding() {
     helper
         .addSourceLines(
@@ -220,6 +291,23 @@ public final class DirectInvocationOnMockTest {
             "  public Object test() {",
             "    Test test = mock(Test.class);",
             "    when((Object) test.test()).thenReturn(null);",
+            "    return null;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void directInvocationOnMock_withinGivenWithCast_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "import static org.mockito.Mockito.mock;",
+            "import static org.mockito.BDDMockito.given;",
+            "class Test {",
+            "  public Object test() {",
+            "    Test test = mock(Test.class);",
+            "    given((Object) test.test()).willReturn(null);",
             "    return null;",
             "  }",
             "}")

--- a/docs/bugpattern/DirectInvocationOnMock.md
+++ b/docs/bugpattern/DirectInvocationOnMock.md
@@ -12,6 +12,8 @@ Both of these are rarely what you want:
     reader will expect the test to succeed only because the code under test
     called `bar()`, not because the test itself did.
 
+Similar patterns are enforced for [BDD] style tests using `BDDMockito.given(...).willReturn(...)` mocking.
+
 Sometimes, test authors, especially those familiar with other mocking frameworks
 (like EasyMock), will call a method on a mock for one of two reasons:
 
@@ -46,3 +48,4 @@ will have other effects. Both kinds of effects can be confusing, so prefer to
 avoid such calls when possible.
 
 [mocks]: https://site.mockito.org/
+[bdd]: https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/BDDMockito.html


### PR DESCRIPTION
Support given for enforcing DirectInvocationOnMock :  issue 3396

* Mockito supports BDDMockito, using "given" to correctly define mock behavior, instead of plain Mockito "when"
* test some use cases that parallel existing cases

---
This is my first PR for this Repo, so I'm approaching with all humbleness.

My team at work saw this error prone warning show up, and 95% of the occurrences were from our use of BDD style `given` calls.   Rather than ignoring the warning outright, I'd like to fix it here.