### PR TITLE
feat: add jpms definition for `annotations`

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>@BugPattern annotation</name>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>error-prone annotations</name>
@@ -49,9 +49,39 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>8</source>
-          <target>8</target>
           <compilerArgs combine.self="override" />
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+              <excludes>
+                <exclude>module-info.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>compile-java9</id>
+            <configuration>
+              <source>9</source>
+              <target>9</target>
+              <release>9</release>
+              <multiReleaseOutput>true</multiReleaseOutput>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Multi-Release>true</Multi-Release>
+            </manifestEntries>
+          </archive>
         </configuration>
       </plugin>
     </plugins>

--- a/annotations/src/main/java/module-info.java
+++ b/annotations/src/main/java/module-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+open module com.google.errorprone.annotation {
+  requires java.base;
+  requires java.compiler;
+  exports com.google.errorprone.annotations;
+  exports com.google.errorprone.annotations.concurrent;
+}

--- a/check_api/pom.xml
+++ b/check_api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>error-prone check api</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>error-prone library</name>

--- a/docgen/pom.xml
+++ b/docgen/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>Documentation tool for generating Error Prone bugpattern documentation</name>

--- a/docgen_processor/pom.xml
+++ b/docgen_processor/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>JSR-269 annotation processor for @BugPattern annotation</name>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <name>Error Prone parent POM</name>
   <groupId>com.google.errorprone</groupId>
   <artifactId>error_prone_parent</artifactId>
-  <version>HEAD-SNAPSHOT</version>
+  <version>1.0-HEAD-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <description>Error Prone is a static analysis tool for Java that catches common programming mistakes at compile-time.</description>
@@ -204,6 +204,16 @@
             <exclude>**/testdata/**</exclude>
           </testExcludes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <compilerArgs combine.children="append">
+                <arg>-Xlint:-options</arg>
+              </compilerArgs>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/refaster/pom.xml
+++ b/refaster/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>error_prone_parent</artifactId>
         <groupId>com.google.errorprone</groupId>
-        <version>HEAD-SNAPSHOT</version>
+        <version>1.0-HEAD-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test_helpers/pom.xml
+++ b/test_helpers/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>error-prone test helpers</name>

--- a/type_annotations/pom.xml
+++ b/type_annotations/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_parent</artifactId>
-    <version>HEAD-SNAPSHOT</version>
+    <version>1.0-HEAD-SNAPSHOT</version>
   </parent>
 
   <name>error-prone type annotations</name>


### PR DESCRIPTION
## Summary

Minimal set of changes to ship a `module-info.java`, and support JVM 1.8 for the `annotations` module only.

### Reasoning

It costs almost nothing to support _only_ the annotations on JVM 1.8, for projects which transitively include `error-prone-annotations`, which can happen via a simple dependency on something like Guava. But, it would be ideal to [ship a `module-info.java`](#2649), so `annotations` is now a `Multi-Release` JAR, with a `module-info.class` in `META-INF/versions/9`.

I am working downstream to [support JPMS in Guava](https://github.com/google/guava/issues/2970), and this PR will be necessary for that to eventually land (without hackery). [Checker Framework recently merged their support](https://github.com/typetools/checker-framework/pull/6326) which means Error Prone is one of the last things on the classpath for Guava without a `module-info.java` definition.

Automatic Modules also aren't the answer because they cannot be used with `jlink`. Such dependencies must be processed by tools like Moditect before they can be used in fully modular Java builds. Because Error Prone Annotations is a dependency in Guava, and is itself very popular, many projects need Error Prone to adopt JPMS so they can ship their own code with modular Java support.

There may be libraries out there that depend on the annotations _and not the compiler_, who wish to ship a MRJAR and retain JVM 1.8 support (Guava).

### Non-release version number change

One wrinkle here is that the Maven project version [is used unconditionally](https://github.com/apache/maven-compiler-plugin/blob/74cfc72acae4f55708bca189b2170167e83df6b3/src/main/java/org/apache/maven/plugin/compiler/CompilerMojo.java#L304-L305) [as the `--module-version`][0]; however, [`HEAD-SNAPSHOT` is not a valid module identifier](https://lists.apache.org/thread/qtghq13qgjoc4pn6ovsdxgnjnm4ozv4d). This leaves only a few choices to support JPMS through recent (`3.8.x+`) Maven Compiler plugin versions:

- `HEAD-SNAPSHOT` needs to become `1.0-HEAD-SNAPSHOT`, and then it is a valid `--module-version`
- Or, Maven Compiler Plugin needs to ship a bugfix and Error Prone will need to wait for a release (if a bugfix ships at all)

I understand this can be a breaking change somewhere within Google, but I don't see a way around this without resorting to severe build hacks. I've gotten it to build anyway by building the `module-info.java` only in a separate Maven project, and then copying it into the JAR at the last moment, but there are serious issues with that route so I suggest it be abandoned in favor of a version string change during dev, if possible.

## Changelog

- feat: add `module-info` to `annotations` module
- feat: ship `annotations` as a `Multi-Release` JAR
- feat: support `1.8` through latest JDK for `annotations` module
- fix: remove automatic module definition from `annotations` module
- fix: `HEAD-SNAPSHOT` → `1.0-HEAD-SNAPSHOT`, because of a Maven Compiler Plugin issue [precluding use as a module version][0]

Fixes and closes #2649

[0]: https://issues.apache.org/jira/browse/MCOMPILER-579
