### PR TITLE
Fix FormatString false positive for switch expression arguments

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringValidation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringValidation.java
@@ -197,11 +197,16 @@ public final class FormatStringValidation {
   private static @Nullable Type getSwitchCaseResultType(CaseTree caseTree, VisitorState state) {
     Tree body = caseTree.getBody();
     if (body == null) {
+      for (StatementTree statement : caseTree.getStatements()) {
+        if (statement instanceof YieldTree yieldTree) {
+          return getExpressionType(yieldTree.getValue(), state);
+        }
+      }
       return null;
     }
     body = ASTHelpers.stripParentheses(body);
     if (body instanceof ExpressionTree expressionTree) {
-      return ASTHelpers.getType(expressionTree);
+      return getExpressionType(expressionTree, state);
     }
     if (body instanceof BlockTree blockTree) {
       for (StatementTree statement : blockTree.getStatements()) {
@@ -210,7 +215,7 @@ public final class FormatStringValidation {
         }
       }
     }
-    return ASTHelpers.getType(body);
+    return getExpressionType(body, state);
   }
 
   private static @Nullable Object getInstance(Type type, VisitorState state) {

--- a/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringValidation.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/formatstring/FormatStringValidation.java
@@ -26,9 +26,14 @@ import com.google.common.collect.Iterables;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.suppliers.Supplier;
 import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.BlockTree;
+import com.sun.source.tree.CaseTree;
 import com.sun.source.tree.ConditionalExpressionTree;
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.StatementTree;
+import com.sun.source.tree.SwitchExpressionTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.YieldTree;
 import com.sun.source.util.SimpleTreeVisitor;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Type;
@@ -150,12 +155,62 @@ public final class FormatStringValidation {
    * or {@link Integer}.
    */
   private static @Nullable Object getInstance(Tree tree, VisitorState state) {
+    tree = ASTHelpers.stripParentheses(tree);
     Object value = ASTHelpers.constValue(tree);
     if (value != null) {
       return value;
     }
-    Type type = ASTHelpers.getType(tree);
+    Type type = getExpressionType(tree, state);
     return getInstance(type, state);
+  }
+
+  private static @Nullable Type getExpressionType(Tree tree, VisitorState state) {
+    tree = ASTHelpers.stripParentheses(tree);
+    if (tree instanceof SwitchExpressionTree switchExpression) {
+      Type fromCases = switchExpressionResultType(switchExpression, state);
+      if (fromCases != null && fromCases.getKind() != TypeKind.ERROR) {
+        return fromCases;
+      }
+    }
+    return ASTHelpers.getType(tree);
+  }
+
+  private static @Nullable Type switchExpressionResultType(
+      SwitchExpressionTree switchExpression, VisitorState state) {
+    Types types = state.getTypes();
+    Type common = null;
+    for (CaseTree caseTree : switchExpression.getCases()) {
+      Type caseType = getSwitchCaseResultType(caseTree, state);
+      if (caseType == null || caseType.getKind() == TypeKind.ERROR) {
+        continue;
+      }
+      Type normalized = types.unboxedTypeOrType(types.erasure(caseType));
+      if (common == null) {
+        common = normalized;
+      } else if (!types.isSameType(common, normalized)) {
+        return null;
+      }
+    }
+    return common;
+  }
+
+  private static @Nullable Type getSwitchCaseResultType(CaseTree caseTree, VisitorState state) {
+    Tree body = caseTree.getBody();
+    if (body == null) {
+      return null;
+    }
+    body = ASTHelpers.stripParentheses(body);
+    if (body instanceof ExpressionTree expressionTree) {
+      return ASTHelpers.getType(expressionTree);
+    }
+    if (body instanceof BlockTree blockTree) {
+      for (StatementTree statement : blockTree.getStatements()) {
+        if (statement instanceof YieldTree yieldTree) {
+          return getExpressionType(yieldTree.getValue(), state);
+        }
+      }
+    }
+    return ASTHelpers.getType(body);
   }
 
   private static @Nullable Object getInstance(Type type, VisitorState state) {

--- a/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringTest.java
@@ -496,4 +496,85 @@ class Test {
             """)
         .doTest();
   }
+
+  @Test
+  public void switchExpressionArgument_nestedSwitch() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void f(int day, int mode) {
+                System.out.printf(
+                    "%d%n",
+                    switch (day) {
+                      case 1 -> switch (mode) {
+                        case 0 -> 1;
+                        default -> 2;
+                      };
+                      default -> 3;
+                    });
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void switchExpressionArgument_blockYield() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void f(int day) {
+                System.out.printf(
+                    "%d%n",
+                    switch (day) {
+                      case 1 -> {
+                        yield 6;
+                      }
+                      default -> 9;
+                    });
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void switchExpressionArgument_colonYield() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              void f(int day) {
+                System.out.printf(
+                    "%d%n",
+                    switch (day) {
+                      case 1:
+                        yield 6;
+                      default:
+                        yield 9;
+                    });
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void switchExpressionArgument_stringCases() {
+    testFormat(
+        "illegal format conversion: 'java.lang.String' cannot be formatted using '%d'",
+        "System.out.printf(\"%d\", switch (1) { case 1 -> \"a\"; default -> \"b\"; });");
+  }
+
+  @Test
+  public void switchExpressionArgument_mixedNumericCases() {
+    testFormat(
+        "cannot be formatted using '%d'",
+        "System.out.printf(\"%d\", switch (1) { case 1 -> 1; default -> 2.0; });");
+  }
 }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/formatstring/FormatStringTest.java
@@ -466,4 +466,34 @@ class Test {
             """)
         .doTest();
   }
+
+  @Test
+  public void switchExpressionArgument() {
+    compilationHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              static final int FRIDAY = 5;
+
+              void f() {
+                int day = FRIDAY;
+                var viaVar = switch (day) {
+                  case 1, 5, 7 -> 6;
+                  case 2 -> 7;
+                  default -> 9;
+                };
+                System.out.printf("via var: %d%n", viaVar);
+                System.out.printf(
+                    "inline: %d%n",
+                    switch (day) {
+                      case 1, 5, 7 -> 6;
+                      case 2 -> 7;
+                      default -> 9;
+                    });
+              }
+            }
+            """)
+        .doTest();
+  }
 }


### PR DESCRIPTION
## Summary

- `FormatString` reported a spurious `illegal format conversion` when an `int`-typed switch expression was passed directly to `printf("%d", ...)` because javac types the whole expression as `Object`, so validation fell back to a generic placeholder instance.
- Infer the switch expression result type from its case bodies (when they agree) before choosing a format-validation stand-in.
- Add a regression test covering both the `var` temporary form and the inlined switch expression.

Fixes #5831

## Test plan

- [x] `mvn -pl core clean test -Dtest=FormatStringTest` (50/50 pass, JDK 25 toolchain)
- [x] `mvn -pl core test -Dtest=LenientFormatStringValidationTest,FormatStringTest`
- [x] Prove-it: reverting only `FormatStringValidation.java` makes `switchExpressionArgument` fail with the original `FormatStringValidation$…` / `%d` diagnostic

Human-reviewed AI assistance (Cursor implementator).


Made with [Cursor](https://cursor.com)