### PR TITLE
Use single quotes for backslashes in StringConcatToTextBlock.md

### DIFF
--- a/docs/bugpattern/StringConcatToTextBlock.md
+++ b/docs/bugpattern/StringConcatToTextBlock.md
@@ -29,7 +29,7 @@ String message =
 
 ## Trailing newlines
 
-If the string should not contain a trailing newline, use a `\ ` to escape the
+If the string should not contain a trailing newline, use a '\' to escape the
 final newline in the text block. That is, these two strings are equivalent:
 
 ```java
@@ -46,11 +46,11 @@ String s =
 
 The suggested fixes for this check preserve the exact contents of the original
 string, so if the original string doesn't include a trailing newline the fix
-will use a `\ ` to escape the last newline.
+will use a '\' to escape the last newline.
 
 If the whitespace in the string isn't significant, for example because the
 string value will be parsed by a parser that doesn't care about the trailing
-newlines, consider removing the final `\ ` to improve the readability of the
+newlines, consider removing the final '\' to improve the readability of the
 string.
 
 [text blocks]: https://docs.oracle.com/en/java/javase/23/text-blocks/index.html


### PR DESCRIPTION
"\`\ \`" doesn't seem to be rendered nicely as follows:

<img width="1156" alt="Screenshot 2025-05-06 at 12 39 51 AM" src="https://github.com/user-attachments/assets/07c90740-d273-42ed-9be5-88634f80cf0c" />

This PR attempts to fix it by using single quotes for backslashes in the `StringConcatToTextBlock.md` instead.

See https://errorprone.info/bugpattern/StringConcatToTextBlock