### PR TITLE
Fix bug where nested `MissingBraces` violations' suggested fixes result in broken code

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/apply/DescriptionBasedDiff.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/DescriptionBasedDiff.java
@@ -99,7 +99,7 @@ public final class DescriptionBasedDiff implements DescriptionListener, Diff {
     importsToRemove.addAll(fix.getImportsToRemove());
     for (Replacement replacement : fix.getReplacements(endPositions)) {
       try {
-        replacements.add(replacement, Replacements.CoalescePolicy.EXISTING_FIRST);
+        replacements.add(replacement, fix.getCoalescePolicy());
       } catch (IllegalArgumentException iae) {
         if (!ignoreOverlappingFixes) {
           throw iae;

--- a/check_api/src/main/java/com/google/errorprone/fixes/Fix.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/Fix.java
@@ -40,6 +40,8 @@ public interface Fix {
     return "";
   }
 
+  Replacements.CoalescePolicy getCoalescePolicy();
+
   Set<Replacement> getReplacements(EndPosTable endPositions);
 
   Collection<String> getImportsToAdd();

--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFix.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFix.java
@@ -23,6 +23,7 @@ import com.google.auto.value.extension.memoized.Memoized;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.fixes.Replacements.CoalescePolicy;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
@@ -46,6 +47,7 @@ public abstract class SuggestedFix implements Fix {
 
   private static SuggestedFix create(SuggestedFix.Builder builder) {
     return new AutoValue_SuggestedFix(
+        builder.coalescePolicy,
         ImmutableList.copyOf(builder.fixes),
         ImmutableSet.copyOf(builder.importsToAdd),
         ImmutableSet.copyOf(builder.importsToRemove),
@@ -90,8 +92,7 @@ public abstract class SuggestedFix implements Fix {
     }
     Replacements replacements = new Replacements();
     for (FixOperation fix : fixes()) {
-      replacements.add(
-          fix.getReplacement(endPositions), Replacements.CoalescePolicy.EXISTING_FIRST);
+      replacements.add(fix.getReplacement(endPositions), getCoalescePolicy());
     }
     return replacements.ascending();
   }
@@ -169,6 +170,7 @@ public abstract class SuggestedFix implements Fix {
     private final List<FixOperation> fixes = new ArrayList<>();
     private final Set<String> importsToAdd = new LinkedHashSet<>();
     private final Set<String> importsToRemove = new LinkedHashSet<>();
+    private CoalescePolicy coalescePolicy = CoalescePolicy.EXISTING_FIRST;
     private String shortDescription = "";
 
     protected Builder() {}
@@ -196,6 +198,12 @@ public abstract class SuggestedFix implements Fix {
     @CanIgnoreReturnValue
     public Builder setShortDescription(String shortDescription) {
       this.shortDescription = shortDescription;
+      return this;
+    }
+
+    @CanIgnoreReturnValue
+    public Builder setCoalescePolicy(CoalescePolicy coalescePolicy) {
+      this.coalescePolicy = coalescePolicy;
       return this;
     }
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/MissingBraces.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/MissingBraces.java
@@ -16,6 +16,7 @@
 
 package com.google.errorprone.bugpatterns;
 
+import static com.google.errorprone.fixes.Replacements.CoalescePolicy.KEEP_ONLY_IDENTICAL_INSERTS;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.errorprone.BugPattern;
@@ -93,7 +94,12 @@ public class MissingBraces extends BugChecker
     if (tree != null && !(tree instanceof BlockTree)) {
       state.reportMatch(
           describeMatch(
-              tree, SuggestedFix.builder().prefixWith(tree, "{").postfixWith(tree, "}").build()));
+              tree,
+              SuggestedFix.builder()
+                  .prefixWith(tree, "{")
+                  .postfixWith(tree, "}")
+                  .setCoalescePolicy(KEEP_ONLY_IDENTICAL_INSERTS)
+                  .build()));
     }
   }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MissingBracesTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MissingBracesTest.java
@@ -76,4 +76,33 @@ public class MissingBracesTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void suggestedFixForNestedProblemsWithOverlappingBracePostfixInsertions() {
+    BugCheckerRefactoringTestHelper.newInstance(MissingBraces.class, getClass())
+        .addInputLines(
+            "Test.java",
+            "import java.util.List;",
+            "class Test {",
+            "  private String findNotNull(List<String> items) {",
+            "    for (String item : items)",
+            "      if (item != null) return item;",
+            "    return null;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import java.util.List;",
+            "class Test {",
+            "  private String findNotNull(List<String> items) {",
+            "    for (String item : items) {",
+            "      if (item != null) {",
+            "        return item;",
+            "      }",
+            "    }",
+            "    return null;",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
@holtherndon-stripe came across this issue while applying `MissingBraces` to Stripe's code base of 4 million lines of Java code. 

See unit test for sample code.

I'm not sure about a few things:
- Why does the coalescing code suppress duplicate inserts? It seems a bit odd that this is the default. I wonder which checkers' fixes need this, and why.
- Is `Fix` the right level of abstraction? Or should the coalescing policy be per `Replacement`?