### PR TITLE
fix: module name → `com.google.errorprone.annotations`

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -90,6 +90,40 @@
           </excludes>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>6.4.0</version>
+        <executions>
+          <execution>
+            <id>generate-OSGi-manifest</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>generate-OSGi-manifest-annotations</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+            <configuration>
+              <!--
+                The OSGi bundle build is overridden here to allow for MRJAR classes in the
+                versioned class space underneath META-INF.
+
+                The `annotations` module also should not have an `Automatic-Module-Name`.
+                Otherwise, these flags should stay in-sync with the same block in the root
+                `pom.xml`.
+              -->
+              <bnd><![CDATA[
+                Bundle-SymbolicName: com.google.errorprone.annotations
+                -exportcontents: com.google.errorprone*,!META-INF.*
+                -noextraheaders: true
+                -removeheaders: Private-Package
+                -fixupmessages: ^Classes found in the wrong directory: .*
+              ]]></bnd>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/annotations/src/main/java/module-info.java
+++ b/annotations/src/main/java/module-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-open module com.google.errorprone.annotation {
+open module com.google.errorprone.annotations {
   requires java.compiler;
 
   exports com.google.errorprone.annotations;

--- a/pom.xml
+++ b/pom.xml
@@ -150,10 +150,9 @@
               <bnd><![CDATA[
                 Bundle-SymbolicName: com.google.$<replacestring;$<replacestring;${project.artifactId};^error_prone;errorprone>;_;.>
                 Automatic-Module-Name: $<Bundle-SymbolicName>
-                -exportcontents: com.google.errorprone*,!META-INF.*
+                -exportcontents: com.google.errorprone*
                 -noextraheaders: true
                 -removeheaders: Private-Package
-                -fixupmessages: ^Classes found in the wrong directory: .*
               ]]></bnd>
             </configuration>
           </execution>


### PR DESCRIPTION
## Summary

Fixes the module name: ~~`com.google.errorprone.annotation`~~ → `com.google.errorprone.annotations`. Amends the OSGi build not to include `Automatic-Module-Name` in the `MANIFEST.MF` for the `annotations` project.

## Changelog

- fix: name in `module-info.java` for `annotations` module
- fix: don't emit `Automatic-Module-Name` in `annotations` module
- chore: preserve all other aspects of OSGi and JAR builds

Relates to [discussion](https://github.com/google/error-prone/pull/4311#issuecomment-1990316489) in google/error-prone#4311. Double checked for correct JAR structure; see [these screenshots](https://github.com/google/error-prone/pull/4311#issuecomment-1991007036).

cc / @cushon @ben-manes