### PR TITLE
Remove dependency on error_prone_type_annotations

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -29,11 +29,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.errorprone</groupId>
-      <artifactId>error_prone_type_annotations</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>


### PR DESCRIPTION
error_prone_type_annotations has been merged in error_prone_annotations, but the latter still depends on the former. Package managers that doesn't handle relocated missing dependencies (such as Bazel's rules_jvm_external) struggles with this.

This cleans up the no longer needed dependency.