### PR TITLE
Make `TypeParameterQualifier` Refaster-aware

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
@@ -22,6 +22,7 @@ import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.findEnclosingMethod;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 import static com.google.errorprone.util.ASTHelpers.hasAnnotation;
+import static com.google.errorprone.util.AnnotationNames.AFTER_TEMPLATE_ANNOTATION;
 import static com.google.errorprone.util.AnnotationNames.BEFORE_TEMPLATE_ANNOTATION;
 import static javax.lang.model.element.ElementKind.TYPE_PARAMETER;
 
@@ -61,16 +62,17 @@ public class TypeParameterQualifier extends BugChecker
 
   @Override
   public Description matchMemberReference(MemberReferenceTree tree, VisitorState state) {
-    if (!matchMethodReferences || isInRefasterBeforeTemplate(state)) {
+    if (!matchMethodReferences || isInRefasterTemplate(state)) {
       return NO_MATCH;
     }
     return match(tree, tree.getQualifierExpression(), state);
   }
 
-  private static boolean isInRefasterBeforeTemplate(VisitorState state) {
+  private static boolean isInRefasterTemplate(VisitorState state) {
     MethodTree enclosingMethod = findEnclosingMethod(state);
     return enclosingMethod != null
-        && hasAnnotation(enclosingMethod, BEFORE_TEMPLATE_ANNOTATION, state);
+        && (hasAnnotation(enclosingMethod, BEFORE_TEMPLATE_ANNOTATION, state)
+            || hasAnnotation(enclosingMethod, AFTER_TEMPLATE_ANNOTATION, state));
   }
 
   private Description match(ExpressionTree tree, ExpressionTree qualifier, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypeParameterQualifier.java
@@ -19,7 +19,10 @@ package com.google.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static com.google.errorprone.fixes.SuggestedFixes.qualifyType;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.util.ASTHelpers.findEnclosingMethod;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.google.errorprone.util.ASTHelpers.hasAnnotation;
+import static com.google.errorprone.util.AnnotationNames.BEFORE_TEMPLATE_ANNOTATION;
 import static javax.lang.model.element.ElementKind.TYPE_PARAMETER;
 
 import com.google.errorprone.BugPattern;
@@ -32,6 +35,7 @@ import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodTree;
 import com.sun.tools.javac.code.Symbol;
 import javax.inject.Inject;
 
@@ -57,10 +61,16 @@ public class TypeParameterQualifier extends BugChecker
 
   @Override
   public Description matchMemberReference(MemberReferenceTree tree, VisitorState state) {
-    if (!matchMethodReferences) {
+    if (!matchMethodReferences || isInRefasterBeforeTemplate(state)) {
       return NO_MATCH;
     }
     return match(tree, tree.getQualifierExpression(), state);
+  }
+
+  private static boolean isInRefasterBeforeTemplate(VisitorState state) {
+    MethodTree enclosingMethod = findEnclosingMethod(state);
+    return enclosingMethod != null
+        && hasAnnotation(enclosingMethod, BEFORE_TEMPLATE_ANNOTATION, state);
   }
 
   private Description match(ExpressionTree tree, ExpressionTree qualifier, VisitorState state) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterQualifierTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterQualifierTest.java
@@ -144,6 +144,25 @@ public class TypeParameterQualifierTest {
   }
 
   @Test
+  public void methodReference_inAfterTemplate() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            import com.google.errorprone.refaster.annotation.AfterTemplate;
+            import java.util.function.Function;
+
+            class Test {
+              @AfterTemplate
+              <T extends Enum<T>> Function<T, String> rule() {
+                return T::name;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void memberSelect_inBeforeTemplate() {
     compilationHelper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterQualifierTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/TypeParameterQualifierTest.java
@@ -125,6 +125,44 @@ public class TypeParameterQualifierTest {
   }
 
   @Test
+  public void methodReference_inBeforeTemplate() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            import com.google.errorprone.refaster.annotation.BeforeTemplate;
+            import java.util.function.Function;
+
+            class Test {
+              @BeforeTemplate
+              <T extends Enum<T>> Function<T, String> rule() {
+                return T::name;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void memberSelect_inBeforeTemplate() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            import com.google.errorprone.refaster.annotation.BeforeTemplate;
+
+            class Test {
+              @BeforeTemplate
+              <T extends Enum<T>> T rule(Class<T> clazz, String value) {
+                // BUG: Diagnostic contains: Enum.valueOf(clazz, value);
+                return T.valueOf(clazz, value);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void negative() {
     compilationHelper
         .addSourceLines(


### PR DESCRIPTION
For method references, there are valid use cases within Refaster template methods.