### PR TITLE
Fix a crash in InvalidLink on `///` markdown doc comments

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/Utils.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/javadoc/Utils.java
@@ -83,7 +83,7 @@ final class Utils {
     int startPos = getStartPosition(docTree, state);
     int endPos =
         (int) positions.getEndPosition(compilationUnitTree, getDocCommentTree(state), docTree);
-    if (endPos == Position.NOPOS) {
+    if (startPos == Position.NOPOS || endPos == Position.NOPOS) {
       return SuggestedFix.emptyFix();
     }
     return SuggestedFix.replace(startPos, endPos, replacement);

--- a/core/src/test/java/com/google/errorprone/bugpatterns/javadoc/InvalidLinkTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/javadoc/InvalidLinkTest.java
@@ -17,9 +17,11 @@
 package com.google.errorprone.bugpatterns.javadoc;
 
 import static com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.util.RuntimeVersion;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -179,6 +181,21 @@ public final class InvalidLinkTest {
             "  /** {@link} */",
             "  void foo();",
             "}")
+        .doTest();
+  }
+
+  @Test
+  public void markdown() {
+    assumeTrue(RuntimeVersion.isAtLeast22());
+    helper
+        .addSourceLines(
+            "Test.java", //
+            "public class Test {",
+            "  /// Hello [bar]",
+            "  // BUG: Diagnostic contains: `bar` is a parameter",
+            "  static void foo(int bar) {}",
+            "}")
+        .setArgs("--release", "22")
         .doTest();
   }
 }


### PR DESCRIPTION
`[foo]` is getting 'desugared' to a link node for `{@link foo}` that doesn't have a start position, for now this change avoids a crash and skip emitting a fix for that case.

PiperOrigin-RevId: 661643507