### PR TITLE
Fix `FixedPosition` `endPosition` constructor parameter

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/FixedPosition.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/FixedPosition.java
@@ -29,7 +29,7 @@ public record FixedPosition(JCTree tree, int startPosition, int endPosition)
   }
 
   public FixedPosition(Tree tree, int startPosition, int endPosition) {
-    this((JCTree) tree, startPosition, startPosition);
+    this((JCTree) tree, startPosition, endPosition);
   }
 
   @Override


### PR DESCRIPTION
# Description

This fixed `FixedPosition`'s constructor which wrongly passes `startPosition` istead of (available) `endPosition`.