### PR TITLE
Make return of findPathFromEnclosingNodeToTopLevel @Nullable

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -440,7 +440,8 @@ public class ASTHelpers {
    * Given a TreePath, finds the first enclosing node of the given type and returns the path from
    * the enclosing node to the top-level {@code CompilationUnitTree}.
    */
-  public static <T> TreePath findPathFromEnclosingNodeToTopLevel(TreePath path, Class<T> klass) {
+  public static <T> @Nullable TreePath findPathFromEnclosingNodeToTopLevel(
+      TreePath path, Class<T> klass) {
     if (path != null) {
       do {
         path = path.getParentPath();


### PR DESCRIPTION
It can clearly return `null`