### PR TITLE
Handle `yield` statement case in `ASTHelpers#targetType`

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/threadsafety/ImmutableCheckerTest.java
@@ -2993,4 +2993,62 @@ public class ImmutableCheckerTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void switchExpressionsYieldStatement_doesNotThrow() {
+    assumeTrue(RuntimeVersion.isAtLeast14());
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.function.Supplier;",
+            "class Test {",
+            "  String test(String mode) {",
+            "    return switch (mode) {",
+            "      case \"random\" -> {",
+            "        yield \"foo\";",
+            "      }",
+            "      default -> throw new IllegalArgumentException();",
+            "    };",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void switchExpressionsMethodReference_doesNotThrow() {
+    assumeTrue(RuntimeVersion.isAtLeast14());
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.function.Supplier;",
+            "class Test {",
+            "  Supplier<Double> test(String mode) {",
+            "    return switch (mode) {",
+            "      case \"random\" -> Math::random;",
+            "      default -> throw new IllegalArgumentException();",
+            "    };",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void switchExpressionsYieldStatementMethodReference_doesNotThrow() {
+    assumeTrue(RuntimeVersion.isAtLeast14());
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.function.Supplier;",
+            "class Test {",
+            "  Supplier<Double> test(String mode) {",
+            "    return switch (mode) {",
+            "      case \"random\" -> {",
+            "        yield Math::random;",
+            "      }",
+            "      default -> throw new IllegalArgumentException();",
+            "    };",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
https://github.com/google/error-prone/commit/7504736304148615ab53fe1479cc18027d822ff7 fixes the switch expression case, but `ImmutableChecker` can still throw `NullPointerException` for the `yield` statement + method reference case. This PR handles that case, too.