### PR TITLE
IdentifierName: accept regex to exempt type name violations

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/IdentifierName.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IdentifierName.java
@@ -60,6 +60,7 @@ import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.util.Name;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import javax.inject.Inject;
@@ -103,10 +104,14 @@ public final class IdentifierName extends BugChecker
 
   private final boolean allowInitialismsInTypeName;
 
+  private final Pattern allowRegexInTypeName;
+
   @Inject
   IdentifierName(ErrorProneFlags flags) {
     this.allowInitialismsInTypeName =
         flags.getBoolean("IdentifierName:AllowInitialismsInTypeName").orElse(false);
+    this.allowRegexInTypeName =
+        Pattern.compile(flags.get("IdentifierName:AllowRegexInTypeName").orElse(".+"));
   }
 
   @Override
@@ -294,7 +299,9 @@ public final class IdentifierName extends BugChecker
   private boolean isConformantTypeName(String name) {
     return !name.contains("_")
         && isUpperCase(name.charAt(0))
-        && (allowInitialismsInTypeName || !PROBABLE_INITIALISM.matcher(name).find());
+        && (allowInitialismsInTypeName
+            || allowRegexInTypeName.matcher(name).matches()
+            || !PROBABLE_INITIALISM.matcher(name).find());
   }
 
   private static boolean isStaticVariable(Symbol symbol) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/IdentifierNameTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/IdentifierNameTest.java
@@ -659,6 +659,21 @@ public class IdentifierNameTest {
   }
 
   @Test
+  public void className_badPattern_allowed() {
+    helper
+        .setArgs("-XepOpt:IdentifierName:AllowRegexInTypeName=.+(IT|MX?Bean)")
+        .addSourceLines(
+            "SomethingMBean.java", //
+            "interface SomethingMBean {",
+            "}")
+        .addSourceLines(
+            "SomethingIT.java", //
+            "class SomethingIT {",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void enumName() {
     helper
         .addSourceLines(


### PR DESCRIPTION
Here is an attempt at teaching `IdentifierName` to allow custom type name patterns that would otherwise be considered (true positive) violations, for use where external factors necessitate a violating form but the existing `AllowInitialismsInTypeName` is either too accepting or fails to match.

This implementation satisfies the JMX M(X)Bean type name pattern (#4776) and the Maven Failsafe plugin filter pattern (#4832), however, I consider some of its details contradictory; see notes.

For the new option I'm using the working name of `AllowRegexInTypeName`, derived from `AllowInitialismsInTypeName`, but I have reservations about that.