### PR TITLE
Make `SuppressibleTreePathScanner` respect `errorProneOptions().isIgnoreSuppressionAnnotations()`

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/bugpatterns/BugChecker.java
+++ b/check_api/src/main/java/com/google/errorprone/bugpatterns/BugChecker.java
@@ -641,6 +641,11 @@ public abstract class BugChecker implements Suppressible, Serializable {
     }
 
     private boolean suppressed(Tree tree) {
+      boolean ignoreSuppressions = state.errorProneOptions().isIgnoreSuppressionAnnotations();
+      if (ignoreSuppressions) {
+        return false;
+      }
+
       boolean isSuppressible =
           tree instanceof ClassTree || tree instanceof MethodTree || tree instanceof VariableTree;
       return isSuppressible && isSuppressed(tree, state);

--- a/core/src/test/java/com/google/errorprone/bugpatterns/BugCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/BugCheckerTest.java
@@ -218,6 +218,26 @@ public class BugCheckerTest {
   }
 
   @Test
+  public void suppressibleTreePathScanner_respectsIgnoreSuppressionAnnotationsFlag() {
+    CompilationTestHelper.newInstance(SuppressibleTreePathScannerCheck.class, getClass())
+        .setArgs("-XepIgnoreSuppressionAnnotations")
+        .addSourceLines(
+            "A.java",
+            """
+            class A {
+              void m() {
+                // BUG: Diagnostic contains:
+                int unsuppressed;
+                @SuppressWarnings("foo")
+                // BUG: Diagnostic contains:
+                int suppressed;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void isSuppressed_disableWarningsInGeneratedCode() {
     CompilationTestHelper.newInstance(CustomSuppressibilityCheck.class, getClass())
         .setArgs("-XepDisableWarningsInGeneratedCode")


### PR DESCRIPTION
 
Currently `SuppressibleTreePathScanner` still skips suppressed trees, even if we turn on ignoreSuppressionAnnotations. This causes false negatives for checks which match on `CompilationUnitTree` and have custom tree scanning logic in the BugChecker, rather than relying on ErrorProneScanner ([eg](https://github.com/google/error-prone/blob/690c2c1038bdbeb1b08cd278e68a176c9140e92d/core/src/main/java/com/google/errorprone/bugpatterns/InlineTrivialConstant.java#L62)). 