### PR TITLE
Skip nested java.lang types in AvoidCommonTypeNames

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/AvoidCommonTypeNames.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/AvoidCommonTypeNames.java
@@ -83,7 +83,12 @@ public class AvoidCommonTypeNames extends BugChecker
                             s ->
                                 s instanceof ClassSymbol
                                     && s.getModifiers().contains(PUBLIC)
-                                    && !IGNORED.contains(s.getSimpleName().toString())))
+                                    && !IGNORED.contains(s.getSimpleName().toString())
+                                    // Nested types (ProcessHandle.Info, Character.UnicodeScript,
+                                    // ...) are not auto-imported by simple name. --release can
+                                    // still surface them through PackageSymbol#members.
+                                    && s.getQualifiedName()
+                                        .contentEquals("java.lang." + s.getSimpleName())))
                 .collect(toImmutableMap(s -> s.getSimpleName().toString(), s -> (ClassSymbol) s));
           });
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/AvoidCommonTypeNamesTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/AvoidCommonTypeNamesTest.java
@@ -114,4 +114,48 @@ public class AvoidCommonTypeNamesTest {
             """)
         .doTest();
   }
+
+  @Test
+  public void negative_nestedJavaLangTypeUnderRelease() {
+    testHelper
+        .addSourceLines(
+            "Info.java",
+            """
+            class Info {}
+            """)
+        .addSourceLines(
+            "UnicodeScript.java",
+            """
+            class UnicodeScript {}
+            """)
+        .setArgs("--release", Integer.toString(Runtime.version().feature()))
+        .doTest();
+  }
+
+  @Test
+  public void negative_nestedJavaLangTypeUnderOlderRelease() {
+    testHelper
+        .addSourceLines(
+            "UnicodeScript.java",
+            """
+            class UnicodeScript {}
+            """)
+        .setArgs("--release", "8")
+        .doTest();
+  }
+
+  @Test
+  public void positive_topLevelStillFlaggedUnderRelease() {
+    testHelper
+        .addSourceLines(
+            "foo/String.java",
+            """
+            package foo;
+
+            // BUG: Diagnostic contains: foo.String clashes with java.lang.String
+            public class String {}
+            """)
+        .setArgs("--release", Integer.toString(Runtime.version().feature()))
+        .doTest();
+  }
 }


### PR DESCRIPTION
AvoidCommonTypeNames warned that a top-level `Info` clashed with `java.lang.ProcessHandle.Info` under `--release`. Those nested types are not auto-imported by simple name, so I dropped them from the clash set.

Fixes #5957