### PR TITLE
Fix typos in OperatorPrecedence.md

### DIFF
--- a/docs/bugpattern/OperatorPrecedence.md
+++ b/docs/bugpattern/OperatorPrecedence.md
@@ -14,15 +14,15 @@ misinterpreted.
 For example, consider this:
 
 ```java
-boolean d = (a && b) || c;",
-boolean e = (a || b) ? c : d;",
-int z = (x + y) << 2;",
+boolean d = (a && b) || c;
+boolean e = (a || b) ? c : d;
+int z = (x + y) << 2;
 ```
 
 Instead of this:
 
 ```java
-boolean r = a && b || c;",
-boolean e = a || b ? c : d;",
-int z = x + y << 2;",
+boolean d = a && b || c;
+boolean e = a || b ? c : d;
+int z = x + y << 2;
 ```


### PR DESCRIPTION
This PR fixes typos in the `OperatorPrecedence.md`.