### PR TITLE
UnusedVariable: exempt @FieldSource

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedVariableTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedVariableTest.java
@@ -1922,4 +1922,32 @@ public class Test {
         .expectUnchanged()
         .doTest();
   }
+
+  @Test
+  public void fieldSource() {
+    helper
+        .addSourceLines(
+            "FieldSource.java",
+            """
+            package org.junit.jupiter.params.provider;
+
+            public @interface FieldSource {
+              String[] value();
+            }
+            """)
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.List;
+            import org.junit.jupiter.params.provider.FieldSource;
+
+            class Test {
+              @FieldSource("parameters")
+              void test() {}
+
+              private static final List<String> parameters = List.of("apple", "banana");
+            }
+            """)
+        .doTest();
+  }
 }


### PR DESCRIPTION
Teach `UnusedVariable` to ignore fields referenced by a `@FieldSource` annotation the same way `UnusedMethod` ignores methods referenced by a `@MethodSource` annotation.

(`@FieldSource` is only "experimental" in v5.12.0, though)

References: https://github.com/google/error-prone/issues/4713
References: https://junit.org/junit5/docs/current/api/org.junit.jupiter.params/org/junit/jupiter/params/provider/FieldSource.html