### PR TITLE
Add support in ASTHelpersSuggestions for getEnclosedElements

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ASTHelpersSuggestions.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ASTHelpersSuggestions.java
@@ -50,7 +50,8 @@ public class ASTHelpersSuggestions extends BugChecker implements MethodInvocatio
       anyOf(
           instanceMethod()
               .onDescendantOf("com.sun.tools.javac.code.Symbol")
-              .namedAnyOf("isDirectlyOrIndirectlyLocal", "isLocal", "packge"),
+              .namedAnyOf(
+                  "isDirectlyOrIndirectlyLocal", "isLocal", "packge", "getEnclosedElements"),
           instanceMethod()
               .onClass((t, s) -> isSubtype(MODULE_SYMBOL.get(s), t, s))
               .namedAnyOf("isStatic"));

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ASTHelpersSuggestionsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ASTHelpersSuggestionsTest.java
@@ -87,4 +87,29 @@ public class ASTHelpersSuggestionsTest {
             "jdk.compiler/com.sun.tools.javac.code", "jdk.compiler/com.sun.tools.javac.util")
         .doTest();
   }
+
+  @Test
+  public void symbolGetEnclosedElements() {
+    testHelper
+        .addInputLines(
+            "Test.java",
+            "import com.sun.tools.javac.code.Symbol.ClassSymbol;",
+            "class Test {",
+            "  void f(ClassSymbol s) {",
+            "    s.getEnclosedElements();",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import static com.google.errorprone.util.ASTHelpers.getEnclosedElements;",
+            "import com.sun.tools.javac.code.Symbol.ClassSymbol;",
+            "class Test {",
+            "  void f(ClassSymbol s) {",
+            "    getEnclosedElements(s);",
+            "  }",
+            "}")
+        .addModules(
+            "jdk.compiler/com.sun.tools.javac.code", "jdk.compiler/com.sun.tools.javac.util")
+        .doTest();
+  }
 }


### PR DESCRIPTION
See #4026.  `Symbol.getEnclosedElements()` is another method that can cause compatibility issues across JDK versions (https://github.com/google/error-prone/issues/3895).  