### PR TITLE
Fix typo in NullTernary.md

### DIFF
--- a/docs/bugpattern/NullTernary.md
+++ b/docs/bugpattern/NullTernary.md
@@ -4,7 +4,7 @@ If a conditional expression evaluates to `null`, unboxing it will result in a
 For example:
 
 ```java
-int x = flag ? foo : null:
+int x = flag ? foo : null;
 ```
 
 If `flag` is false, `null` will be auto-unboxed from an `Integer` to `int`,


### PR DESCRIPTION
This PR fixes a typo in the `NullTernary.md`.