### PR TITLE
Fix `NullTernary` false positive in switch expression

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/TargetType.java
+++ b/check_api/src/main/java/com/google/errorprone/util/TargetType.java
@@ -112,9 +112,7 @@ public record TargetType(Type type, TreePath path) {
     Type type = new TargetTypeVisitor(current, state, parent).visit(parent.getLeaf(), null);
     if (type == null) {
       Tree actualTree = null;
-      if (parent.getLeaf() instanceof YieldTree) {
-        actualTree = parent.getParentPath().getParentPath().getParentPath().getLeaf();
-      } else if (CONSTANT_CASE_LABEL_TREE != null
+      if (CONSTANT_CASE_LABEL_TREE != null
           && CONSTANT_CASE_LABEL_TREE.isAssignableFrom(parent.getLeaf().getClass())) {
         actualTree = parent.getParentPath().getParentPath().getLeaf();
       }
@@ -222,6 +220,19 @@ public record TargetType(Type type, TreePath path) {
         return getType(switchTree);
       }
       return getType(getSwitchExpression(switchTree));
+    }
+
+    @Override
+    public @Nullable Type visitYield(YieldTree tree, Void unused) {
+      // A `yield` in a switch *expression* has the switch expression's own type as its target
+      // type (just like an arrow-case body, handled by visitCase). It is unrelated to the type
+      // of the switch selector.
+      for (TreePath path = parent.getParentPath(); path != null; path = path.getParentPath()) {
+        if (path.getLeaf() instanceof SwitchExpressionTree switchExpression) {
+          return getType(switchExpression);
+        }
+      }
+      return null;
     }
 
     private static @Nullable ExpressionTree getSwitchExpression(@Nullable Tree tree) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NullTernaryTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NullTernaryTest.java
@@ -204,4 +204,24 @@ class Test {
             """)
         .doTest();
   }
+
+  @Test
+  public void nullTernaryInSwitchYield_referenceType_negative() {
+    testHelper
+            .addSourceLines(
+                    "Test.java",
+                    """
+                    class Test {
+                      String f(int n) {
+                        return switch (n) {
+                          case 0 -> "zero";
+                          default -> {
+                            yield (n % 2 == 0) ? "even" : null;
+                          }
+                        };
+                      }
+                    }
+                    """)
+            .doTest();
+  }
 }


### PR DESCRIPTION
Closes https://github.com/google/error-prone/issues/5753

Fixes an issue where the target type of a `yield` statement inside a `switch` expression block was not being resolved correctly by `TargetType` as it did not have a dedicated visitor method for `YieldTree`.

Test (introduced): `mvn -pl core test "-Dtest=NullTernaryTest"`
