### PR TITLE
Allow suppression of `TypeParameterQualifier` violations

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
@@ -36,10 +36,7 @@ import com.sun.tools.javac.code.Symbol;
 import javax.inject.Inject;
 
 /** A {@link BugChecker}; see the associated {@link BugPattern} annotation for details. */
-@BugPattern(
-    summary = "Type parameter used as type qualifier",
-    severity = ERROR,
-    suppressionAnnotations = {})
+@BugPattern(summary = "Type parameter used as type qualifier", severity = ERROR)
 public class TypeParameterQualifier extends BugChecker
     implements MemberSelectTreeMatcher, MemberReferenceTreeMatcher {
   private final boolean matchMethodReferences;

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterQualifierTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterQualifierTest.java
@@ -125,6 +125,22 @@ public class TypeParameterQualifierTest {
   }
 
   @Test
+  public void suppression() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              @SuppressWarnings("TypeParameterQualifier")
+              static <T extends Enum<T>> T get(Class<T> clazz, String value) {
+                return T.valueOf(clazz, value);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void negative() {
     compilationHelper
         .addSourceLines(


### PR DESCRIPTION
There are valid use cases within Refaster `@BeforeTemplate` methods.