### PR TITLE
Add null check to hasDirectAnnotationWithSimpleName

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -1001,6 +1001,9 @@ public class ASTHelpers {
    * annotation inheritance (see JLS 9.6.4.3).
    */
   public static boolean hasDirectAnnotationWithSimpleName(Symbol sym, String simpleName) {
+    if (sym == null) {
+      return false;
+    }
     if (sym instanceof MethodSymbol) {
       return hasDirectAnnotationWithSimpleName((MethodSymbol) sym, simpleName);
     }


### PR DESCRIPTION
The lack of a null check means that `hasDirectAnnotationWithSimpleName` can't be composed with matcher that may attempt to match nodes for which `getDeclaredSymbol` will return `null`. For example:

```java
Matchers.enclosingNode(Matchers.hasAnnotationWithSimpleName("MyAnnotation"))
```