### PR TITLE
Add MockitoBean to list of exempted variable annotations

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/WellKnownKeep.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/WellKnownKeep.java
@@ -64,7 +64,8 @@ public final class WellKnownKeep {
           "org.openqa.selenium.support.FindBys",
           "org.apache.beam.sdk.transforms.DoFn.TimerId",
           "org.apache.beam.sdk.transforms.DoFn.StateId",
-          "org.springframework.boot.test.mock.mockito.MockBean");
+          "org.springframework.boot.test.mock.mockito.MockBean",
+          "org.springframework.test.context.bean.override.mockito.MockitoBean");
 
   /**
    * Annotations that exempt methods from being considered unused.


### PR DESCRIPTION
`MockitoBean` is the replacement for `MockBean`, which was [deprecated](https://docs.spring.io/spring-boot/3.5/api/java/org/springframework/boot/test/mock/mockito/MockBean.html) but otherwise used in the same way. Since upgrading our Spring Boot version and migrating over, we've been getting `UnusedVariable` warnings since `MockitoBean` isn't exempted.

There's a [previous PR that was approved here](https://github.com/google/error-prone/pull/4800) but never merged and is now out of date, so creating this new one.

Thank you!

Fixes: https://github.com/google/error-prone/issues/4804