### PR TITLE
UnusedException: consistent with UnnamedVariable

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedException.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedException.java
@@ -128,7 +128,8 @@ public final class UnusedException extends BugChecker implements CatchTreeMatche
   }
 
   private static boolean isSuppressedViaName(VariableTree parameter) {
-    return parameter.getName().toString().startsWith("unused");
+    String name = parameter.getName().toString();
+    return name.isEmpty() || name.startsWith("unused");
   }
 
   private static Optional<SuggestedFix> fixConstructor(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnusedExceptionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnusedExceptionTest.java
@@ -247,6 +247,25 @@ public final class UnusedExceptionTest {
   }
 
   @Test
+  public void suppressibleByLeavingExceptionUnamed() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void test() {
+                try {
+                } catch (Exception _) {
+                  throw new RuntimeException("foo");
+                }
+              }
+            }
+            """)
+        .setArgs("--enable-preview", "--release", Integer.toString(Runtime.version().feature()))
+        .doTest();
+  }
+
+  @Test
   public void anonymousClass() {
     refactoringHelper
         .addInputLines(

--- a/docs/bugpattern/UnusedException.md
+++ b/docs/bugpattern/UnusedException.md
@@ -26,8 +26,8 @@ Prefer wrapping the original exception instead,
 
 ## Suppression
 
-If the exception is deliberately unused, rename it `unused` to suppress this
-diagnostic.
+If the exception is deliberately unused, rename it `_` or `unused` to suppress
+this diagnostic.
 
 ```java
 static <T extends Enum<T>> T tryForName(Class<T> enumType, String name) {


### PR DESCRIPTION
A false positive [`UnusedException`](https://errorprone.info/bugpattern/UnusedException) can be suppressed by naming the caught exception `/unused.*/`. The recently added [`UnnamedVariable`](https://errorprone.info/bugpattern/UnnamedVariable), in the meantime, wants deliberately unused variables to be unnamed with the Java 22 `_` character, putting the two checks at odds. Teach `UnusedException` to also accept `_` as a suppression mechanism.