### PR TITLE
Add DoNotMockRecords to warn against mocking record data objects

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/AbstractAnnotationMockChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AbstractAnnotationMockChecker.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2024 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+
+import com.google.common.base.Strings;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.Lists;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.code.Attribute.Compound;
+import com.sun.tools.javac.code.Symbol.CompletionFailure;
+import com.sun.tools.javac.code.Symbol.TypeSymbol;
+import com.sun.tools.javac.code.Type;
+
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
+/**
+ * Helper for enforcing Annotations that disallow mocking.
+ *
+ * @param <ANNOTATION> The annotation that should not be mocked.
+ */
+abstract class AbstractAnnotationMockChecker<ANNOTATION extends Annotation> extends AbstractMockChecker implements
+    MethodInvocationTreeMatcher, VariableTreeMatcher {
+
+  private final Class<ANNOTATION> annotationClass;
+  private final String annotationName;
+  private final Function<ANNOTATION, String> getValueFunction;
+  private final Supplier<MockForbidder> forbidder = Suppliers.memoize(this::forbidder);
+
+  public AbstractAnnotationMockChecker(TypeExtractor<VariableTree> varExtractor,
+      TypeExtractor<MethodInvocationTree> methodExtractor,
+      Class<ANNOTATION> annotationClass, Function<ANNOTATION, String> getValueFunction) {
+    super(varExtractor, methodExtractor);
+    this.annotationClass = annotationClass;
+    this.annotationName = annotationClass.getSimpleName();
+    this.getValueFunction = getValueFunction;
+  }
+
+  @Override
+  public final Description matchMethodInvocation(final MethodInvocationTree tree,
+      final VisitorState state) {
+    return methodExtractor
+        .extract(tree, state)
+        .flatMap(type -> argFromClass(type, state))
+        .map(type -> checkMockedType(type, tree, state))
+        .orElse(NO_MATCH);
+  }
+
+  @Override
+  public final Description matchVariable(VariableTree tree, VisitorState state) {
+    return varExtractor
+        .extract(tree, state)
+        .map(type -> checkMockedType(type, tree, state))
+        .orElse(NO_MATCH);
+  }
+
+  @Override
+  protected Description checkMockedType(Type mockedClass, Tree tree, VisitorState state) {
+    if (ASTHelpers.isSameType(Type.noType, mockedClass, state)) {
+      return NO_MATCH;
+    }
+
+    // We could extract this for loop to a "default" MockForbidder, but there's not much
+    // advantage in doing so.
+    for (Type currentType : Lists.reverse(state.getTypes().closure(mockedClass))) {
+      TypeSymbol currentSymbol = currentType.asElement();
+      ANNOTATION doNotMock = currentSymbol.getAnnotation(annotationClass);
+      if (doNotMock != null) {
+        return buildDescription(tree)
+            .setMessage(buildMessage(mockedClass, currentSymbol, doNotMock))
+            .build();
+      }
+
+      for (Compound compound : currentSymbol.getAnnotationMirrors()) {
+        TypeSymbol metaAnnotationType = (TypeSymbol) compound.getAnnotationType().asElement();
+        try {
+          metaAnnotationType.complete();
+        } catch (CompletionFailure e) {
+          // if the annotation isn't on the compilation classpath, we can't check it for
+          // the annotationClass meta-annotation
+          continue;
+        }
+        doNotMock = metaAnnotationType.getAnnotation(annotationClass);
+        if (doNotMock != null) {
+          return buildDescription(tree)
+              .setMessage(buildMessage(mockedClass, currentSymbol, metaAnnotationType, doNotMock))
+              .build();
+        }
+      }
+    }
+    return forbidder
+        .get()
+        .forbidReason(mockedClass, state)
+        .map(
+            reason ->
+                buildDescription(tree)
+                    .setMessage(
+                        buildMessage(mockedClass, reason.unmockableClass().tsym, reason.reason()))
+                    .build())
+        .orElse(NO_MATCH);
+  }
+
+  protected String buildMessage(Type mockedClass, TypeSymbol forbiddenType, ANNOTATION doNotMock) {
+    return buildMessage(mockedClass, forbiddenType, null, doNotMock);
+  }
+
+  protected String buildMessage(
+      Type mockedClass,
+      TypeSymbol forbiddenType,
+      @Nullable TypeSymbol metaAnnotationType,
+      ANNOTATION doNotMock) {
+    return String.format(
+        "%s; %s is annotated as @%s%s: %s.",
+        buildMessage(mockedClass, forbiddenType),
+        forbiddenType,
+        metaAnnotationType == null ? annotationName : metaAnnotationType,
+        (metaAnnotationType == null
+            ? ""
+            : String.format(" (which is annotated as @%s)", annotationName)),
+        Optional.ofNullable(Strings.emptyToNull(getValueFunction.apply(doNotMock)))
+            .orElseGet(() -> String.format("It is annotated as %s.", annotationName)));
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DoNotMockAutoValue.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DoNotMockAutoValue.java
@@ -20,8 +20,6 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 
 import com.google.auto.value.AutoValue;
 import com.google.errorprone.BugPattern;
-import com.sun.source.tree.VariableTree;
-import java.util.stream.Stream;
 
 /** Suggests not mocking AutoValue classes. */
 @BugPattern(
@@ -29,13 +27,11 @@ import java.util.stream.Stream;
         "AutoValue classes represent pure data classes, so mocking them should not be necessary."
             + " Construct a real instance of the class instead.",
     severity = WARNING)
-public final class DoNotMockAutoValue extends AbstractMockChecker<AutoValue> {
-  private static final TypeExtractor<VariableTree> MOCKED_VAR =
-      fieldAnnotatedWithOneOf(Stream.of("org.mockito.Mock", "org.mockito.Spy"));
+public final class DoNotMockAutoValue extends AbstractAnnotationMockChecker<AutoValue> {
 
   public DoNotMockAutoValue() {
     super(
-        MOCKED_VAR,
+        MOCKING_ANNOTATION,
         MOCKING_METHOD,
         AutoValue.class,
         unused ->

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DoNotMockChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DoNotMockChecker.java
@@ -19,8 +19,6 @@ package com.google.errorprone.bugpatterns;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.annotations.DoNotMock;
-import com.sun.source.tree.VariableTree;
-import java.util.stream.Stream;
 
 /**
  * Points out if a Mockito or EasyMock mock is mocking an object that would be better off being
@@ -33,12 +31,9 @@ import java.util.stream.Stream;
     severity = SeverityLevel.ERROR,
     summary = "Identifies undesirable mocks.",
     documentSuppression = false)
-public class DoNotMockChecker extends AbstractMockChecker<DoNotMock> {
-
-  private static final TypeExtractor<VariableTree> MOCKED_VAR =
-      fieldAnnotatedWithOneOf(Stream.of("org.mockito.Mock", "org.mockito.Spy"));
+public class DoNotMockChecker extends AbstractAnnotationMockChecker<DoNotMock> {
 
   public DoNotMockChecker() {
-    super(MOCKED_VAR, MOCKING_METHOD, DoNotMock.class, DoNotMock::value);
+    super(MOCKING_ANNOTATION, MOCKING_METHOD, DoNotMock.class, DoNotMock::value);
   }
 }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DoNotMockRecords.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DoNotMockRecords.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+
+import com.google.common.collect.Lists;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.code.Symbol.TypeSymbol;
+import com.sun.tools.javac.code.Type;
+
+import javax.lang.model.element.ElementKind;
+
+@BugPattern(
+    name = "DoNotMockRecords",
+    summary = "Records are intended to model plain data so mocking them should not be necessary. "
+        + "Construct a real instance of the class instead.",
+    severity = SeverityLevel.SUGGESTION)
+public final class DoNotMockRecords extends AbstractMockChecker {
+
+  public DoNotMockRecords() {
+    super(MOCKING_ANNOTATION, MOCKING_METHOD);
+  }
+
+  @Override
+  public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    return methodExtractor
+        .extract(tree, state)
+        .flatMap(type -> argFromClass(type, state))
+        .map(type -> checkMockedType(type, tree, state))
+        .orElse(NO_MATCH);
+  }
+
+  @Override
+  public Description matchVariable(VariableTree tree, VisitorState state) {
+    return varExtractor
+        .extract(tree, state)
+        .map(type -> checkMockedType(type, tree, state))
+        .orElse(NO_MATCH);
+  }
+
+  @Override
+  protected Description checkMockedType(Type mockedClass, Tree tree, VisitorState state) {
+    if (ASTHelpers.isSameType(Type.noType, mockedClass, state)) {
+      return NO_MATCH;
+    }
+
+    for (final Type currentType : Lists.reverse(state.getTypes().closure(mockedClass))) {
+      final TypeSymbol currentSymbol = currentType.asElement();
+      if (ElementKind.RECORD == currentSymbol.getKind()) {
+        return buildDescription(tree)
+            .setMessage(buildMessage(mockedClass, currentSymbol))
+            .build();
+      }
+    }
+
+    return NO_MATCH;
+  }
+}

--- a/core/src/test/java/com/google/errorprone/bugpatterns/DoNotMockRecordsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/DoNotMockRecordsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns;
+
+import com.google.errorprone.CompilationTestHelper;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link DoNotMockRecords}.
+ */
+@RunWith(JUnit4.class)
+public class DoNotMockRecordsTest {
+
+  private final CompilationTestHelper helper = CompilationTestHelper.newInstance(
+      DoNotMockRecords.class, getClass());
+
+  @Test
+  public void positive_mockito_annotation() {
+    helper
+        .addSourceLines(
+            "R.java",
+            "public record R() {}")
+        .addSourceLines(
+            "Test.java",
+        "import org.mockito.Mock;",
+        "class TestMockMethod {",
+        "  // BUG: Diagnostic contains:",
+        "  @Mock private R r1;",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positive_mockito_method() {
+    helper
+        .addSourceLines(
+            "R.java",
+            "public record R() {}")
+        .addSourceLines(
+            "Test.java",
+            "import static org.mockito.Mockito.mock;",
+            "class TestMockMethod {",
+        "  // BUG: Diagnostic contains:",
+        "  private final R r2 = mock(R.class);",
+        "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative() {
+    helper
+        .addSourceLines(
+            "R.java",
+            "public class R {}")
+        .addSourceLines(
+            "Test.java",
+        "import org.mockito.Mockito;",
+        "import org.mockito.Mock;",
+        "class TestMockMethod {",
+        "  @Mock private R r1;",
+        "  private final R r2 = Mockito.mock(R.class);",
+        "}")
+        .doTest();
+  }
+}


### PR DESCRIPTION
## Overview

>Enhance the Java programming language with [records](http://cr.openjdk.java.net/~briangoetz/amber/datum.html), which are classes that act as transparent carriers for immutable data. Records can be thought of as nominal tuples.

[Records](https://openjdk.org/jeps/395) are _typically_ used as simple wrappers of data without any methods or complex behavior requiring external dependencies or expensive IO operations. As such, they should (almost) never be mocked, and instead a real instance should be used instead. 

## Details
The class hierarchy has changed from 
```
|- AbstractMockChecker
  |-- DoNotMockAutoValue
  |-- DoNotMockChecker
```
to 
```
|- AbstractMockChecker
  |-- DoNotMockRecords
  |-- AbstractAnnotationMockChecker
    |-- DoNotMockAutoValue
    |-- DoNotMockChecker
```

This was because `AbstractMockChecker` assumed that only annotations would be used in determining that a class should not be mocked. The majority of `AbstractAnnotationMockChecker` is a straight lift and shift of the original `AbstractMockChecker`.

## Open Questions
- `ElementKind.RECORD` results in an IDE error in Intellij as it is annotated with `@since 16`, suggesting that the language level of the module be changed. This does not cause issues with complilation, but as I am entirely new to projects that deal with the AST I am wondering if there is a better approach here. 