### PR TITLE
[UnusedVariable] Add MockitoBean in exempting variable annotations

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
@@ -156,7 +156,8 @@ public final class UnusedVariable extends BugChecker implements CompilationUnitT
           "org.openqa.selenium.support.FindBys",
           "org.apache.beam.sdk.transforms.DoFn.TimerId",
           "org.apache.beam.sdk.transforms.DoFn.StateId",
-          "org.springframework.boot.test.mock.mockito.MockBean");
+          "org.springframework.boot.test.mock.mockito.MockBean",
+          "org.springframework.test.context.bean.override.mockito.MockitoBean");
 
   // TODO(ghm): Find a sensible place to dedupe this with UnnecessarilyVisible.
   private static final ImmutableSet<String> ANNOTATIONS_INDICATING_PARAMETERS_SHOULD_BE_CHECKED =


### PR DESCRIPTION
[UnusedVariable] Add MockitoBean in EXEMPTING_VARIABLE_ANNOTATIONS for UnusedVariable because spring 6.2 is migrating from MockBean to MockitoBean.

See spring 6.2 documentation https://docs.spring.io/spring-boot/api/java/org/springframework/boot/test/mock/mockito/MockBean.html

Don't hesitate if you have any questions / comments.

Thank you for your amazing error prone checker, it really helps to code better and avoid to make some common bug patterns.