### PR TITLE
Fix edge case in `InconsistentCapitalization`

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/InconsistentCapitalizationTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/InconsistentCapitalizationTest.java
@@ -194,6 +194,16 @@ public class InconsistentCapitalizationNegativeCases {
       }
     }
   }
+  
+  static class HandlesFieldsWithInconsistentCapitalization {
+    
+    private int abc;
+    private int ABC;
+    
+    void foo(int ABC) {
+    
+    }
+  }
 }\
 """)
         .doTest();


### PR DESCRIPTION
`InconsistentCapitalization` does not correctly handle the case that the class has multiple fields with names that are equivalent except for capitalization.

For example, the following code
```
class Test {
    
    private int abc;
    private int ABC;
    
    void foo(int ABC) {
    
    }
}
```
results in an error
```
[InconsistentCapitalization] Found the field 'abc' with the same name as the parameter 'ABC' but with different capitalization.
```

This proposed change fixes the behaviour for this edge case.