### PR TITLE
Adds type_annotations back but as a relocation to annotations

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -29,6 +29,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_type_annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     <module>core</module>
     <module>annotation</module>
     <module>annotations</module>
+    <module>type_annotations</module>
     <module>docgen</module>
     <module>docgen_processor</module>
     <module>refaster</module>

--- a/type_annotations/pom.xml
+++ b/type_annotations/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2025 The Error Prone Authors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.google.errorprone</groupId>
+    <artifactId>error_prone_parent</artifactId>
+    <version>1.0-HEAD-SNAPSHOT</version>
+  </parent>
+
+  <name>error-prone type annotations</name>
+  <artifactId>error_prone_type_annotations</artifactId>
+
+  <distributionManagement>
+    <relocation>
+      <artifactId>error_prone_annotations</artifactId>
+      <message>error_prone_type_annotations has been merged into error_prone_annotations</message>
+    </relocation>
+  </distributionManagement>
+
+  <licenses>
+    <license>
+      <name>Apache 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+</project>


### PR DESCRIPTION
Adds a dependency to type_annotations into annotations to make sure it'll "update" an older type_annotations dependency present in the same "bag" of dependencies (works best in Gradle; Maven having a "nearest definition" rule so won't always work but hopefully people align versions one way or another).