### PR TITLE
Allow lambdas and method references referencing subclasses

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassInitializationDeadlock.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassInitializationDeadlock.java
@@ -38,6 +38,8 @@ import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
@@ -109,6 +111,16 @@ public class ClassInitializationDeadlock extends BugChecker implements BugChecke
 
       @Override
       public Void visitMethod(MethodTree node, Void unused) {
+        return null;
+      }
+
+      @Override
+      public Void visitMemberReference(MemberReferenceTree node, Void unused) {
+        return null;
+      }
+
+      @Override
+      public Void visitLambdaExpression(LambdaExpressionTree node, Void unused) {
         return null;
       }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ClassInitializationDeadlockTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ClassInitializationDeadlockTest.java
@@ -18,6 +18,7 @@ package com.google.errorprone.bugpatterns;
 
 import com.google.auto.value.processor.AutoValueProcessor;
 import com.google.errorprone.CompilationTestHelper;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -307,6 +308,65 @@ public class ClassInitializationDeadlockTest {
             "  private static Object cycle = new B();",
             "}",
             "class B extends A {}")
+        .doTest();
+  }
+
+  @Test
+  public void simpleSubclassMethodReference() {
+    testHelper
+        .addSourceLines(
+            "Foo.java",
+            "import java.util.function.Supplier;",
+            "class A {",
+            "  static Supplier<B> supplier = B::new;",
+            "}",
+            "class B extends A {}")
+        .doTest();
+  }
+
+  @Test
+  public void compoundSubclassMethodReference() {
+    testHelper
+        .addSourceLines(
+            "Foo.java",
+            "import java.util.Comparator;",
+            "class A {",
+            "  static Comparator<B> comparator = Comparator.comparing(B::value);",
+            "}",
+            "class B extends A {",
+            "  int value;",
+            "  int value() {",
+            "    return value;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void lambda() {
+    testHelper
+        .addSourceLines(
+            "Foo.java",
+            "import java.util.function.Supplier;",
+            "class A {",
+            "  static Supplier<B> supplier = () -> new B();",
+            "}",
+            "class B extends A {}")
+        .doTest();
+  }
+
+  @Test
+  public void subclassStaticMethod() {
+    testHelper
+        .addSourceLines(
+            "Foo.java",
+            "class A {",
+            "  // BUG: Diagnostic contains:",
+            "  static int value = B.value(); ",
+            "}",
+            "class B extends A {",
+            "  static int value() { return 0; }",
+            "}")
         .doTest();
   }
 }


### PR DESCRIPTION
### Background

In our company's codebase, we make heavy use of the popular [Immutables](https://github.com/immutables/immutables) library to generate value objects. Our typical style looks like this:

```java
@Immutable
@HubSpotStyle
public abstract class MyImmutableIF {
  public abstract int property();
}
```

From this definition, Immutables would generate a `MyImmutable` value class extending `MyImmutableIF`, and an associated builder. We tend to reference the generated type (`MyImmutable` in this case) in consuming code rather than the abstract definition type (`MyImmutableIF`). In hindsight, that usage pattern does complicate some things, but we now have thousands of these value classes so we'll likely need to support this pattern for the foreseeable future.

One downside of this usage pattern is it tends to lead to the chance of a class initialization deadlock. For example, often immutable creators want to have some default instance, and they'll define that on their abstract type:

```java
@Immutable
@HubSpotStyle
public abstract class MyImmutableIF {
  public static final MyImmutable DEFAULT = MyImmutable.builder().setProperty(42).build();

  public abstract int property();
}
```

This is obviously prone to a class initialization deadlock (since `MyImmutable` extends `MyImmutableIF`, and `MyImmutable DEFAULT` is a static field of `MyImmutableIF` assigned to during the class's initialization), and we've been bitten by them many times in the past using this pattern. This was the inspiration for my fix in https://github.com/google/error-prone/pull/4429, and with that in place `ClassInitializationDeadlock` correctly detects these situations.

One way we've worked around the possibility of deadlocks in these situations is to defer the construction of the default value past class initialization time:

```java
@Immutable
@HubSpotStyle
public abstract class MyImmutableIF {
  private static final Supplier<MyImmutable> DEFAULT = Suppliers.memoize(
      () -> MyImmutable.builder().setProperty(42).build()
  );

  public static MyImmutable default() {
    return DEFAULT.get();
  }

  public abstract int property();
}
```

(Using Guava's [`Suppliers.memoize`](https://guava.dev/releases/33.2.1-jre/api/docs/com/google/common/base/Suppliers.html#memoize(com.google.common.base.Supplier)))

This is not prone to class initialization deadlock since, according to [the JVM spec](https://docs.oracle.com/javase/specs/jvms/se21/html/jvms-5.html#jvms-5.5) and real-world experimentation, `MyImmutable` won't be initialized when `MyImmutableIF` is initialized. `MyImmutable` will only be initialized once `MyImmutableIF.default()` is called (assuming it hasn't otherwise already been initialized before that, of course).

Another common example in our codebase is holding some common function object that operates on instances of the value class:

```java
@Immutable
@HubSpotStyle
public abstract class MyImmutableIF {
  private static final Comparator<MyImmutable> COMPARATOR =
      Comparator.comparingInt(MyImmutable::property);

  public abstract int property();
}
```

This is also not prone to class initialization deadlock; referencing methods does not initialize the class containing the referenced method (at least not with `javac` and HotSpot, I think it's possible for that to differ between compiler and/or JVM implementations).

However, `ClassInitializationDeadlock` (with my previous fix) flags both of these situations, the first at the usage of `MyImmutable.builder()` inside the lambda passed to `Suppliers.memoize`, and the second at the reference to `MyImmutable::property`.

### The fix

This PR updates `ClassInitializationDeadlock` to ignore lambda expressions and member references when looking for references that could enable a class initialization deadlock.

I recognize this isn't a perfect fix. Some lambdas or member references can actually be problematic. Here's a contrived example:

```java
class A {
  static Object cycle = ((Supplier) B::new).get();
}
class B extends A {}
```

With this PR, Error Prone wouldn't flag that usage, but it is prone to a class initialization deadlock.

However, I can't think of any useful usages of lambdas or member references that would both enable a class initialization deadlock and wouldn't otherwise reference the other class in a way that would initialize it anyway.

Thanks for your consideration.