### PR TITLE
Upgrade JSpecify 0.2.0 -> 0.3.0

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/NullArgumentForNonNullParameter.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/NullArgumentForNonNullParameter.java
@@ -248,7 +248,8 @@ public final class NullArgumentForNonNullParameter extends BugChecker
       if (hasAnnotation(sym, "com.google.protobuf.Internal$ProtoNonnullApi", state)) {
         return true;
       }
-      if (hasAnnotation(sym, "org.jspecify.nullness.NullMarked", state)
+      if ((hasAnnotation(sym, "org.jspecify.annotations.NullMarked", state)
+              || hasAnnotation(sym, "org.jspecify.nullness.NullMarked", state))
           && weTrustNullMarkedOn(sym, state)) {
         return true;
       }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/NullnessUtils.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/NullnessUtils.java
@@ -129,7 +129,8 @@ class NullnessUtils {
 
   static boolean isInNullMarkedScope(Symbol sym, VisitorState state) {
     for (; sym != null; sym = sym.getEnclosingElement()) {
-      if (hasAnnotation(sym, "org.jspecify.nullness.NullMarked", state)) {
+      if (hasAnnotation(sym, "org.jspecify.annotations.NullMarked", state)
+          || hasAnnotation(sym, "org.jspecify.nullness.NullMarked", state)) {
         return true;
       }
     }
@@ -353,7 +354,7 @@ class NullnessUtils {
             .orElse(
                 state.isAndroidCompatible()
                     ? "androidx.annotation.Nullable"
-                    : "org.jspecify.nullness.Nullable");
+                    : "org.jspecify.annotations.Nullable");
     if (sym != null) {
       ClassSymbol classSym = (ClassSymbol) sym;
       if (classSym.isAnnotationType()) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NullableOptionalTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NullableOptionalTest.java
@@ -79,7 +79,7 @@ public final class NullableOptionalTest {
         .addSourceLines(
             "Test.java",
             "import java.util.Optional;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "final class Test {",
             " @Nullable",
             " // BUG: Diagnostic contains:",
@@ -136,7 +136,7 @@ public final class NullableOptionalTest {
     compilationHelper
         .addSourceLines(
             "Test.java",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "final class Test {",
             " @Nullable",
             " private Object foo() {",
@@ -151,7 +151,7 @@ public final class NullableOptionalTest {
     compilationHelper
         .addSourceLines(
             "Test.java",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "final class Test {",
             " private void foo(@Nullable Object object) {}",
             "}")

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/EqualsMissingNullableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/EqualsMissingNullableTest.java
@@ -125,7 +125,7 @@ public class EqualsMissingNullableTest {
     conservativeHelper
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.NullMarked;",
             "@NullMarked",
             "abstract class Foo {",
             "  // BUG: Diagnostic contains: @Nullable",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/FieldMissingNullableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/FieldMissingNullableTest.java
@@ -457,7 +457,7 @@ public class FieldMissingNullableTest {
         .addOutputLines(
             "out/Test.java",
             "class T {",
-            "  private final @org.jspecify.nullness.Nullable Object obj2 = null;",
+            "  private final @org.jspecify.annotations.Nullable Object obj2 = null;",
             "  class Nullable {}",
             "}")
         .doTest();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/NullArgumentForNonNullParameterTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/NullArgumentForNonNullParameterTest.java
@@ -177,7 +177,7 @@ public class NullArgumentForNonNullParameterTest {
     aggressiveHelper
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.NullMarked;",
             "@NullMarked",
             "class Foo {",
             "  void consume(String s) {}",
@@ -194,7 +194,7 @@ public class NullArgumentForNonNullParameterTest {
     conservativeHelper
         .addSourceLines(
             "Foo.java",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.NullMarked;",
             "@NullMarked",
             "class Foo {",
             "  void consume(String s) {}",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/ReturnMissingNullableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/ReturnMissingNullableTest.java
@@ -840,7 +840,7 @@ public class ReturnMissingNullableTest {
         .addOutputLines(
             "com/google/errorprone/bugpatterns/nullness/LiteralNullReturnTest.java",
             "package com.google.errorprone.bugpatterns.nullness;",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "public class LiteralNullReturnTest {",
             "",
             "  public @Nullable String getMessage(boolean b) {",
@@ -1689,7 +1689,7 @@ public class ReturnMissingNullableTest {
         .addOutputLines(
             "out/Test.java",
             "class T {",
-            "  @org.jspecify.nullness.Nullable private final Object method(boolean b) { return b ?"
+            "  @org.jspecify.annotations.Nullable private final Object method(boolean b) { return b ?"
                 + " null : 0; }",
             "  class Nullable {}",
             "}")
@@ -1712,7 +1712,7 @@ public class ReturnMissingNullableTest {
             "}")
         .addOutputLines(
             "out/Test.java",
-            "import org.jspecify.nullness.Nullable;",
+            "import org.jspecify.annotations.Nullable;",
             "class T {",
             "  private final @Nullable Object method(boolean b) {",
             "    if (b) {",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/VoidMissingNullableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/VoidMissingNullableTest.java
@@ -334,7 +334,7 @@ public class VoidMissingNullableTest {
         .addSourceLines(
             "Test.java",
             "import javax.annotation.Nullable;",
-            "import org.jspecify.nullness.NullMarked;",
+            "import org.jspecify.annotations.NullMarked;",
             "@NullMarked",
             "class Test {",
             "  // BUG: Diagnostic contains: @Nullable",

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
     <protobuf.version>3.19.6</protobuf.version>
     <grpc.version>1.43.3</grpc.version>
-    <jspecify.version>0.2.0</jspecify.version>
+    <jspecify.version>0.3.0</jspecify.version>
     <guice.version>5.1.0</guice.version>
   </properties>
 


### PR DESCRIPTION
The removed `org.jspecify.nullness` package is still supported where
possible, but `NullnessUtils#pickNullableAnnotation` now falls back to
suggesting `org.jspecify.annotations.Nullable`.

See:
- https://github.com/jspecify/jspecify/releases/tag/v0.3.0-alpha-1
- https://github.com/jspecify/jspecify/releases/tag/v0.3.0-alpha-2
- https://github.com/jspecify/jspecify/releases/tag/v0.3.0-alpha-3
- https://github.com/jspecify/jspecify/releases/tag/v0.3.0
- https://github.com/jspecify/jspecify/compare/v0.2.0...v0.3.0