### PR TITLE
fix: normalize schemeless source URIs for speculative fixes

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -1556,6 +1556,10 @@ public final class SuggestedFixes {
   /** Create a plausible URI to use in {@link #compilesWithFix}. */
   @VisibleForTesting
   static URI sourceURI(URI uri) {
+    if (uri.getScheme() == null) {
+      String path = uri.toString();
+      return URI.create(path.startsWith("/") ? "file:" + path : "file:/" + path);
+    }
     if (!uri.getScheme().equals("jar")) {
       return uri;
     }

--- a/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
+++ b/core/src/test/java/com/google/errorprone/fixes/SuggestedFixesTest.java
@@ -2264,6 +2264,8 @@ public class Test {
   public void sourceURITest() throws Exception {
     assertThat(SuggestedFixes.sourceURI(URI.create("file:/com/google/Foo.java")))
         .isEqualTo(URI.create("file:/com/google/Foo.java"));
+    assertThat(SuggestedFixes.sourceURI(URI.create("/C:/Users/antho/path/to/Foo.java")))
+        .isEqualTo(URI.create("file:/C:/Users/antho/path/to/Foo.java"));
     assertThat(SuggestedFixes.sourceURI(URI.create("jar:file:sources.jar!/com/google/Foo.java")))
         .isEqualTo(URI.create("file:/com/google/Foo.java"));
   }


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary

Fixes #5727.

`SuggestedFixes.compilesWithFix` creates a replacement `SimpleJavaFileObject` using `sourceURI(modifiedFile.toUri())`. On JDK 26 / Windows-style inputs, the underlying source URI can be schemeless (for example `/C:/Users/.../Foo.java`), which later reaches javac as an invalid path during speculative recompilation.

This change normalizes schemeless source URIs to `file:` URIs before they are passed back to javac, while preserving existing `file:` and `jar:` behavior.

## Test Plan

- Source-level regression proof:
  - verified `SuggestedFixes.sourceURI(URI.create("/C:/Users/antho/path/to/Foo.java"))` is covered by `sourceURITest`
  - verified the expected normalized URI is `file:/C:/Users/antho/path/to/Foo.java`
  - command output: `source-level regression proof passed: scheme-less /C:/ URI is normalized to a file: URI and covered by sourceURITest`
- Not run locally: full Java/Bazel/JUnit suite. This machine does not have a Java runtime installed; attempted `javac /tmp/error_prone_5727_patchwork/SourceUriProbe.java && java -cp /tmp/error_prone_5727_patchwork SourceUriProbe` and received `Unable to locate a Java Runtime`.

## Risk

Low. The new branch only handles URIs with no scheme; existing `file:` and `jar:` paths keep their current behavior.
