### PR TITLE
Upgrade `compile-testing` 0.21.0 -> 0.23.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <junit.version>4.13.2</junit.version>
     <dataflow.version>3.41.0-eisop1</dataflow.version>
     <mockito.version>4.9.0</mockito.version>
-    <compile.testing.version>0.21.0</compile.testing.version>
+    <compile.testing.version>0.23.0</compile.testing.version>
     <caffeine.version>3.0.5</caffeine.version>
     <flogger.version>0.7.4</flogger.version>
     <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>


### PR DESCRIPTION
This way `error_prone_test_helpers`'s runtime classpath includes
`auto-value-annotations` instead of `auto-value`.

See:
- https://github.com/google/compile-testing/releases/tag/v0.22.0
- https://github.com/google/compile-testing/releases/tag/v0.23.0
- https://github.com/google/compile-testing/compare/v0.21.0...v0.23.0