### PR TITLE
Add support for specifying badEnclosingTypes for `BadImport` via flags

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/BadImportTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/BadImportTest.java
@@ -388,4 +388,63 @@ public final class BadImportTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void badEnclosingTypes() {
+    refactoringTestHelper
+        .setArgs("-XepOpt:BadImport:BadEnclosingTypes=org.immutables.value.Value")
+        .addInputLines(
+            "org/immutables/value/Value.java",
+            "package org.immutables.value;",
+            "",
+            "public @interface Value {",
+            "  @interface Immutable {}",
+            "}")
+        .expectUnchanged()
+        .addInputLines(
+            "Test.java",
+            "import org.immutables.value.Value.Immutable;",
+            "",
+            "@Immutable",
+            "interface Test {}")
+        .addOutputLines(
+            "Test.java",
+            "import org.immutables.value.Value;",
+            "",
+            "@Value.Immutable",
+            "interface Test {}")
+        .doTest();
+  }
+
+  @Test
+  public void badEnclosingTypes_doesNotMatchFullyQualifiedName() {
+    compilationTestHelper
+        .setArgs("-XepOpt:BadImport:BadEnclosingTypes=org.immutables.value.Value")
+        .addSourceLines(
+            "org/immutables/value/Value.java",
+            "package org.immutables.value;",
+            "",
+            "public @interface Value {",
+            "  @interface Immutable {}",
+            "}")
+        .addSourceLines("Test.java", "@org.immutables.value.Value.Immutable", "interface Test {}")
+        .doTest();
+  }
+
+  @Test
+  public void badEnclosingTypes_staticMethod() {
+    compilationTestHelper
+        .setArgs("-XepOpt:BadImport:BadEnclosingTypes=com.google.common.collect.ImmutableList")
+        .addSourceLines(
+            "Test.java",
+            "import static com.google.common.collect.ImmutableList.toImmutableList;",
+            "import com.google.common.collect.ImmutableList;",
+            "import java.util.stream.Collector;",
+            "",
+            "class Test {",
+            "  // BUG: Diagnostic contains: ImmutableList.toImmutableList()",
+            "  Collector<?, ?, ImmutableList<Object>> immutableList = toImmutableList();",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualifiedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualifiedTest.java
@@ -226,7 +226,32 @@ public final class UnnecessarilyFullyQualifiedTest {
   }
 
   @Test
-  public void exemptedTypes() {
+  public void staticNestedClass() {
+    helper
+        .addInputLines(
+            "test/EnclosingType.java",
+            "package test;",
+            "",
+            "public final class EnclosingType {",
+            "  public static final class StaticNestedClass {}",
+            "}")
+        .expectUnchanged()
+        .addInputLines(
+            "Test.java",
+            "interface Test {",
+            "  test.EnclosingType.StaticNestedClass method();",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import test.EnclosingType.StaticNestedClass;",
+            "interface Test {",
+            "  StaticNestedClass method();",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void exemptedEnclosingTypes() {
     helper
         .setArgs("-XepOpt:BadImport:BadEnclosingTypes=org.immutables.value.Value")
         .addInputLines(
@@ -258,7 +283,7 @@ public final class UnnecessarilyFullyQualifiedTest {
   }
 
   @Test
-  public void exemptedTypes_importWouldBeAmbiguous() {
+  public void exemptedEnclosingTypes_importWouldBeAmbiguous() {
     helper
         .setArgs("-XepOpt:BadImport:BadEnclosingTypes=org.immutables.value.Value")
         .addInputLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualifiedTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessarilyFullyQualifiedTest.java
@@ -224,4 +224,70 @@ public final class UnnecessarilyFullyQualifiedTest {
             "package b;")
         .doTest();
   }
+
+  @Test
+  public void exemptedTypes() {
+    helper
+        .setArgs("-XepOpt:BadImport:BadEnclosingTypes=org.immutables.value.Value")
+        .addInputLines(
+            "org/immutables/value/Value.java",
+            "package org.immutables.value;",
+            "",
+            "public @interface Value {",
+            "  @interface Immutable {}",
+            "}")
+        .expectUnchanged()
+        .addInputLines(
+            "Test.java",
+            "import org.immutables.value.Value.Immutable;",
+            "",
+            "class Test {",
+            "  @org.immutables.value.Value.Immutable",
+            "  abstract class AbstractType {}",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "import org.immutables.value.Value;",
+            "import org.immutables.value.Value.Immutable;",
+            "",
+            "class Test {",
+            "  @Value.Immutable",
+            "  abstract class AbstractType {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void exemptedTypes_importWouldBeAmbiguous() {
+    helper
+        .setArgs("-XepOpt:BadImport:BadEnclosingTypes=org.immutables.value.Value")
+        .addInputLines(
+            "org/immutables/value/Value.java",
+            "package org.immutables.value;",
+            "",
+            "public @interface Value {",
+            "  @interface Immutable {}",
+            "}")
+        .expectUnchanged()
+        .addInputLines(
+            "annotation/Value.java",
+            "package annotation;",
+            "",
+            "public @interface Value {",
+            "  String value();",
+            "}")
+        .expectUnchanged()
+        .addInputLines(
+            "Test.java",
+            "import annotation.Value;",
+            "",
+            "final class Test {",
+            "  Test(@Value(\"test\") String value) {}",
+            "",
+            "  @org.immutables.value.Value.Immutable",
+            "  abstract class AbstractType {}",
+            "}")
+        .expectUnchanged()
+        .doTest();
+  }
 }


### PR DESCRIPTION
Following the discussions in https://github.com/google/error-prone/pull/2236, this PR introduces the `BadImport:BadEnclosingTypes` flag to disallow nested types of specified enclosing type.

This PR also takes the flag into account in `UnnecessarilyFullyQualified` to suggest importing `EnclosingType.NestedType` when possible.

For instance, when `-XepOpt:BadImport:BadEnclosingTypes=org.immutables.value.Value` is set, it would suggest the following: 

```java
final class Test {
  @org.immutables.value.Value.Immutable
  abstract class AbstractType {}
}
```
->
```java
final class Test {
  @Value.Immutable
  abstract class AbstractType {}
}
```

Also, it won't require suppressing `UnnecessarilyFullyQualified` in the example in https://github.com/google/error-prone/pull/2236.

```java
import org.springframework.beans.factory.annotation.Value;

final class Test {
  Demo(@Value("some.property") String property) {}

  @org.immutables.value.Value.Immutable
  abstract class AbstractType {}
}
```

Closes https://github.com/google/error-prone/pull/2236.