### PR TITLE
ByteBufferBackingArray: recognize hasArray() guards in conditionals

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/ByteBufferBackingArrayTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ByteBufferBackingArrayTest.java
@@ -104,6 +104,13 @@ public class ByteBufferBackingArrayPositiveCases {
     // BUG: Diagnostic contains: ByteBuffer.array()
     buff.array();
   }
+  
+  void array_precededByHasArray_isFlagged() {
+    ByteBuffer buffer = ByteBuffer.allocateDirect(10);
+    buffer.hasArray();
+    // BUG: Diagnostic contains: ByteBuffer.array()
+    buffer.array();
+  }
 }\
 """)
         .doTest();
@@ -248,6 +255,33 @@ public class ByteBufferBackingArrayNegativeCases {
           buffer.array();
           return null;
         };
+  }
+
+  void array_precededByHasArray_inConditional_isNotFlagged() {
+    ByteBuffer buffer = ByteBuffer.allocateDirect(10);
+    if (buffer.hasArray()) {
+      buffer.array();
+    }
+  }
+
+  void array_inElseOfNegatedHasArray_isNotFlagged() {
+    ByteBuffer buffer = ByteBuffer.allocateDirect(10);
+    if (!buffer.hasArray()) {
+      // no array() here
+    } else {
+      buffer.array(); // safe due to else of !hasArray()
+    }
+  }
+
+  void array_precededByHasArray_inIfElse_isNotFlagged() {
+    final int frameSize = 100;
+    final ByteBuffer buffer = ByteBuffer.allocateDirect(frameSize);
+    if (buffer.hasArray()) {
+      buffer.array();
+    } else {
+      final byte[] array = new byte[frameSize];
+      buffer.get(array);
+    }
   }
 }\
 """)


### PR DESCRIPTION
Previously, the checker only accepted `arrayOffset()` calls or safe constructors. Now it also accepts `array()` calls when properly guarded by `hasArray()` checks in if/else conditions.

Valid patterns now recognized:
- `if (buffer.hasArray()) { buffer.array(); }`
- `if (!buffer.hasArray()) { ... } else { buffer.array(); }`

Fixes #5241