### PR TITLE
ThreadSafe: recognize name

### DIFF
--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -585,6 +585,7 @@ import com.google.errorprone.bugpatterns.threadsafety.ImmutableRefactoring;
 import com.google.errorprone.bugpatterns.threadsafety.StaticGuardedByInstance;
 import com.google.errorprone.bugpatterns.threadsafety.SynchronizeOnNonFinalField;
 import com.google.errorprone.bugpatterns.threadsafety.ThreadPriorityCheck;
+import com.google.errorprone.bugpatterns.threadsafety.ThreadSafeChecker;
 import com.google.errorprone.bugpatterns.time.DateChecker;
 import com.google.errorprone.bugpatterns.time.DurationFrom;
 import com.google.errorprone.bugpatterns.time.DurationGetTemporalUnit;
@@ -1258,6 +1259,7 @@ public class BuiltInCheckerSuppliers {
           SystemExitOutsideMain.class,
           SystemOut.class,
           TestExceptionChecker.class,
+          ThreadSafeChecker.class,
           ThrowSpecificExceptions.class,
           ThrowsUncheckedException.class,
           TimeUnitMismatch.class,


### PR DESCRIPTION
Error Prone advertises https://errorprone.info/bugpattern/ThreadSafe but does not recognize the name:

> Fatal error compiling: ThreadSafe is not a valid checker name

The implementing checker, `ThreadSafeChecker`, is missing from the index of built-in checkers. Add it to the disabled checkers alongside the other experimental checkers.

Fixes https://github.com/google/error-prone/issues/4833