### PR TITLE
Suggest maven-compiler-plugin 3.11.0 in docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,7 +46,7 @@ Edit your `pom.xml` file to add settings to the maven-compiler-plugin:
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>3.11.0</version>
         <configuration>
           <source>8</source>
           <target>8</target>


### PR DESCRIPTION
I found that with 3.10.1, Error Prone (and NullAway) warnings aren't even printed (!).  Some related discussion at https://github.com/uber/NullAway/issues/830.  I created a relevant sample repo:

https://github.com/msridhar/ep-maven-test-warnings

You can compare running `mvn clean compile` as is with changing [this line](https://github.com/msridhar/ep-maven-test-warnings/blob/main/pom.xml#L23) to be `3.10.1`; with the latter version many fewer warnings are printed, and no Error Prone warnings are printed as far as I can see.

I'm open to adding text that warns users off of versions earlier than 3.11.0 if we think that is warranted.