### PR TITLE
Improve `LockOnNonEnclosingClassLiteral` documentation

### DIFF
--- a/docs/bugpattern/LockOnNonEnclosingClassLiteral.md
+++ b/docs/bugpattern/LockOnNonEnclosingClassLiteral.md
@@ -1,18 +1,33 @@
-Lock on the class other than the enclosing class of the code block can
-unintentionally prevent the locked class or other classing using the same lock
-being used properly. A issue can be caused when the locked class being edited or
-deleted. And it can also be exhausting and time consuming for the others who is
-using the same class literal as lock to make sure the synchronized blocks can
-work properly as expected. Hence locking on the class other than the enclosing
-class of the synchronized code block is disencouraged by the error prone.
-Locking on the enclosing class or an instance is a preferred practice.
+Having a lock on a class, other than the enclosing class of the code block, can
+unintentionally prevent the locked class from being used properly when other
+classes effectively lock on the same resource. From a maintainability
+perspective, it can be time-consuming to ensure the `synchronized` blocks are
+working as expected. Hence, locking on a class other than the enclosing class
+of the `synchronized` code block is discouraged by Error Prone. Locking on the
+enclosing class or an instance is a preferred practice.
 
-For example, lock on `Other.class` rather than `Example.class` will trigger the
-error prone warning: ``` class Example {
+For example, a lock on `Other.class` rather than `Example.class` will trigger an
+Error Prone warning:
 
-method() { synchronized (Other.class) { } } } ```
+```java
+class Example {
+  void method() {
+    synchronized (Other.class) {
+    }
+  }
+}
+```
 
-Lock on instance or the enclosing class of the synchronized code block will not
-trigger the warning: ``` class Example {
+A lock on the instance or the enclosing class of the `synchronized` code block will
+not trigger the warning:
 
-method() { synchronized (Example.class) {} synchronized (this) {} } } ```
+```java
+class Example {
+  void method() {
+    synchronized (Example.class) {
+    }
+    synchronized (this) {
+    }
+  }
+}
+```


### PR DESCRIPTION
I noticed that the code is not properly rendered in the markdown: https://errorprone.info/bugpattern/LockOnNonEnclosingClassLiteral.

While working on this, I improved and re-flowed the text.

Let me know if I changed too much and should limit it to the incorrect rendering of the code examples.