### PR TITLE
Upgrade java-diff-utils 4.0 -> 4.12

### DIFF
--- a/check_api/pom.xml
+++ b/check_api/pom.xml
@@ -59,7 +59,7 @@
       <!-- Apache 2.0 -->
       <groupId>io.github.java-diff-utils</groupId>
       <artifactId>java-diff-utils</artifactId>
-      <version>4.0</version>
+      <version>4.12</version>
     </dependency>
     <dependency>
       <!-- Apache 2.0 -->

--- a/check_api/src/main/java/com/google/errorprone/apply/PatchFileDestination.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/PatchFileDestination.java
@@ -20,7 +20,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.github.difflib.DiffUtils;
 import com.github.difflib.UnifiedDiffUtils;
-import com.github.difflib.algorithm.DiffException;
 import com.github.difflib.patch.Patch;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -60,12 +59,7 @@ public final class PatchFileDestination implements FileDestination {
     if (!oldSource.equals(newSource)) {
       List<String> originalLines = LINE_SPLITTER.splitToList(oldSource);
 
-      Patch<String> diff = null;
-      try {
-        diff = DiffUtils.diff(originalLines, LINE_SPLITTER.splitToList(newSource));
-      } catch (DiffException e) {
-        throw new AssertionError("DiffUtils.diff should not fail", e);
-      }
+      Patch<String> diff = DiffUtils.diff(originalLines, LINE_SPLITTER.splitToList(newSource));
       String relativePath = baseDir.relativize(sourceFilePath).toString();
       List<String> unifiedDiff =
           UnifiedDiffUtils.generateUnifiedDiff(relativePath, relativePath, originalLines, diff, 2);


### PR DESCRIPTION
This drops the indirect dependency on `org.eclipse.jgit`, guaranteeing
that CVE-2023-4759 is mitigated.

Resolves #4081.

See:
- https://nvd.nist.gov/vuln/detail/CVE-2023-4759
- https://github.com/java-diff-utils/java-diff-utils/releases/tag/java-diff-utils-parent-4.12
- https://github.com/java-diff-utils/java-diff-utils/compare/java-diff-utils-4.0...java-diff-utils-parent-4.12