### PR TITLE
PrivateConstructorForUtilityClass: ignore `@SpringBootApplication`

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/PrivateConstructorForUtilityClass.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PrivateConstructorForUtilityClass.java
@@ -61,6 +61,7 @@ public final class PrivateConstructorForUtilityClass extends BugChecker
       ImmutableSet.of(
           "org.junit.runner.RunWith",
           "org.robolectric.annotation.Implements",
+          "org.springframework.boot.autoconfigure.SpringBootApplication",
           "com.google.auto.value.AutoValue");
 
   @Override


### PR DESCRIPTION
For #4834.

I'm not sure whether a test can be created for this; only `@AutoValue` already has one, I guess that class path is in order for that.