### PR TITLE
BadInstanceof: test for interaction with pattern variable

### DIFF
--- a/core/src/test/java/com/google/errorprone/bugpatterns/BadInstanceofTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/BadInstanceofTest.java
@@ -74,6 +74,9 @@ public final class BadInstanceofTest {
         .addSourceLines(
             "Test.java",
 """
+import static java.lang.annotation.ElementType.TYPE_USE;
+import java.lang.annotation.Target;
+
 class A {
   // BUG: Diagnostic contains: `new C()` is a non-null instance of C which is a subtype of A
   boolean t = new C() instanceof A;
@@ -87,6 +90,22 @@ class A {
     // BUG: Diagnostic contains: `c` is an instance of C which is a subtype of A
     return !(c instanceof A);
   }
+
+  // False-positive
+  String g() {
+    // BUG: Diagnostic contains: `maybeString()` is an instance of String which is a subtype of String
+    if (maybeString() instanceof String present) {
+      return present;
+    }
+    return "absent";
+  }
+
+  @Nullable String maybeString() {
+    return null;
+  }
+
+  @Target(TYPE_USE)
+  @interface Nullable {}
 }
 
 class C extends A {}


### PR DESCRIPTION
The `BadInstanceof` check argues that the construct

```java
    if (t() instanceof T some) {
      return some;
    }
```

is equivalent to a null check. That's true in the classic case where some local stands in the place of `t()`. However, with JDK 16's `instanceof` pattern variables we have the ability to only conditionally declare a local for `t()`, and in that case using the prescribed null check is a greater syntactic and semantic change. This commit adds a test for this construct for posterity.

It may be that the example should be discouraged for the same basic clarity reasons that underlie the `BadInstanceof` check, but then a new, more focused check seems warranted.

This leans into the evolution of `instanceof`, patterns, and nullability annotations. A counter-point is that `instanceof` has always behaved this way w.r.t. null and so the situation has not _actually_ changed, and that what has changed instead is that I should just disable `BadInstanceof` as obsolete. The check defaults to WARN, though.