### PR TITLE
Introduce `IdentifierName:AllowInitialismsInTypeName` flag

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/IdentifierNameTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/IdentifierNameTest.java
@@ -602,6 +602,17 @@ public class IdentifierNameTest {
   }
 
   @Test
+  public void className_badInitialism_allowed() {
+    helper
+        .setArgs("-XepOpt:IdentifierName:AllowInitialismsInTypeName=true")
+        .addSourceLines(
+            "Test.java", //
+            "class RPCServiceTester {",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void className_lowerCamelCase() {
     helper
         .addSourceLines(


### PR DESCRIPTION
While default `IdentifierName` behavior is unchanged, this flag allows
users to slightly relax the type name validation performed by this
check.