### PR TITLE
Avoid breaking protobuf release for now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
-    <protobuf.version>4.28.2</protobuf.version>
+    <protobuf.version>3.25.5</protobuf.version>
     <grpc.version>1.43.3</grpc.version>
     <jspecify.version>1.0.0</jspecify.version>
   </properties>


### PR DESCRIPTION
Protobuf-java was upgraded to 4.28.2 to address #4584.

The vulnerability
[CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8) is
fixed in protobuf-java 3.25.5, as initially suggested in #4584.

Protobuf-java saw major breaking changes in 4.26, partially mitigated in
the 27 series. Because it takes time to adopt to these breaking changes,
it is better I think to only address the vulnerability and not jump into
the breaking releases yet.

Specifically, the problem is that now everyone that uses error-prone is
forced to jump to the breaking Protobuf releases today.

This includes all users of the chain of Google BOMs (libraries-bom,
first-party-dependencies, google-cloud-bom and
gapic-generator-java-bom). Those still reference 3.25.5 [1].

This PR fixes the issue. I think error-prone should then be released and
included in gapic-generator-java-pom-parent.

Thank you!

[1] https://github.com/googleapis/sdk-platform-java/blob/main/gapic-generator-java-pom-parent/pom.xml#L34
