### PR TITLE
Match `Varifier` for non-final variables

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/Varifier.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/Varifier.java
@@ -76,7 +76,6 @@ public final class Varifier extends BugChecker implements VariableTreeMatcher {
     var symbol = getSymbol(tree);
     ExpressionTree initializer = tree.getInitializer();
     if (!symbol.getKind().equals(LOCAL_VARIABLE)
-        || !isConsideredFinal(symbol)
         || initializer == null
         || hasImplicitType(tree, state)) {
       return NO_MATCH;


### PR DESCRIPTION
`Varifier` should match all cases of local variable non-implicit types, not just `final` ones.