### PR TITLE
fix(UnusedVariable): skip synthetic fields with no explicit source position

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
@@ -704,6 +704,11 @@ public final class UnusedVariable extends BugChecker implements CompilationUnitT
       if (wellKnownKeep.shouldKeep(variableTree)) {
         return;
       }
+      // Skip variables that don't have an explicit source position
+      // (e.g., Lombok-generated fields like @Slf4j's log field).
+      if (!hasExplicitSource(variableTree, state)) {
+        return;
+      }
       switch (symbol.getKind()) {
         case FIELD -> {
           // We are only interested in private fields and those which are not special.


### PR DESCRIPTION
### Problem

When Lombok generates a field (e.g., the `log` field from `@Slf4j`), the AST node has a synthetic source position (`Position.NOPOS`). The `UnusedVariable` checker flags these fields as unused and attempts to build a fix, but `replaceIncludingComments` throws a `SourcePositionException` because the position doesn't map to any actual source code.

Stack trace: `SourcePositionException: invalid source position` at `UnusedVariable.buildUnusedVarFixes`.

### Fix

Add a `hasExplicitSource` check in `handleVariable` to skip variables that don't have a valid source position. This is the same pattern already used in `buildUnusedParameterFixes` to handle enum constructors with bogus positions.

`hasExplicitSource` returns `false` when the start or end position is `Position.NOPOS` or when they are equal, which is exactly the case for Lombok-generated nodes.

### References

Fixes https://github.com/google/error-prone/issues/5964