### PR TITLE
[PatternMatchingInstanceof] Make negated matches optional

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/PatternMatchingInstanceofTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/PatternMatchingInstanceofTest.java
@@ -58,6 +58,36 @@ public final class PatternMatchingInstanceofTest {
   }
 
   @Test
+  public void positive_disabledNegation() {
+    helper
+        .addInputLines(
+            "Test.java",
+            """
+            class Test {
+              void test(Object o) {
+                if (o instanceof Test) {
+                  Test test = (Test) o;
+                  test(test);
+                }
+              }
+            }
+            """)
+        .addOutputLines(
+            "Test.java",
+            """
+            class Test {
+              void test(Object o) {
+                if (o instanceof Test test) {
+                  test(test);
+                }
+              }
+            }
+            """)
+        .setArgs("-XepOpt:PatternMatchingInstanceof:EnableNegatedMatches=false")
+        .doTest();
+  }
+
+  @Test
   public void negatedIf() {
     helper
         .addInputLines(
@@ -85,6 +115,27 @@ public final class PatternMatchingInstanceofTest {
               }
             }
             """)
+        .doTest();
+  }
+
+  @Test
+  public void negatedIf_disabledNegation() {
+    helper
+        .addInputLines(
+            "Test.java",
+            """
+            class Test {
+              void test(Object o) {
+                if (!(o instanceof Test)) {
+                } else {
+                  Test test = (Test) o;
+                  test(test);
+                }
+              }
+            }
+            """)
+        .expectUnchanged()
+        .setArgs("-XepOpt:PatternMatchingInstanceof:EnableNegatedMatches=false")
         .doTest();
   }
 
@@ -184,6 +235,27 @@ public final class PatternMatchingInstanceofTest {
               }
             }
             """)
+        .doTest();
+  }
+
+  @Test
+  public void negatedIfWithReturn_disabledNegation() {
+    helper
+        .addInputLines(
+            "Test.java",
+            """
+            class Test {
+              void test(Object o) {
+                if (!(o instanceof Test)) {
+                  return;
+                }
+                Test test = (Test) o;
+                test(test);
+              }
+            }
+            """)
+        .expectUnchanged()
+        .setArgs("-XepOpt:PatternMatchingInstanceof:EnableNegatedMatches=false")
         .doTest();
   }
 
@@ -615,6 +687,47 @@ public final class PatternMatchingInstanceofTest {
               }
             }
             """)
+        .doTest();
+  }
+
+  @Test
+  public void withinIfCondition_andUsedAfter_disabledNegation() {
+    helper
+        .addInputLines(
+            "Test.java",
+            """
+            class Test {
+              private final int x = 0;
+              private final int y = 1;
+
+              @Override
+              public boolean equals(Object o) {
+                if (!(o instanceof Test) || ((Test) o).x != this.x) {
+                  return false;
+                }
+                Test other = (Test) o;
+                return other.y == this.y;
+              }
+            }
+            """)
+        .addOutputLines(
+            "Test.java",
+            """
+            class Test {
+              private final int x = 0;
+              private final int y = 1;
+
+              @Override
+              public boolean equals(Object o) {
+                if (!(o instanceof Test test) || test.x != this.x) {
+                  return false;
+                }
+                Test other = (Test) o;
+                return other.y == this.y;
+              }
+            }
+            """)
+        .setArgs("-XepOpt:PatternMatchingInstanceof:EnableNegatedMatches=false")
         .doTest();
   }
 

--- a/docs/bugpattern/PatternMatchingInstanceof.md
+++ b/docs/bugpattern/PatternMatchingInstanceof.md
@@ -24,5 +24,11 @@ void handle(Object o) {
 }
 ```
 
+If the flag `-XepOpt:PatternMatchingInstanceof:EnableNegatedMatches=false` is used,
+only casts that are in the same expression as the instanceof
+or in the block that starts with the instanceof are rewritten,
+but casts inside else branches or below an if statement with a negated instanceof
+are left unchanged.
+
 For more information on pattern matching and `instanceof`, see
 [Pattern Matching for the instanceof Operator](https://docs.oracle.com/en/java/javase/21/language/pattern-matching-instanceof.html)


### PR DESCRIPTION
This introduces a configuration option that allows one to disable the replacement of casts that are implied by a negated instanceof expression and are not within the same expression as the instanceof. This affects casts in else branches and those below an if statement where the then branch always returns from the method. Casts where the readability benefit of a pattern-maching instanceof is clear, i.e. those within the then branch of an if and those inside the same expression, are still replaced.

The default of the option is true, which keeps the current behavior. It would also be possible to change this in order to only produce suggestions for the obvious cases by default.

Fixes #4925