### PR TITLE
Added RedundantNullCheck bug pattern

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/NullnessUtils.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/NullnessUtils.java
@@ -420,13 +420,16 @@ class NullnessUtils {
 
     Name name = nullChecked instanceof IdentifierTree id ? id.getName() : null;
 
-    VarSymbol varSymbol = getSymbol(nullChecked) instanceof VarSymbol vs ? vs : null;
+    Symbol symbol = getSymbol(nullChecked);
+    VarSymbol varSymbol = symbol instanceof VarSymbol vs ? vs : null;
+    MethodSymbol methodSymbol = symbol instanceof MethodSymbol ms ? ms : null;
 
-    return new NullCheck(name, varSymbol, polarity);
+    return new NullCheck(name, varSymbol, methodSymbol, polarity);
   }
 
   /**
-   * A check of a variable against {@code null}, like {@code foo == null}.
+   * A check of a variable or method call against {@code null}, like {@code foo == null},
+   * or {@code foo.method() == null}.
    *
    * <p>This class exposes the variable in two forms: the {@link VarSymbol} (if available) and the
    * {@link Name} (if the null check was performed on a bare identifier, like {@code foo}). Many
@@ -455,10 +458,13 @@ class NullnessUtils {
    *     documentation.
    * @param varSymbolButUsuallyPreferBareIdentifier Returns the symbol that was checked against
    *     {@code null}.
+   * @param methodSymbol Returns the method symbol that was checked against {@code null}, if the
+   *     null check took that form.
    */
   record NullCheck(
       @Nullable Name bareIdentifier,
       @Nullable VarSymbol varSymbolButUsuallyPreferBareIdentifier,
+      @Nullable MethodSymbol methodSymbol,
       Polarity polarity) {
     boolean bareIdentifierMatches(ExpressionTree other) {
       return other instanceof IdentifierTree identifierTree

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheck.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheck.java
@@ -126,9 +126,11 @@ public class RedundantNullCheck extends BugChecker
         varSymbol.getKind() == ElementKind.LOCAL_VARIABLE
             || varSymbol.getKind() == ElementKind.RESOURCE_VARIABLE;
 
-    Optional<Nullness> varNullness = NullnessAnnotations.fromAnnotationsOn(varSymbol);
-    if (varNullness.isPresent()) {
-      return varNullness.get() == Nullness.NULLABLE;
+    if (!isLocalOrResourceVariable) {
+      Optional<Nullness> varNullness = NullnessAnnotations.fromAnnotationsOn(varSymbol);
+      if (varNullness.isPresent()) {
+        return varNullness.get() == Nullness.NULLABLE;
+      }
     }
 
     if (varSymbol.asType().getKind() == TYPEVAR) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheck.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheck.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.nullness;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
+import com.google.errorprone.bugpatterns.nullness.NullnessUtils.NullCheck;
+import com.google.errorprone.dataflow.nullnesspropagation.Nullness;
+import com.google.errorprone.dataflow.nullnesspropagation.NullnessAnnotations;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+
+import com.sun.source.tree.BinaryTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+
+import java.util.Optional;
+
+@BugPattern(
+    summary = "Explicit null check on a variable or method call that is not @Nullable within a @NullMarked scope.",
+    severity = WARNING)
+public class RedundantNullCheck extends BugChecker implements BinaryTreeMatcher {
+
+  @Override
+  public Description matchBinary(BinaryTree tree, VisitorState state) {
+    NullCheck nullCheck = NullnessUtils.getNullCheck(tree);
+    if (nullCheck == null) {
+      return NO_MATCH;
+    }
+
+    VarSymbol varSymbol = nullCheck.varSymbolButUsuallyPreferBareIdentifier();
+    if (varSymbol != null) {
+      VariableTree varDecl = NullnessUtils.findDeclaration(state, varSymbol);
+
+      if (varDecl != null
+          && varDecl.getInitializer() != null
+          && varDecl.getInitializer().getKind() == Tree.Kind.METHOD_INVOCATION) {
+        MethodInvocationTree methodInvocation = (MethodInvocationTree) varDecl.getInitializer();
+        MethodSymbol methodSymbol = ASTHelpers.getSymbol(methodInvocation);
+
+        if (methodSymbol != null && isEffectivelyNullable(methodSymbol, state)) {
+          return NO_MATCH;
+        }
+      }
+
+      if (!NullnessUtils.isInNullMarkedScope(varSymbol, state)) {
+        return NO_MATCH;
+      }
+
+      if (NullnessUtils.isAlreadyAnnotatedNullable(varSymbol)) {
+        return NO_MATCH;
+      }
+    } else {
+      MethodSymbol methodSymbol = nullCheck.methodSymbol();
+      if (methodSymbol == null) {
+        return NO_MATCH;
+      }
+      if (isEffectivelyNullable(methodSymbol, state)) {
+        return NO_MATCH;
+      }
+    }
+    return buildDescription(tree).build();
+  }
+
+  private static boolean isEffectivelyNullable(MethodSymbol methodSymbol, VisitorState state) {
+    Optional<Nullness> returnTypeNullness = NullnessAnnotations.fromAnnotationsOn(methodSymbol);
+    if (returnTypeNullness.isPresent()) {
+      // Explicit @Nullable or @NonNull on the return type
+      return returnTypeNullness.get() == Nullness.NULLABLE;
+    }
+    // No explicit annotation on return type.
+    // Default based on the null-marked status of the method's defining scope.
+    // If the method's defining scope is NOT @NullMarked (or is @NullUnmarked),
+    // its unannotated return type is effectively nullable.
+    return !NullnessUtils.isInNullMarkedScope(methodSymbol, state);
+  }
+}

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheck.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheck.java
@@ -24,6 +24,7 @@ import static com.google.errorprone.util.ASTHelpers.isConsideredFinal;
 import static javax.lang.model.type.TypeKind.TYPEVAR;
 
 import com.google.errorprone.BugPattern;
+import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.BinaryTreeMatcher;
@@ -47,6 +48,7 @@ import com.sun.tools.javac.code.Symbol.VarSymbol;
 
 import java.util.Optional;
 
+import javax.inject.Inject;
 import javax.lang.model.element.ElementKind;
 
 @BugPattern(
@@ -58,8 +60,19 @@ public class RedundantNullCheck extends BugChecker
   private static final Matcher<ExpressionTree> OBJECTS_REQUIRE_NON_NULL =
       staticMethod().onClass("java.util.Objects").named("requireNonNull");
 
+  private final boolean checkRequireNonNull;
+
+  @Inject
+  public RedundantNullCheck(ErrorProneFlags flags) {
+    this.checkRequireNonNull =
+        flags.getBoolean("RedundantNullCheck:CheckRequireNonNull").orElse(false);
+  }
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+    if (!checkRequireNonNull) {
+      return NO_MATCH;
+    }
     if (!OBJECTS_REQUIRE_NON_NULL.matches(tree, state)) {
       return NO_MATCH;
     }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheck.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheck.java
@@ -156,16 +156,11 @@ public class RedundantNullCheck extends BugChecker
       if (initializer.getKind() == Tree.Kind.METHOD_INVOCATION) {
         MethodInvocationTree methodInvocation = (MethodInvocationTree) initializer;
         MethodSymbol methodSymbol = ASTHelpers.getSymbol(methodInvocation);
-        if (methodSymbol != null && isEffectivelyNullable(methodSymbol, state)) {
-          return true;
-        }
+        return methodSymbol != null && isEffectivelyNullable(methodSymbol, state);
       } else if (initializer instanceof LiteralTree) {
-        if (initializer.getKind() == Tree.Kind.NULL_LITERAL) {
-          return true;
-        }
-      } else {
-        return true;
+        return initializer.getKind() == Tree.Kind.NULL_LITERAL;
       }
+      return true;
     }
 
     return !NullnessUtils.isInNullMarkedScope(varSymbol, state);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheck.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheck.java
@@ -156,10 +156,11 @@ public class RedundantNullCheck extends BugChecker
       if (initializer.getKind() == Tree.Kind.METHOD_INVOCATION) {
         MethodInvocationTree methodInvocation = (MethodInvocationTree) initializer;
         MethodSymbol methodSymbol = ASTHelpers.getSymbol(methodInvocation);
-        return methodSymbol != null && isEffectivelyNullable(methodSymbol, state);
+        return methodSymbol == null || isEffectivelyNullable(methodSymbol, state);
       } else if (initializer instanceof LiteralTree) {
         return initializer.getKind() == Tree.Kind.NULL_LITERAL;
       }
+
       return true;
     }
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheck.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheck.java
@@ -122,6 +122,10 @@ public class RedundantNullCheck extends BugChecker
   }
 
   private static boolean isEffectivelyNullable(VarSymbol varSymbol, VisitorState state) {
+    boolean isLocalOrResourceVariable =
+        varSymbol.getKind() == ElementKind.LOCAL_VARIABLE
+            || varSymbol.getKind() == ElementKind.RESOURCE_VARIABLE;
+
     Optional<Nullness> varNullness = NullnessAnnotations.fromAnnotationsOn(varSymbol);
     if (varNullness.isPresent()) {
       return varNullness.get() == Nullness.NULLABLE;
@@ -136,9 +140,7 @@ public class RedundantNullCheck extends BugChecker
       return true;
     }
 
-    if ((varSymbol.getKind() == ElementKind.LOCAL_VARIABLE
-            || varSymbol.getKind() == ElementKind.RESOURCE_VARIABLE)
-        && varDecl != null) {
+    if (isLocalOrResourceVariable && varDecl != null) {
       if (varDecl.getInitializer() == null) {
         return true;
       }

--- a/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
+++ b/core/src/main/java/com/google/errorprone/scanner/BuiltInCheckerSuppliers.java
@@ -580,6 +580,7 @@ import com.google.errorprone.bugpatterns.nullness.NullablePrimitiveArray;
 import com.google.errorprone.bugpatterns.nullness.NullableTypeParameter;
 import com.google.errorprone.bugpatterns.nullness.NullableWildcard;
 import com.google.errorprone.bugpatterns.nullness.ParameterMissingNullable;
+import com.google.errorprone.bugpatterns.nullness.RedundantNullCheck;
 import com.google.errorprone.bugpatterns.nullness.ReturnMissingNullable;
 import com.google.errorprone.bugpatterns.nullness.UnnecessaryCheckNotNull;
 import com.google.errorprone.bugpatterns.nullness.UnsafeWildcard;
@@ -1257,6 +1258,7 @@ public class BuiltInCheckerSuppliers {
           PrivateConstructorForUtilityClass.class,
           PublicApiNamedStreamShouldReturnStream.class,
           QualifierWithTypeUse.class,
+          RedundantNullCheck.class,
           RedundantOverride.class,
           RedundantThrows.class,
           RefersToDaggerCodegen.class,

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheckTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheckTest.java
@@ -754,4 +754,19 @@ public class RedundantNullCheckTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void positive_nonNullAnnotated_outsideNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NonNull;",
+            "class Test {",
+            "  void foo(@NonNull String s) {",
+            "    // BUG: Diagnostic contains: RedundantNullCheck",
+            "    if (s == null) {}",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheckTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheckTest.java
@@ -672,6 +672,7 @@ public class RedundantNullCheckTest {
   @Test
   public void positive_objectsRequireNonNull_inNullMarkedScope() {
     compilationHelper
+        .setArgs("-XepOpt:RedundantNullCheck:CheckRequireNonNull=true")
         .addSourceLines(
             "Test.java",
             "import org.jspecify.annotations.NullMarked;",
@@ -689,6 +690,7 @@ public class RedundantNullCheckTest {
   @Test
   public void positive_objectsRequireNonNull_methodCall_inNullMarkedScope() {
     compilationHelper
+        .setArgs("-XepOpt:RedundantNullCheck:CheckRequireNonNull=true")
         .addSourceLines(
             "Test.java",
             "import org.jspecify.annotations.NullMarked;",
@@ -705,8 +707,25 @@ public class RedundantNullCheckTest {
   }
 
   @Test
+  public void negative_objectsRequireNonNull_byDefault() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import java.util.Objects;",
+            "@NullMarked",
+            "class Test {",
+            "  void foo(String s) {",
+            "    Objects.requireNonNull(s);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void negative_objectsRequireNonNull_explicitlyNullable_inNullMarkedScope() {
     compilationHelper
+        .setArgs("-XepOpt:RedundantNullCheck:CheckRequireNonNull=true")
         .addSourceLines(
             "Test.java",
             "import org.jspecify.annotations.NullMarked;",
@@ -724,6 +743,7 @@ public class RedundantNullCheckTest {
   @Test
   public void negative_objectsRequireNonNull_outsideNullMarkedScope() {
     compilationHelper
+        .setArgs("-XepOpt:RedundantNullCheck:CheckRequireNonNull=true")
         .addSourceLines(
             "Test.java",
             "import java.util.Objects;",

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheckTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheckTest.java
@@ -621,17 +621,16 @@ public class RedundantNullCheckTest {
   }
 
   @Test
-  public void negative_localVariable_annotatedNullable_inNullMarkedScope() {
+  public void positive_localVariable_annotatedNullable() {
     compilationHelper
         .addSourceLines(
             "Test.java",
-            "import org.jspecify.annotations.NullMarked;",
             "import org.jspecify.annotations.Nullable;",
-            "@NullMarked",
             "class Test {",
             "  void foo() {",
             "    @Nullable String s = \"hello\";",
-            "    if (s == null) { /* This is fine */ }",
+            "    // BUG: Diagnostic contains: RedundantNullCheck",
+            "    if (s == null) {}",
             "  }",
             "}")
         .doTest();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheckTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheckTest.java
@@ -496,6 +496,22 @@ public class RedundantNullCheckTest {
   }
 
   @Test
+  public void positive_constructorCall_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "@NullMarked",
+            "class Test {",
+            "  void foo() {",
+            "    // BUG: Diagnostic contains: RedundantNullCheck",
+            "    if (new Object() == null) {}",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void negative_methodCall_onInstance_explicitlyNullableReturn_inNullMarkedScope() {
     compilationHelper
         .addSourceLines(
@@ -648,6 +664,72 @@ public class RedundantNullCheckTest {
             "  T get() { return null; }",
             "  void foo() {",
             "    if (get() == null) { /* This is fine, T could be nullable */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positive_objectsRequireNonNull_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import java.util.Objects;",
+            "@NullMarked",
+            "class Test {",
+            "  void foo(String s) {",
+            "    // BUG: Diagnostic contains: RedundantNullCheck",
+            "    Objects.requireNonNull(s);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positive_objectsRequireNonNull_methodCall_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import java.util.Objects;",
+            "@NullMarked",
+            "class Test {",
+            "  String getString() { return \"foo\"; }",
+            "  void foo() {",
+            "    // BUG: Diagnostic contains: RedundantNullCheck",
+            "    Objects.requireNonNull(getString());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_objectsRequireNonNull_explicitlyNullable_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "import java.util.Objects;",
+            "@NullMarked",
+            "class Test {",
+            "  void foo(@Nullable String s) {",
+            "    Objects.requireNonNull(s); // This is fine",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_objectsRequireNonNull_outsideNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import java.util.Objects;",
+            "class Test {",
+            "  void foo(String s) {",
+            "    Objects.requireNonNull(s); // This is fine",
             "  }",
             "}")
         .doTest();

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheckTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheckTest.java
@@ -621,6 +621,23 @@ public class RedundantNullCheckTest {
   }
 
   @Test
+  public void negative_localVariable_annotatedNullable_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "@NullMarked",
+            "class Test {",
+            "  void foo() {",
+            "    @Nullable String s = \"hello\";",
+            "    if (s == null) { /* This is fine */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void positive_variableInitializedWithLiteral_inNullMarkedScope() {
     compilationHelper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheckTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheckTest.java
@@ -1,0 +1,497 @@
+/*
+ * Copyright 2025 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.bugpatterns.nullness;
+
+import com.google.errorprone.CompilationTestHelper;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class RedundantNullCheckTest {
+
+  private final CompilationTestHelper compilationHelper =
+      CompilationTestHelper.newInstance(RedundantNullCheck.class, getClass());
+
+  @Test
+  public void positive_equalsNull_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "@NullMarked",
+            "class Test {",
+            "  void foo(String s) {",
+            "    // BUG: Diagnostic contains: RedundantNullCheck",
+            "    if (s == null) {",
+            "      System.out.println(\"s is null\");",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positive_notEqualsNull_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "@NullMarked",
+            "class Test {",
+            "  void foo(String s) {",
+            "    // BUG: Diagnostic contains: RedundantNullCheck",
+            "    if (s != null) {",
+            "      System.out.println(\"s is not null\");",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_explicitlyNullable_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "@NullMarked",
+            "class Test {",
+            "  void foo(@Nullable String s) {",
+            "    if (s == null) { /* This is fine */ }",
+            "    if (s != null) { /* This is fine */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_outsideNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void foo(String s) {",
+            "    if (s == null) { /* This is fine */ }",
+            "    if (s != null) { /* This is fine */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_classMarkedAndUnmarked_effectivelyUnmarked() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.NullUnmarked;",
+            "@NullMarked",
+            "@NullUnmarked", // This should override @NullMarked for the class scope
+            "class Test {",
+            "  void foo(String s) {",
+            "    if (s == null) { /* This is fine */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_packageNullMarked_classNullUnmarked() {
+    compilationHelper
+        .addSourceLines(
+            "foo/package-info.java",
+            "@org.jspecify.annotations.NullMarked",
+            "package foo;")
+        .addSourceLines(
+            "foo/Test.java",
+            "package foo;",
+            "import org.jspecify.annotations.NullUnmarked;",
+            "@NullUnmarked",
+            "class Test {",
+            "  void foo(String s) {",
+            "    if (s == null) { /* This is fine */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positive_packageNullMarked_classNotAnnotated() {
+    compilationHelper
+        .addSourceLines(
+            "foo/package-info.java",
+            "@org.jspecify.annotations.NullMarked",
+            "package foo;")
+        .addSourceLines(
+            "foo/Test.java",
+            "package foo;",
+            "class Test {",
+            "  void foo(String s) {",
+            "    // BUG: Diagnostic contains: RedundantNullCheck",
+            "    if (s == null) {}",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_packageNullMarked_methodNullUnmarked() {
+    compilationHelper
+        .addSourceLines(
+            "foo/package-info.java",
+            "@org.jspecify.annotations.NullMarked",
+            "package foo;")
+        .addSourceLines(
+            "foo/Test.java",
+            "package foo;",
+            "import org.jspecify.annotations.NullUnmarked;",
+            "class Test {",
+            "  @NullUnmarked",
+            "  void foo(String s) {",
+            "    if (s == null) { /* This is fine */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positive_field_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "@NullMarked",
+            "class Test {",
+            "  String f;",
+            "  void foo() {",
+            "    // BUG: Diagnostic contains: RedundantNullCheck",
+            "    if (f == null) {",
+            "      System.out.println(\"f is null\");",
+            "    }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_field_explicitlyNullable_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "@NullMarked",
+            "class Test {",
+            "  @Nullable String f;",
+            "  void foo() {",
+            "    if (f == null) { /* This is fine */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_variableInitializedFromUnannotatedMethod_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "UnannotatedLib.java", // Separate file, not @NullMarked
+            "class UnannotatedLib {",
+            "  public static String getString() { return null; }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "@NullMarked",
+            "class Test {",
+            "  void process() {",
+            "    String result = UnannotatedLib.getString();",
+            "    if (result == null) { /* This check should NOT be redundant */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_variableInitializedFromMapGet_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import java.util.Map;",
+            "@NullMarked",
+            "class Test {",
+            "  void process(Map<String, String> map, String key) {",
+            "    String value = map.get(key);",
+            "    if (value == null) { /* This check should NOT be redundant */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_variableInitializedFromAnnotatedLib_returnNullable_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "AnnotatedLibNullable.java",
+            "package mylib;",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "@NullMarked",
+            "public class AnnotatedLibNullable {",
+            "  public static @Nullable String getString() { return null; }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import mylib.AnnotatedLibNullable;",
+            "@NullMarked",
+            "class Test {",
+            "  void process() {",
+            "    String result = AnnotatedLibNullable.getString();",
+            "    if (result == null) { /* This check should NOT be redundant */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positive_variableInitializedFromNonAnnotatedLib_returnNonNull_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "NonAnnotatedLibNonNull.java", // Not @NullMarked
+            "package mylib;",
+            "import org.jspecify.annotations.NonNull;",
+            "public class NonAnnotatedLibNonNull {",
+            // Even though the lib is not @NullMarked, the @NonNull is explicit
+            "  public static @NonNull String getString() { return \"non-null\"; }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import mylib.NonAnnotatedLibNonNull;",
+            "@NullMarked",
+            "class Test {",
+            "  void process() {",
+            "    String result = NonAnnotatedLibNonNull.getString();",
+            "    // BUG: Diagnostic contains: RedundantNullCheck",
+            "    if (result == null) { }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positive_methodCall_inNullMarkedScope_defaultNonNullReturn() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "@NullMarked",
+            "class Test {",
+            "  String getString() { return \"foo\"; }",
+            "  void process() {",
+            "    // BUG: Diagnostic contains: RedundantNullCheck",
+            "    if (getString() == null) {}",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_methodCall_inNullMarkedScope_explicitlyNullableReturn() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "@NullMarked",
+            "class Test {",
+            "  @Nullable String getNullableString() { return null; }",
+            "  void process() {",
+            "    if (getNullableString() == null) { /* This is fine */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positive_methodCall_inNullMarkedScope_explicitlyNonNullReturn() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.NonNull;",
+            "@NullMarked",
+            "class Test {",
+            "  @NonNull String getNonNullString() { return \"foo\"; }",
+            "  void process() {",
+            "    // BUG: Diagnostic contains: RedundantNullCheck",
+            "    if (getNonNullString() == null) {}",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_methodCall_fromUnannotatedLib_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "UnannotatedLib.java", // Separate file, not @NullMarked
+            "class UnannotatedLib {",
+            "  public static String getString() { return null; }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "@NullMarked",
+            "class Test {",
+            "  void process() {",
+            "    if (UnannotatedLib.getString() == null) { /* This check should NOT be redundant */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_methodCall_fromMapGet_inNullMarkedScope() {
+    // This test is similar to variableInitializedFromMapGet, but checks direct method call
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import java.util.Map;",
+            "@NullMarked",
+            "class Test {",
+            "  void process(Map<String, String> map, String key) {",
+            "    if (map.get(key) == null) { /* This check should NOT be redundant */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_methodCall_fromAnnotatedLib_returnNullable_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "AnnotatedLibNullable.java",
+            "package mylib;",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "@NullMarked", // Library itself is null-marked
+            "public class AnnotatedLibNullable {",
+            "  public static @Nullable String getString() { return null; }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import mylib.AnnotatedLibNullable;",
+            "@NullMarked",
+            "class Test {",
+            "  void process() {",
+            "    if (AnnotatedLibNullable.getString() == null) { /* This check should NOT be redundant */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positive_methodCall_fromNonAnnotatedLib_returnNonNull_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "NonAnnotatedLibNonNull.java", // Not @NullMarked
+            "package mylib;",
+            "import org.jspecify.annotations.NonNull;",
+            "public class NonAnnotatedLibNonNull {",
+            "  public static @NonNull String getString() { return \"non-null\"; }",
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import mylib.NonAnnotatedLibNonNull;",
+            "@NullMarked",
+            "class Test {",
+            "  void process() {",
+            "    // BUG: Diagnostic contains: RedundantNullCheck",
+            "    if (NonAnnotatedLibNonNull.getString() == null) { }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_methodCall_fromNullUnmarkedClass_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "NullUnmarkedLib.java",
+            "package mylib;",
+            "import org.jspecify.annotations.NullUnmarked;",
+            "@NullUnmarked",
+            "public class NullUnmarkedLib {",
+            "  public static String getString() { return null; }", // Implicitly nullable return
+            "}")
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import mylib.NullUnmarkedLib;",
+            "@NullMarked",
+            "class Test {",
+            "  void process() {",
+            "    if (NullUnmarkedLib.getString() == null) { /* This is fine */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void positive_methodCall_onInstance_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "@NullMarked",
+            "class Test {",
+            "  class Greeter { String greet() { return \"hello\"; } }",
+            "  void process() {",
+            "    Greeter greeter = new Greeter();",
+            "    // BUG: Diagnostic contains: RedundantNullCheck",
+            "    if (greeter.greet() == null) {}",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void negative_methodCall_onInstance_explicitlyNullableReturn_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            "import org.jspecify.annotations.NullMarked;",
+            "import org.jspecify.annotations.Nullable;",
+            "@NullMarked",
+            "class Test {",
+            "  class Greeter { @Nullable String greet() { return null; } }",
+            "  void process() {",
+            "    Greeter greeter = new Greeter();",
+            "    if (greeter.greet() == null) { /* This is fine */ }",
+            "  }",
+            "}")
+        .doTest();
+  }
+}

--- a/docs/bugpattern/nullness/RedundantNullCheck.md
+++ b/docs/bugpattern/nullness/RedundantNullCheck.md
@@ -1,4 +1,5 @@
-A null check (e.g., `x == null` or `x != null`) is redundant if it is performed on a variable or method call that is known to be non-null within a `@NullMarked` scope. This check can optionally be configured to flag redundant calls to `Objects.requireNonNull(x)` as well.
+A null check (e.g., `x == null` or `x != null`) is redundant if it is performed on an expression that is statically determined to be non-null according to language semantics or nullness annotations.
+This check can optionally be configured to flag redundant calls to `Objects.requireNonNull(x)` as well.
 
 Within a `@NullMarked` scope, types are non-null by default unless explicitly annotated with `@Nullable`.
 Therefore, checking a variable or method return value (that isn't `@Nullable`) for nullness is unnecessary, as it should never be null.

--- a/docs/bugpattern/nullness/RedundantNullCheck.md
+++ b/docs/bugpattern/nullness/RedundantNullCheck.md
@@ -1,4 +1,4 @@
-A null check is redundant if it is performed on a variable or method call that is known to be non-null within a `@NullMarked` scope.
+A null check (e.g., `x == null`, `x != null`, `Objects.requireNonNull(x)`) is redundant if it is performed on a variable or method call that is known to be non-null within a `@NullMarked` scope.
 
 Within a `@NullMarked` scope, types are non-null by default unless explicitly annotated with `@Nullable`.
 Therefore, checking a variable or method return value (that isn't `@Nullable`) for nullness is unnecessary, as it should never be null.

--- a/docs/bugpattern/nullness/RedundantNullCheck.md
+++ b/docs/bugpattern/nullness/RedundantNullCheck.md
@@ -1,4 +1,4 @@
-A null check (e.g., `x == null`, `x != null`, `Objects.requireNonNull(x)`) is redundant if it is performed on a variable or method call that is known to be non-null within a `@NullMarked` scope.
+A null check (e.g., `x == null` or `x != null`) is redundant if it is performed on a variable or method call that is known to be non-null within a `@NullMarked` scope. This check can optionally be configured to flag redundant calls to `Objects.requireNonNull(x)` as well.
 
 Within a `@NullMarked` scope, types are non-null by default unless explicitly annotated with `@Nullable`.
 Therefore, checking a variable or method return value (that isn't `@Nullable`) for nullness is unnecessary, as it should never be null.
@@ -46,6 +46,14 @@ class MyClass {
 
 This check helps to clean up code and reduce clutter by removing unnecessary null checks, making the code easier to read and maintain.
 It also reinforces the contract provided by `@NullMarked` and `@Nullable` annotations.
+
+## Configuration
+
+By default, this check only flags redundant null checks using `== null` and `!= null`. To also flag redundant calls to `Objects.requireNonNull(x)`, enable it with the following flag:
+
+```
+-XepOpt:RedundantNullCheck:CheckRequireNonNull=true
+```
 
 ## Suppression
 

--- a/docs/bugpattern/nullness/RedundantNullCheck.md
+++ b/docs/bugpattern/nullness/RedundantNullCheck.md
@@ -1,0 +1,52 @@
+A null check is redundant if it is performed on a variable or method call that is known to be non-null within a `@NullMarked` scope.
+
+Within a `@NullMarked` scope, types are non-null by default unless explicitly annotated with `@Nullable`.
+Therefore, checking a variable or method return value (that isn't `@Nullable`) for nullness is unnecessary, as it should never be null.
+
+Example:
+
+```java
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+class MyClass {
+  void process(String definitelyNonNull) {
+    // BUG: Diagnostic contains: RedundantNullCheck
+    if (definitelyNonNull == null) {
+      System.out.println("This will never happen");
+    }
+    // ...
+  }
+
+  String getString() {
+    return "hello";
+  }
+
+  @Nullable String getNullableString() {
+    return null;
+  }
+
+  void anotherMethod() {
+    String s = getString();
+    // BUG: Diagnostic contains: RedundantNullCheck
+    if (s == null) {
+      // s is known to be non-null because getString() is not @Nullable
+      // and we are in a @NullMarked scope.
+      System.out.println("Redundant check");
+    }
+
+    String nullableStr = getNullableString();
+    if (nullableStr == null) { // This check is NOT redundant
+      System.out.println("Nullable string might be null");
+    }
+  }
+}
+```
+
+This check helps to clean up code and reduce clutter by removing unnecessary null checks, making the code easier to read and maintain.
+It also reinforces the contract provided by `@NullMarked` and `@Nullable` annotations.
+
+## Suppression
+
+Suppress false positives by adding the suppression annotation `@SuppressWarnings("RedundantNullCheck")` to the enclosing element.


### PR DESCRIPTION
Closes #5107.

A null check is redundant if it is performed on a variable or method call that is known to be non-null within a `@NullMarked` scope.

Within a `@NullMarked` scope, types are non-null by default unless explicitly annotated with `@Nullable`.
Therefore, checking a variable or method return value (that isn't `@Nullable`) for nullness is unnecessary, as it should never be null.

Example:

```java
import org.jspecify.annotations.NullMarked;
import org.jspecify.annotations.Nullable;

@NullMarked
class MyClass {
  void process(String definitelyNonNull) {
    // BUG: Diagnostic contains: RedundantNullCheck
    if (definitelyNonNull == null) {
      System.out.println("This will never happen");
    }
    // ...
  }

  String getString() {
    return "hello";
  }

  @Nullable String getNullableString() {
    return null;
  }

  void anotherMethod() {
    String s = getString();
    // BUG: Diagnostic contains: RedundantNullCheck
    if (s == null) {
      // s is known to be non-null because getString() is not @Nullable
      // and we are in a @NullMarked scope.
      System.out.println("Redundant check");
    }

    String nullableStr = getNullableString();
    if (nullableStr == null) { // This check is NOT redundant
      System.out.println("Nullable string might be null");
    }
  }
}
```

This check helps to clean up code and reduce clutter by removing unnecessary null checks, making the code easier to read and maintain.
It also reinforces the contract provided by `@NullMarked` and `@Nullable` annotations.