### PR TITLE
Nullness: ignore Jakarta Validation

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -360,6 +360,13 @@
       <artifactId>javax.inject</artifactId>
       <version>1</version>
     </dependency>
+    <dependency>
+      <!-- Apache 2.0 -->
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+      <version>3.1.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/MultipleNullnessAnnotationsTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/MultipleNullnessAnnotationsTest.java
@@ -166,4 +166,26 @@ public class MultipleNullnessAnnotationsTest {
             """)
         .doTest();
   }
+
+  @Test
+  public void falseNullnessAnnotations() {
+    testHelper
+        .addSourceLines(
+            "T.java",
+            """
+            import static java.lang.annotation.ElementType.*;
+            import java.lang.annotation.Target;
+            import org.jspecify.annotations.Nullable;
+
+            @Target(FIELD)
+            @interface NotNull {}
+
+            abstract class T {
+              @jakarta.validation.constraints.NotNull @Nullable Object negative;
+              // BUG: Diagnostic contains:
+              @NotNull @Nullable Object positive;
+            }
+            """)
+        .doTest();
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheckTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/nullness/RedundantNullCheckTest.java
@@ -1034,4 +1034,32 @@ public class RedundantNullCheckTest {
             """)
         .doTest();
   }
+
+  @Test
+  public void negative_falseNullnessAnnotation_inNullMarkedScope() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.NonNull;
+            import org.jspecify.annotations.Nullable;
+            import jakarta.validation.constraints.NotNull;
+
+            @NullMarked
+            class Test {
+              @NotNull @Nullable String negative;
+              @NonNull @Nullable String positive;
+
+              void foo() {
+                if (negative == null) {
+                  /* This is fine */
+                }
+                // BUG: Diagnostic contains: RedundantNullCheck
+                if (positive == null) {}
+              }
+            }
+            """)
+        .doTest();
+  }
 }


### PR DESCRIPTION
Teach checks like `MultipleNullnessAnnotations` and `RedundantNullCheck`
to disregard annotations that look like nullness specification
annotations but that actually are not; namely the Jakarta Validation
`@NotNull` constraint.

Resolves: https://github.com/google/error-prone/issues/4334

