### PR TITLE
Fix invalid javadoc of  `@IncompatibleModifiers`

### DIFF
--- a/annotations/src/main/java/com/google/errorprone/annotations/IncompatibleModifiers.java
+++ b/annotations/src/main/java/com/google/errorprone/annotations/IncompatibleModifiers.java
@@ -29,11 +29,11 @@ import java.lang.annotation.Target;
  * <pre>{@code
  * @IncompatibleModifiers(modifier = Modifier.PUBLIC)
  * @interface MyAnnotation {}
- * </pre>
+ * }</pre>
  *
  * <p>will be considered illegal when used as:
  *
- * <pre>
+ * <pre>{@code
  * @MyAnnotation public void foo() {}
  * }</pre>
  *


### PR DESCRIPTION
# Description

This simply adds missing parts of `@IncompatibleModifiers` Javadoc which currently is broken.