### PR TITLE
Upgrade protobuf-java to 3.19.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
     <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
-    <protobuf.version>3.19.2</protobuf.version>
-    <grpc.version>1.43.2</grpc.version>
+    <protobuf.version>3.19.6</protobuf.version>
+    <grpc.version>1.43.3</grpc.version>
     <jspecify.version>0.2.0</jspecify.version>
     <guice.version>5.1.0</guice.version>
   </properties>


### PR DESCRIPTION
Upgrade protobuf-java to 3.19.6 to remove presence of CVE-2022-3171, CVE-2022-3509, and CVE-2022-3510. Upgrade protoc-gen-grpc-java to 1.43.3 since it also depends on protobuf-java 3.19.6.

Closes #3945.