### PR TITLE
Replace ZoneId.of("UTC") with ZoneOffset.UTC

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/time/ZoneIdOfZ.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/time/ZoneIdOfZ.java
@@ -40,9 +40,9 @@ import com.sun.source.tree.MethodInvocationTree;
  * @author kak@google.com (Kurt Alfred Kluever)
  */
 @BugPattern(
-    summary = "Use ZoneOffset.UTC instead of ZoneId.of(\"Z\").",
+    summary = "Use ZoneOffset.UTC instead of ZoneId.of(\"Z\") or ZoneId.of(\"UTC\").",
     explanation =
-        "Avoid the magic constant (ZoneId.of(\"Z\")) in favor of a more descriptive API: "
+        "Avoid the magic constants (ZoneId.of(\"Z\")) and (ZoneId.of(\"UTC\")) in favor of a more descriptive API: "
             + " ZoneOffset.UTC",
     severity = ERROR)
 public final class ZoneIdOfZ extends BugChecker implements MethodInvocationTreeMatcher {
@@ -57,7 +57,7 @@ public final class ZoneIdOfZ extends BugChecker implements MethodInvocationTreeM
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (ZONE_ID_OF.matches(tree, state)) {
       String zone = constValue(tree.getArguments().get(0), String.class);
-      if (zone != null && zone.equals("Z")) {
+      if (zone != null && (zone.equals("Z") || zone.equals("UTC"))) {
         SuggestedFix.Builder fix = SuggestedFix.builder().addImport(ZONE_OFFSET);
         fix.replace(tree, String.format("%s.UTC", qualifyType(state, fix, ZONE_OFFSET)));
         return describeMatch(tree, fix.build());

--- a/core/src/test/java/com/google/errorprone/bugpatterns/time/ZoneIdOfZTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/time/ZoneIdOfZTest.java
@@ -52,6 +52,19 @@ public class ZoneIdOfZTest {
   }
 
   @Test
+  public void zoneIdOfUtc() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.ZoneId;",
+            "public class TestClass {",
+            "  // BUG: Diagnostic contains: private static final ZoneId UTC = ZoneOffset.UTC;",
+            "  private static final ZoneId UTC = ZoneId.of(\"UTC\");",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void zoneIdOfLowerCaseZ() {
     helper
         .addSourceLines(
@@ -59,6 +72,18 @@ public class ZoneIdOfZTest {
             "import java.time.ZoneId;",
             "public class TestClass {",
             "  private static final ZoneId UTC = ZoneId.of(\"z\");",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void zoneIdOfLowerCaseUtc() {
+    helper
+        .addSourceLines(
+            "TestClass.java",
+            "import java.time.ZoneId;",
+            "public class TestClass {",
+            "  private static final ZoneId UTC = ZoneId.of(\"utc\");",
             "}")
         .doTest();
   }


### PR DESCRIPTION
This PR updates the `ZoneIdOfZ` check to also replace `ZoneId.of("UTC")`.