### PR TITLE
Simplify JDK matrix:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        java: [ 25, 21 ]
+        java: [ 25, 23, 21 ]
         experimental: [ false ]
         # Only test on macos and windows with a single recent JDK to avoid a
         # combinatorial explosion of test configurations.
@@ -33,12 +33,6 @@ jobs:
             experimental: false
           - os: windows-latest
             java: 25
-            experimental: false
-          - os: ubuntu-latest
-            java: 25
-            experimental: false
-          - os: ubuntu-latest
-            java: 23
             experimental: false
           - os: ubuntu-latest
             java: EA


### PR DESCRIPTION
- We don't need to list "JDK 25 on ubuntu-latest" in `include` because it's covered by the generated `os`-`java` cross product.
- We can add 23 to the `java` list so that "JDK 23 on ubuntu-latest" is generated automatically instead of having to list it in `include`.
