### PR TITLE
IdentifierName: support JDK 22 unnamed variables

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/IdentifierName.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/IdentifierName.java
@@ -278,6 +278,9 @@ public final class IdentifierName extends BugChecker
     if (isStaticVariable(symbol) && isConformantStaticVariableName(name)) {
       return true;
     }
+    if (name.isEmpty()) {
+      return true;
+    }
     return isConformantLowerCamelName(name);
   }
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/IdentifierNameTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/IdentifierNameTest.java
@@ -16,6 +16,8 @@
 
 package com.google.errorprone.bugpatterns;
 
+import static com.google.common.truth.TruthJUnit.assume;
+
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.Test;
@@ -668,6 +670,29 @@ public class IdentifierNameTest {
             "    void f() {}",
             "  }",
             "}")
+        .doTest();
+  }
+
+  @Test
+  public void unnamedVariables() {
+    assume().that(Runtime.version().feature()).isAtLeast(22);
+    helper
+        .addSourceLines(
+            "Test.java",
+            """
+            import java.util.Scanner;
+            import java.util.function.Function;
+
+            class Test {
+              void unnamed() {
+                try (var _ = new Scanner("discarded")) {
+                  Function<String, String> f = _ -> "bar";
+                  String _ = f.apply("foo");
+                }
+                catch (Exception _) {}
+              }
+            }
+            """)
         .doTest();
   }
 }


### PR DESCRIPTION
This PR nominally fixes #4847 but it is perhaps more illustrative than usable.