### PR TITLE
Add space after link in diagnostic message (fixes #3910)

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/matchers/Description.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/Description.java
@@ -137,7 +137,7 @@ public class Description {
    */
   @Nullable
   private static String linkTextForDiagnostic(String linkUrl) {
-    return isNullOrEmpty(linkUrl) ? null : "  (see " + linkUrl + ")";
+    return isNullOrEmpty(linkUrl) ? null : "  (see " + linkUrl + " )";
   }
 
   /** Returns a new builder for {@link Description}s. */


### PR DESCRIPTION
see https://github.com/google/error-prone/issues/3910