### PR TITLE
Extend ProtoStringFieldReferenceEquality to support older versions of protobuf

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ProtoStringFieldReferenceEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ProtoStringFieldReferenceEquality.java
@@ -38,13 +38,11 @@ import com.sun.source.tree.Tree.Kind;
     summary = "Comparing protobuf fields of type String using reference equality")
 public class ProtoStringFieldReferenceEquality extends BugChecker implements BinaryTreeMatcher {
 
-  private static final String PROTO_SUPER_CLASS = "com.google.protobuf.GeneratedMessage";
-
-  private static final String LITE_PROTO_SUPER_CLASS = "com.google.protobuf.GeneratedMessageLite";
+  private static final String LITE_PROTO_INTERFACE = "com.google.protobuf.MessageLite";
 
   private static final Matcher<ExpressionTree> PROTO_STRING_METHOD =
       allOf(
-          instanceMethod().onDescendantOfAny(PROTO_SUPER_CLASS, LITE_PROTO_SUPER_CLASS),
+          instanceMethod().onDescendantOf(LITE_PROTO_INTERFACE),
           isSameType(Suppliers.STRING_TYPE));
 
   @Override

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ProtoStringFieldReferenceEqualityTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ProtoStringFieldReferenceEqualityTest.java
@@ -32,16 +32,16 @@ public class ProtoStringFieldReferenceEqualityTest {
   public void positive() {
     compilationHelper
         .addSourceLines(
-            "com/google/protobuf/GeneratedMessage.java",
+            "com/google/protobuf/MessageLite.java",
             """
             package com.google.protobuf;
 
-            public class GeneratedMessage {}
+            public interface MessageLite {}
             """)
         .addSourceLines(
             "Proto.java",
             """
-            public abstract class Proto extends com.google.protobuf.GeneratedMessage {
+            public abstract class Proto implements com.google.protobuf.MessageLite {
               public abstract String getMessage();
             }
             """)
@@ -68,16 +68,16 @@ public class ProtoStringFieldReferenceEqualityTest {
   public void negative() {
     compilationHelper
         .addSourceLines(
-            "com/google/protobuf/GeneratedMessage.java",
+            "com/google/protobuf/MessageLite.java",
             """
             package com.google.protobuf;
 
-            public class GeneratedMessage {}
+            public interface MessageLite {}
             """)
         .addSourceLines(
             "Proto.java",
             """
-            public abstract class Proto extends com.google.protobuf.GeneratedMessage {
+            public abstract class Proto implements com.google.protobuf.MessageLite {
               public abstract int getId();
 
               public abstract String getMessage();


### PR DESCRIPTION
`ProtoStringFieldReferenceEquality` assumes that all protobuf messages extend `com.google.protobuf.GeneratedMessage`, but older versions of protobuf (before v26) use `com.google.protobuf.GeneratedMessageV3` as the base class for messages.

This change updates `ProtoStringFieldReferenceEquality` to use `com.google.protobuf.MessageLite` to detect protobufs. This interface is present in older versions of protobuf and it hasn't changed since then.