### PR TITLE
Remove redundant JDK toolchain version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,6 @@
         <configuration>
           <toolchains>
             <jdk>
-              <version>17</version>
               <version>25</version>
             </jdk>
           </toolchains>


### PR DESCRIPTION
This PR removes the redundant specification of JDK version in the configuration of the `maven-toolchains-plugin`.

Each property can only have one value, and the way the Maven parameter implementation works, the last value wins. I confirmed this by running a build of the current `master` using `mvnDebug` and adding a breakpoint in the `maven-toolchains-plugin`'s `ToolchainsMojo` to see what the configuration values it pulled in were:

![](https://github.com/user-attachments/assets/aab451ad-3162-45fa-b9b6-4604f9b900d7)

So the toolchains plugin is always picking `25` given the current configuration; the `17` is silently ignored.