### PR TITLE
Bundle google-java-format in the with-dependencies JAR

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -437,6 +437,7 @@
                   <include>com.google.code.findbugs:jsr305</include>
                   <include>com.google.protobuf:protobuf-java</include>
                   <include>javax.inject:javax.inject</include>
+                  <include>com.google.googlejavaformat:google-java-format</include>
                 </includes>
               </artifactSet>
             </configuration>


### PR DESCRIPTION
Add google-java-format in with-dependencies JAR, broken after https://github.com/google/error-prone/commit/5f71110374e63f3c35b661f538295fa15b5c1db2 Similar to #1398, #1259 and #1238