### PR TITLE
Make AssignmentExpression matcher parenthesis-invariant on nested assignments

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/AssignmentExpression.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AssignmentExpression.java
@@ -33,6 +33,7 @@ import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.ParenthesizedTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 
 /** A BugPattern; see the summary. */
@@ -45,7 +46,17 @@ public final class AssignmentExpression extends BugChecker implements Assignment
 
   @Override
   public Description matchAssignment(AssignmentTree tree, VisitorState state) {
-    Tree parent = state.getPath().getParentPath().getLeaf();
+    TreePath parentPath = state.getPath().getParentPath();
+    // Exempt the C-ism of (foo = getFoo()) != null, etc. before unwrapping parens.
+    if (parentPath.getLeaf() instanceof ParenthesizedTree
+        && parentPath.getParentPath().getLeaf() instanceof BinaryTree) {
+      return Description.NO_MATCH;
+    }
+    // Unwrap ParenthesizedTree for parenthesis-invariant matching.
+    while (parentPath.getLeaf() instanceof ParenthesizedTree) {
+      parentPath = parentPath.getParentPath();
+    }
+    Tree parent = parentPath.getLeaf();
     if (parent instanceof ExpressionStatementTree) {
       return Description.NO_MATCH;
     }
@@ -53,11 +64,6 @@ public final class AssignmentExpression extends BugChecker implements Assignment
       return Description.NO_MATCH;
     }
     if (parent instanceof LambdaExpressionTree) {
-      return Description.NO_MATCH;
-    }
-    // Exempt the C-ism of (foo = getFoo()) != null, etc.
-    if (parent instanceof ParenthesizedTree
-        && state.getPath().getParentPath().getParentPath().getLeaf() instanceof BinaryTree) {
       return Description.NO_MATCH;
     }
     // Detect duplicate assignments: a = a = foo() so that we can generate a fix.

--- a/core/src/test/java/com/google/errorprone/bugpatterns/AssignmentExpressionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/AssignmentExpressionTest.java
@@ -147,4 +147,22 @@ public final class AssignmentExpressionTest {
             """)
         .doTest();
   }
+
+  @Test
+  public void parenthesizedAssignmentInDeclaration() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void test() {
+                int a = 0;
+                int b = 1;
+                // BUG: Diagnostic contains:
+                int k = (a = b);
+              }
+            }
+            """)
+        .doTest();
+  }
 }


### PR DESCRIPTION
## Description

Fixes #5827

The `AssignmentExpression` checker's `matchAssignment` method was not parenthesis-invariant. When an assignment expression was wrapped in `ParenthesizedTree` (e.g. `int k = (a = b)`), the checker did not look through the parentheses to determine the enclosing context. This caused the checker to miss the assignment, producing inconsistent results depending on whether parentheses were present.

## Fix

1. Check the C-ism exemption (`(a = getFoo()) != null`) before unwrapping parentheses, so it still applies correctly.
2. Unwrap consecutive `ParenthesizedTree` nodes from the parent path before deciding whether the assignment is embedded in a larger expression.

## Before/After behavior

Before: `int k = (a = b)` not flagged, `int k = a = b` flagged
After: Both forms flagged (paren-invariant)
C-ism `if ((a = getObject()) != null)` still exempted (unchanged)

## Testing

- All existing tests pass (6 tests)
- Added `parenthesizedAssignmentInDeclaration` test covering the paren-wrapped case
