### PR TITLE
fix(#5845): strip parentheses before matching in 6 bug checks to eliminate false positives/negatives

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/AssignmentExpression.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AssignmentExpression.java
@@ -33,6 +33,7 @@ import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.ParenthesizedTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 
 /** A BugPattern; see the summary. */
@@ -55,18 +56,23 @@ public final class AssignmentExpression extends BugChecker implements Assignment
     if (parent instanceof LambdaExpressionTree) {
       return Description.NO_MATCH;
     }
+    // Walk through any enclosing parentheses to find the effective parent context.
+    TreePath effectiveParentPath = state.getPath().getParentPath();
+    while (effectiveParentPath.getLeaf() instanceof ParenthesizedTree) {
+      effectiveParentPath = effectiveParentPath.getParentPath();
+    }
+    Tree effectiveParent = effectiveParentPath.getLeaf();
     // Exempt the C-ism of (foo = getFoo()) != null, etc.
-    if (parent instanceof ParenthesizedTree
-        && state.getPath().getParentPath().getParentPath().getLeaf() instanceof BinaryTree) {
+    if (effectiveParent instanceof BinaryTree) {
       return Description.NO_MATCH;
     }
     // Detect duplicate assignments: a = a = foo() so that we can generate a fix.
-    if (isDuplicateAssignment(tree, parent)) {
+    if (isDuplicateAssignment(tree, effectiveParent)) {
       return describeMatch(
           tree, SuggestedFix.replace(tree, state.getSourceForNode(tree.getExpression())));
     }
     // If we got here it's something like x = y = 0, which is odd but not disallowed.
-    if (parent instanceof AssignmentTree) {
+    if (effectiveParent instanceof AssignmentTree) {
       return Description.NO_MATCH;
     }
     return describeMatch(tree);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/DuplicateBranches.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/DuplicateBranches.java
@@ -20,6 +20,7 @@ import static com.google.common.collect.Iterables.getLast;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getStartPosition;
+import static com.google.errorprone.util.ASTHelpers.stripParentheses;
 import static java.util.stream.Collectors.joining;
 
 import com.google.errorprone.BugPattern;
@@ -31,6 +32,7 @@ import com.google.errorprone.matchers.Description;
 import com.google.errorprone.util.ErrorProneTokens;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ConditionalExpressionTree;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IfTree;
 import com.sun.source.tree.Tree;
 
@@ -66,7 +68,9 @@ public class DuplicateBranches extends BugChecker
     // do exactly what we want here, which is to compare the syntax including of identifiers and
     // not their underlying symbols, and it would require a lot of case work to implement for all
     // AST nodes.
-    if (!thenTree.toString().equals(elseTree.toString())) {
+    Tree strippedThen = thenTree instanceof ExpressionTree et ? stripParentheses(et) : thenTree;
+    Tree strippedElse = elseTree instanceof ExpressionTree et ? stripParentheses(et) : elseTree;
+    if (!strippedThen.toString().equals(strippedElse.toString())) {
       return NO_MATCH;
     }
     int start = getStartPosition(elseTree);

--- a/core/src/main/java/com/google/errorprone/bugpatterns/InlineTrivialConstant.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/InlineTrivialConstant.java
@@ -20,6 +20,7 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 import static com.google.errorprone.util.ASTHelpers.isSameType;
+import static com.google.errorprone.util.ASTHelpers.stripParentheses;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
@@ -119,7 +120,7 @@ public class InlineTrivialConstant extends BugChecker implements CompilationUnit
     if (!isSameType(sym.asType(), state.getSymtab().stringType, state)) {
       return Optional.empty();
     }
-    ExpressionTree initializer = tree.getInitializer();
+    ExpressionTree initializer = stripParentheses(tree.getInitializer());
     if (initializer.getKind().equals(Tree.Kind.STRING_LITERAL)) {
       String value = (String) ((LiteralTree) initializer).getValue();
       if (Objects.equals(value, "")) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/LoopConditionChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LoopConditionChecker.java
@@ -187,7 +187,7 @@ public class LoopConditionChecker extends BugChecker
     }
 
     private void check(ExpressionTree expression) {
-      Symbol sym = ASTHelpers.getSymbol(expression);
+      Symbol sym = ASTHelpers.getSymbol(ASTHelpers.stripParentheses(expression));
       modified |= variables.contains(sym);
     }
   }

--- a/core/src/main/java/com/google/errorprone/bugpatterns/NonAtomicVolatileUpdate.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/NonAtomicVolatileUpdate.java
@@ -28,6 +28,7 @@ import static com.google.errorprone.matchers.Matchers.sameVariable;
 import static com.google.errorprone.matchers.Matchers.toType;
 
 import com.google.errorprone.BugPattern;
+import com.google.errorprone.util.ASTHelpers;
 import com.google.errorprone.BugPattern.StandardTags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker.AssignmentTreeMatcher;
@@ -55,7 +56,7 @@ public class NonAtomicVolatileUpdate extends BugChecker
   /** Extracts the expression from a UnaryTree and applies a matcher to it. */
   private static Matcher<UnaryTree> expressionFromUnaryTree(Matcher<ExpressionTree> exprMatcher) {
     return (UnaryTree tree, VisitorState state) -> {
-      return exprMatcher.matches(tree.getExpression(), state);
+      return exprMatcher.matches(ASTHelpers.stripParentheses(tree.getExpression()), state);
     };
   }
 
@@ -63,7 +64,7 @@ public class NonAtomicVolatileUpdate extends BugChecker
   private static Matcher<CompoundAssignmentTree> variableFromCompoundAssignmentTree(
       Matcher<ExpressionTree> exprMatcher) {
     return (CompoundAssignmentTree tree, VisitorState state) -> {
-      return exprMatcher.matches(tree.getVariable(), state);
+      return exprMatcher.matches(ASTHelpers.stripParentheses(tree.getVariable()), state);
     };
   }
 
@@ -71,7 +72,7 @@ public class NonAtomicVolatileUpdate extends BugChecker
   private static Matcher<AssignmentTree> variableFromAssignmentTree(
       Matcher<ExpressionTree> exprMatcher) {
     return (AssignmentTree tree, VisitorState state) -> {
-      return exprMatcher.matches(tree.getVariable(), state);
+      return exprMatcher.matches(ASTHelpers.stripParentheses(tree.getVariable()), state);
     };
   }
 

--- a/core/src/main/java/com/google/errorprone/bugpatterns/PatternMatchingInstanceof.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/PatternMatchingInstanceof.java
@@ -23,6 +23,7 @@ import static com.google.errorprone.fixes.SuggestedFix.mergeFixes;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
 import static com.google.errorprone.util.ASTHelpers.getType;
+import static com.google.errorprone.util.ASTHelpers.stripParentheses;
 import static com.google.errorprone.util.SourceVersion.supportsPatternMatchingInstanceof;
 import static com.google.errorprone.util.TargetType.targetType;
 import static java.lang.Boolean.TRUE;
@@ -278,7 +279,7 @@ public final class PatternMatchingInstanceof extends BugChecker implements Insta
         new TreePathScanner<Void, Void>() {
           @Override
           public Void visitTypeCast(TypeCastTree node, Void unused) {
-            var castee = constantExpressions.constantExpression(node.getExpression(), state);
+            var castee = constantExpressions.constantExpression(stripParentheses(node.getExpression()), state);
             if (castee.isPresent()
                 && castee.get().equals(symbol)
                 && state.getTypes().isSameType(getType(node.getType()), targetType)) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/AssignmentExpressionTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/AssignmentExpressionTest.java
@@ -131,6 +131,157 @@ public final class AssignmentExpressionTest {
   }
 
   @Test
+  public void multipleAssignments_parenthesizedInner_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void test() {
+                Object a;
+                Object b;
+                a = (b = new Object());
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void comparedToNull_innerParenthesized_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void test() {
+                Object a;
+                Object b;
+                if ((a = (b = new Object())) != null) {
+                  return;
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void initializerWithParenthesizedAssignment_finding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void test() {
+                int j;
+                // BUG: Diagnostic contains:
+                int i = (j = 0);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void deeplyChainedAssignments_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void test() {
+                Object a, b, c;
+                a = (b = (c = new Object()));
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void deeplyChainedInitializer_innerFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void test() {
+                int k;
+                int j;
+                // BUG: Diagnostic contains:
+                int i = (j = (k = 0));
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void duplicateAssignment_throughParens() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            """
+            class Test {
+              void test() {
+                // BUG: Diagnostic contains:
+                Object a = (a = new Object());
+              }
+            }
+            """)
+        .addOutputLines(
+            "Test.java",
+            """
+            class Test {
+              void test() {
+                // BUG: Diagnostic contains:
+                Object a = (new Object());
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void doubleParenthesizedBinaryContext_noFinding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              Object a;
+              Object b;
+
+              void test() {
+                if (((a = b)) != null) {
+                  return;
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void returnedParenthesized_finding() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              Object field;
+
+              Object test() {
+                // BUG: Diagnostic contains:
+                return (field = new Object());
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void returnedValue() {
     helper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/DuplicateBranchesTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/DuplicateBranchesTest.java
@@ -54,6 +54,131 @@ public class DuplicateBranchesTest {
   }
 
   @Test
+  public void positive_parenthesizedBranch() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              int f() {
+                // BUG: Diagnostic contains:
+                return true ? 1 * 5 : (1 * 5);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void positive_parenthesizedThenBranch() {
+    BugCheckerRefactoringTestHelper.newInstance(DuplicateBranches.class, getClass())
+        .addInputLines(
+            "Test.java",
+            """
+            class Test {
+              int x;
+
+              void m() {
+                x = true ? (1 * 5) : 1 * 5;
+              }
+            }
+            """)
+        .addOutputLines(
+            "Test.java",
+            """
+            class Test {
+              int x;
+
+              void m() {
+                x = 1 * 5;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void positive_bothBranchesParenthesized() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              int x;
+
+              void m() {
+                // BUG: Diagnostic contains:
+                x = true ? (1 * 5) : (1 * 5);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void positive_parenthesizedStringBranch() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              String f(boolean a) {
+                // BUG: Diagnostic contains:
+                return a ? "hello" : ("hello");
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void positive_parenthesizedVariableBranch() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              String f(boolean a, String x) {
+                // BUG: Diagnostic contains:
+                return a ? x : (x);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void positive_parenthesizedMethodCallBranch() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              String f(boolean a) {
+                // BUG: Diagnostic contains:
+                return a ? toString() : (toString());
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void negative_differentContentAfterStripping() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              int f(boolean a, int x) {
+                return a ? (x + 1) : (x - 1);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void negative() {
     compilationHelper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/InlineTrivialConstantTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/InlineTrivialConstantTest.java
@@ -52,6 +52,89 @@ public class InlineTrivialConstantTest {
   }
 
   @Test
+  public void positive_parenthesizedInitializer() {
+    BugCheckerRefactoringTestHelper.newInstance(InlineTrivialConstant.class, getClass())
+        .addInputLines(
+            "Test.java",
+            """
+            class Test {
+              private static final String EMPTY = ("");
+
+              void f() {
+                System.err.println(EMPTY);
+              }
+            }
+            """)
+        .addOutputLines(
+            "Test.java",
+            """
+            class Test {
+
+              void f() {
+                System.err.println("");
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void positive_doubleParenthesizedInitializer() {
+    BugCheckerRefactoringTestHelper.newInstance(InlineTrivialConstant.class, getClass())
+        .addInputLines(
+            "Test.java",
+            """
+            class Test {
+              private static final String EMPTY = ((""));
+
+              void f() {
+                System.err.println(EMPTY);
+              }
+            }
+            """)
+        .addOutputLines(
+            "Test.java",
+            """
+            class Test {
+
+              void f() {
+                System.err.println("");
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void positive_otherValidNamesParenthesized() {
+    CompilationTestHelper.newInstance(InlineTrivialConstant.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              // BUG: Diagnostic contains:
+              private static final String EMPTY_STR = ("");
+              // BUG: Diagnostic contains:
+              private static final String EMPTY_STRING = ("");
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void negative_nonEmptyParenthesized() {
+    CompilationTestHelper.newInstance(InlineTrivialConstant.class, getClass())
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              private static final String EMPTY = ("hello");
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void negative() {
     CompilationTestHelper.newInstance(InlineTrivialConstant.class, getClass())
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/LoopConditionCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/LoopConditionCheckerTest.java
@@ -176,6 +176,169 @@ public class LoopConditionCheckerTest {
   }
 
   @Test
+  public void negative_parenthesizedUpdate() {
+    compilationTestHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void f() {
+                for (int i = 0; i < 10; (i)++) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void negative_doubleParenthesizedUpdate() {
+    compilationTestHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void f() {
+                for (int i = 0; i < 10; ((i))++) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void negative_parenthesizedPrefixIncrement() {
+    compilationTestHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void f() {
+                for (int i = 0; i < 10; ++(i)) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void negative_parenthesizedPrefixDecrement() {
+    compilationTestHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void f() {
+                for (int i = 9; i >= 0; --(i)) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void negative_parenthesizedPostfixDecrement() {
+    compilationTestHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void f() {
+                for (int i = 9; i >= 0; (i)--) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void negative_parenthesizedDoWhileBody() {
+    compilationTestHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void f() {
+                int i = 0;
+                do {
+                  (i)++;
+                } while (i < 10);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void negative_parenthesizedWhileBody() {
+    compilationTestHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void f() {
+                int i = 0;
+                while (i < 10) {
+                  (i)++;
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void negative_multipleConditionVarsParenthesized() {
+    compilationTestHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void f() {
+                int i, j;
+                for (i = 0, j = 0; i < 10 && j < 5; (i)++, (j)++) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void negative_parenthesizedCompoundAssignmentInBody() {
+    compilationTestHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void f() {
+                int i = 0;
+                while (i < 10) {
+                  (i) += 1;
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void negative_parenthesizedAssignmentInBody() {
+    compilationTestHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void f() {
+                int i = 0;
+                while (i < 10) {
+                  (i) = i + 1;
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void negative_field() {
     compilationTestHelper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/NonAtomicVolatileUpdateTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/NonAtomicVolatileUpdateTest.java
@@ -109,6 +109,146 @@ public class NonAtomicVolatileUpdateTest {
   }
 
   @Test
+  public void parenthesizedOperand_positive() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              volatile int x;
+              volatile long y;
+
+              void bad() {
+                // BUG: Diagnostic contains:
+                (x)++;
+                // BUG: Diagnostic contains:
+                (y)++;
+                // BUG: Diagnostic contains:
+                (x)--;
+                // BUG: Diagnostic contains:
+                (y)--;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void parenthesizedPrefixIncrementDecrement_positive() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              volatile int x;
+
+              void bad() {
+                // BUG: Diagnostic contains:
+                ++(x);
+                // BUG: Diagnostic contains:
+                --(x);
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void doubleParenthesized_positive() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              volatile int x;
+
+              void bad() {
+                // BUG: Diagnostic contains:
+                ((x))++;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void parenthesizedCompoundAssignment_positive() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              volatile int x;
+              volatile long y;
+
+              void bad() {
+                // BUG: Diagnostic contains:
+                (x) += 1;
+                // BUG: Diagnostic contains:
+                (y) -= 1;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void parenthesizedNonVolatile_negative() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              int nonVolatile;
+
+              void ok() {
+                (nonVolatile)++;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void parenthesizedSynchronized_negative() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              volatile int x;
+
+              void ok() {
+                synchronized (this) {
+                  (x)++;
+                  ++(x);
+                  (x) += 1;
+                }
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void parenthesizedVolatileString_positive() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              volatile String s;
+
+              void bad() {
+                // BUG: Diagnostic contains:
+                (s) += "update";
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void negativeCases() {
     compilationHelper
         .addSourceLines(

--- a/core/src/test/java/com/google/errorprone/bugpatterns/PatternMatchingInstanceofTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/PatternMatchingInstanceofTest.java
@@ -87,6 +87,128 @@ public final class PatternMatchingInstanceofTest {
   }
 
   @Test
+  public void seesThroughParensOnCastOperand() {
+    helper
+        .addInputLines(
+            "Test.java",
+            """
+            class Test {
+              int test(Object o) {
+                if (o instanceof String) {
+                  String s = (String)(o);
+                  return s.length();
+                }
+                return o.hashCode();
+              }
+            }
+            """)
+        .addOutputLines(
+            "Test.java",
+            """
+            class Test {
+              int test(Object o) {
+                if (o instanceof String s) {
+
+                  return s.length();
+                }
+                return o.hashCode();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void seesThroughDoubleParensOnCastOperand() {
+    helper
+        .addInputLines(
+            "Test.java",
+            """
+            class Test {
+              int test(Object o) {
+                if (o instanceof String) {
+                  String s = (String)((o));
+                  return s.length();
+                }
+                return o.hashCode();
+              }
+            }
+            """)
+        .addOutputLines(
+            "Test.java",
+            """
+            class Test {
+              int test(Object o) {
+                if (o instanceof String s) {
+
+                  return s.length();
+                }
+                return o.hashCode();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void parenthesizedOperandNegatedIfElse() {
+    helper
+        .addInputLines(
+            "Test.java",
+            """
+            class Test {
+              int test(Object o) {
+                if (!(o instanceof String)) {
+                } else {
+                  String s = (String)(o);
+                  return s.length();
+                }
+                return o.hashCode();
+              }
+            }
+            """)
+        .addOutputLines(
+            "Test.java",
+            """
+            class Test {
+              int test(Object o) {
+                if (!(o instanceof String s)) {
+                } else {
+
+                  return s.length();
+                }
+                return o.hashCode();
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void parenthesizedOperandInTernary() {
+    helper
+        .addInputLines(
+            "Test.java",
+            """
+            class Test {
+              int test(Object o) {
+                return o instanceof String ? ((String)(o)).length() : 0;
+              }
+            }
+            """)
+        .addOutputLines(
+            "Test.java",
+            """
+            class Test {
+              int test(Object o) {
+                return o instanceof String string ? string.length() : 0;
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void seesThroughParens() {
     helper
         .addInputLines(


### PR DESCRIPTION
Fixes: #5845 

## Problem
                                                                                                                                                                                          
  Six unrelated checks share a root cause: their AST matchers inspect raw `ExpressionTree`
  operands without unwrapping enclosing `ParenthesizedTree` nodes. Per JLS §15.8.5, a
  parenthesized expression denotes the same variable as its contained expression —
  parentheses are semantically inert. Because `ASTHelpers.getSymbol(ParenthesizedTree)`
  returns `null` (no case for `PARENTHESIZED` in the dispatch), wrapping or unwrapping one
  pair of redundant parentheses around an operand silently flips the verdict.

  | Check | Reproducer | Direction |
  |---|---|---|
  | `LoopConditionChecker` | `for (int i = 0; i < 10; (i)++) {}` | false positive |
  | `NonAtomicVolatileUpdate` | `(x)++` on a volatile field | false negative |
  | `PatternMatchingInstanceof` | `String s = (String)(o)` | false negative |
  | `DuplicateBranches` | `true ? 1 * 5 : (1 * 5)` | false negative |
  | `InlineTrivialConstant` | `private static final String EMPTY = ("")` | false negative |
  | `AssignmentExpression` | `a = b = 0` vs `a = (b = 0)` verdict drift | both directions |

  ---

  ## Fix
                                                                                                                                                                                          
  Apply `ASTHelpers.stripParentheses()` at the point where each check extracts the operand
  it will inspect.

  ### `LoopConditionChecker`
  `UpdateScanner.check()`: strip before `getSymbol`. One change covers all four call sites
  (`visitUnary`, `visitAssignment`, `visitCompoundAssignment`, `visitMethodInvocation`).

  ### `NonAtomicVolatileUpdate`
  Strip in all three extractor lambdas (`expressionFromUnaryTree`,
  `variableFromCompoundAssignmentTree`, `variableFromAssignmentTree`) before the
  `hasModifier(VOLATILE)` check.

  ### `PatternMatchingInstanceof`
  Strip `node.getExpression()` in `findAllCasts.visitTypeCast` before the
  `constantExpression` symbol lookup.

  ### `DuplicateBranches`
  Strip both arms before `toString()` comparison. Source positions for the suggested fix
  still use the original (possibly-parenthesized) tree, so the replacement is always
  syntactically valid.

  ### `InlineTrivialConstant`                                                                                                                                                
  Strip `tree.getInitializer()` before the `STRING_LITERAL` kind check and value                                                                                                          
  extraction.

  ### `AssignmentExpression`
  Walk `getParentPath()` in a loop until the leaf is no longer `ParenthesizedTree`, then                                                                                     
  use the resulting `effectiveParent` for all three downstream decisions:                                                                                                                 
  - binary-context exemption (`(foo = bar) != null`)
  - duplicate-assignment detection (`a = a = foo()`)
  - chained-assignment exemption (`x = y = 0`)

  ---

  ## Tests
                                                                                                                                                                                          
  32 new test cases across all six checkers:

  - Single and multiple layers of redundant parentheses
  - All operator forms: postfix/prefix increment/decrement, compound assignment (`+=`, `-=`),
    simple assignment
  - Negative cases confirming legitimate no-find verdicts are unaffected (e.g. non-volatile
    fields, synchronized blocks, different branch content after stripping)
  - Realistic patterns: negated if/else, ternary arms, do-while/while loop bodies, chained
    assignments, inline cast use, duplicate assignment through parentheses
