### PR TITLE
Add OSGi runtime metadata to error-prone's MANIFEST.MF files

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -54,16 +54,6 @@
           <compilerArgs combine.self="override" />
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>com.google.errorprone.annotations</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -137,9 +137,36 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>6.4.0</version>
+        <executions>
+          <execution>
+            <id>generate-OSGi-manifest</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+            <configuration>
+              <bnd><![CDATA[
+                Bundle-SymbolicName: com.google.$<replacestring;$<replacestring;${project.artifactId};^error_prone;errorprone>;_;.>
+                Automatic-Module-Name: $<Bundle-SymbolicName>
+                -exportcontents: com.google.errorprone*
+                -noextraheaders: true
+                -removeheaders: Private-Package
+              ]]></bnd>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.2.2</version>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
As suggested in https://github.com/google/error-prone/issues/2967#issuecomment-1535520417 this PR aims to add OSGi runtime metadata to the error-prone jars.
It achieves this by employing the [bnd-maven-plugin:bnd-process](https://github.com/bndtools/bnd/tree/master/maven-plugins/bnd-maven-plugin#bnd-process-goal) goal to generate the OSGi metadata, like the values of the Manifest headers `Bundle-SymbolicName`, `Import-Package` and `Export-Package`.

The schema used for `Bundle-SymbolicName` headers is based on the schema used for the `Automatic-Module-Name` in the error-prone-annotations artifact.
With this change additionally all other error-prone artifacts get a `Automatic-Module-Name` too.

@cushon can you please review this PR? If you have any question, I would be happy to answer them.

Fixes https://github.com/google/error-prone/issues/2967

