### PR TITLE
Create variable names that are CheckStyle compat

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/PatternMatchingInstanceof.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PatternMatchingInstanceof.java
@@ -53,6 +53,8 @@ import com.sun.source.util.TreePath;
 import com.sun.source.util.TreePathScanner;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.TypeTag;
+
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.stream.Stream;
 import javax.inject.Inject;
@@ -162,11 +164,17 @@ public final class PatternMatchingInstanceof extends BugChecker implements Insta
   private static String generateVariableName(Type targetType, VisitorState state) {
     Type unboxed = state.getTypes().unboxedType(targetType);
     String simpleName = targetType.tsym.getSimpleName().toString();
-    String lowerFirstLetter = toLowerCase(String.valueOf(simpleName.charAt(0)));
-    String camelCased = lowerFirstLetter + simpleName.substring(1);
+    char[] chars = simpleName.toCharArray();
+    chars[0] = Character.toLowerCase(chars[0]);
+    for (int i = 1; i < chars.length + 1; i++) {
+      if (Character.isUpperCase(chars[i]) && Character.isUpperCase(chars[i + 1])) {
+        chars[i] = Character.toLowerCase(chars[i]);
+      }
+    }
+    String camelCased = new String(chars);
     if (SourceVersion.isKeyword(camelCased)
         || (unboxed != null && unboxed.getTag() != TypeTag.NONE)) {
-      return lowerFirstLetter;
+      return Character.toString(Character.toLowerCase(simpleName.charAt(0)));
     }
     return camelCased;
   }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PatternMatchingInstanceof.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PatternMatchingInstanceof.java
@@ -165,11 +165,14 @@ public final class PatternMatchingInstanceof extends BugChecker implements Insta
     Type unboxed = state.getTypes().unboxedType(targetType);
     String simpleName = targetType.tsym.getSimpleName().toString();
     char[] chars = simpleName.toCharArray();
+    boolean priotCharWasUpper = Character.isUpperCase(chars[0]);;
     chars[0] = Character.toLowerCase(chars[0]);
-    for (int i = 1; i < chars.length + 1; i++) {
-      if (Character.isUpperCase(chars[i]) && Character.isUpperCase(chars[i + 1])) {
+    for (int i = 1; i < chars.length - 1; i++) {
+      boolean currentCharIsUpper = Character.isUpperCase(chars[i]);
+      if (currentCharIsUpper && priotCharWasUpper && Character.isUpperCase(chars[i + 1])) {
         chars[i] = Character.toLowerCase(chars[i]);
       }
+      priotCharWasUpper = currentCharIsUpper;
     }
     String camelCased = new String(chars);
     if (SourceVersion.isKeyword(camelCased)

--- a/core/src/test/java/com/google/errorprone/bugpatterns/PatternMatchingInstanceofTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/PatternMatchingInstanceofTest.java
@@ -507,11 +507,17 @@ public final class PatternMatchingInstanceofTest {
                     "Class.java",
                     """
                     import java.sql.SQLException;
+                    import java.io.InterruptedIOException;
                     
                     class Class {
                       void test(SQLException e) {
                         if (e instanceof SQLException) {
-                          test((Class) e);
+                          test((SQLException) e);
+                        }
+                      }
+                      void test(InterruptedIOException e) {
+                        if (e instanceof InterruptedIOException) {
+                          test((InterruptedIOException) e);
                         }
                       }
                     }
@@ -520,11 +526,17 @@ public final class PatternMatchingInstanceofTest {
                     "Class.java",
                     """
                     import java.sql.SQLException;
+                    import java.io.InterruptedIOException;
                     
                     class Class {
                       void test(SQLException o) {
                         if (e instanceof SQLException sqlException) {
                           test(sqlException);
+                        }
+                      }
+                      void test(InterruptedIOException e) {
+                        if (e instanceof InterruptedIOException interruptedIoException) {
+                          test(interruptedIoException);
                         }
                       }
                     }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/PatternMatchingInstanceofTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/PatternMatchingInstanceofTest.java
@@ -501,6 +501,38 @@ public final class PatternMatchingInstanceofTest {
   }
 
   @Test
+  public void checkStyleCompliantName() {
+    helper
+            .addInputLines(
+                    "Class.java",
+                    """
+                    import java.sql.SQLException;
+                    
+                    class Class {
+                      void test(SQLException e) {
+                        if (e instanceof SQLException) {
+                          test((Class) e);
+                        }
+                      }
+                    }
+                    """)
+            .addOutputLines(
+                    "Class.java",
+                    """
+                    import java.sql.SQLException;
+                    
+                    class Class {
+                      void test(SQLException o) {
+                        if (e instanceof SQLException sqlException) {
+                          test(sqlException);
+                        }
+                      }
+                    }
+                    """)
+            .doTest();
+  }
+
+  @Test
   public void recordPatternMatching() {
     assume().that(Runtime.version().feature()).isAtLeast(21);
 


### PR DESCRIPTION
Existing code creates variable name for pattern match by lowercasing first char.
A common case where this rule will apply is SQLException, but sQLException fails https://checkstyle.sourceforge.io/checks/naming/abbreviationaswordinname.html#Description
where allowedAbbreviationLength is anything < 3.

This change lowercases the first char, and then any subsequent char where the char before is uppercase, and the char after is uppercase, resulting in:
SQLException -> sqlException
IOException -> ioException
InterruptedIOException -> interuptedIoException