### PR TITLE
Clarify that class Ascii is from Guava.

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/StringCaseLocaleUsage.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/StringCaseLocaleUsage.java
@@ -86,7 +86,7 @@ public final class StringCaseLocaleUsage extends BugChecker implements MethodInv
     var fix =
         SuggestedFix.builder()
             .setShortDescription(
-                "Replace with Ascii.toLower/UpperCase; this changes behaviour for non-ASCII"
+                "Replace with Guava's Ascii.toLower/UpperCase; this changes behaviour for non-ASCII"
                     + " Strings");
     String ascii = SuggestedFixes.qualifyType(state, fix, "com.google.common.base.Ascii");
     fix.replace(

--- a/docs/bugpattern/StringCaseLocaleUsage.md
+++ b/docs/bugpattern/StringCaseLocaleUsage.md
@@ -10,4 +10,5 @@ If this kind of regionalisation is desired, use
 `.toLowerCase(Locale.getDefault())` to make that explicit. If not,
 `.toLowerCase(Locale.ROOT)` or `.toLowerCase(Locale.ENGLISH)` will give you
 casing independent of the user's current `Locale`. If you know that you're
-operating on ASCII, prefer `Ascii.toLower/UpperCase` to make that explicit.
+operating on ASCII, prefer `Ascii.toLower/UpperCase` (from Guava, if available)
+to make that explicit.


### PR DESCRIPTION
This avoids initial confusion for stupid users (like me!) who when working outside of Google internal codebase and when first encountering this error go look for a class `Ascii` in the JDK.

@cushon how about this? Or would rather prefer not?