### PR TITLE
Fix a Refaster crash on `module-info.java` files

### DIFF
--- a/core/src/main/java/com/google/errorprone/refaster/UMemberSelect.java
+++ b/core/src/main/java/com/google/errorprone/refaster/UMemberSelect.java
@@ -65,7 +65,10 @@ public abstract class UMemberSelect extends UExpression implements MemberSelectT
   @Override
   public Choice<Unifier> visitIdentifier(IdentifierTree ident, Unifier unifier) {
     Symbol sym = ASTHelpers.getSymbol(ident);
-    if (sym != null && sym.owner.type != null && sym.owner.type.isReference()) {
+    if (sym != null
+        && sym.owner != null
+        && sym.owner.type != null
+        && sym.owner.type.isReference()) {
       JCExpression thisIdent = unifier.thisExpression(sym.owner.type);
       return getIdentifier()
           .unify(ident.getName(), unifier)

--- a/core/src/test/java/com/google/errorprone/refaster/UMemberSelectTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/UMemberSelectTest.java
@@ -16,10 +16,16 @@
 
 package com.google.errorprone.refaster;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.SerializableTester;
+import com.sun.tools.javac.code.Symbol.ModuleSymbol;
+import com.sun.tools.javac.code.Symtab;
+import com.sun.tools.javac.tree.JCTree.JCIdent;
+import com.sun.tools.javac.tree.TreeMaker;
+import com.sun.tools.javac.util.Names;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -37,6 +43,18 @@ public class UMemberSelectTest extends AbstractUTreeTest {
     UType type = mock(UType.class);
     UMemberSelect memberSelect = UMemberSelect.create(fooLit, "length", type);
     assertInlines("\"foo\".length", memberSelect);
+  }
+
+  @Test
+  public void unifyWithModuleIdentifier() {
+    UMemberSelect memberSelect =
+        UMemberSelect.create(ULiteral.stringLit("foo"), "length", mock(UType.class));
+
+    ModuleSymbol module =
+        Symtab.instance(context).enterModule(Names.instance(context).fromString("somemodule"));
+    JCIdent moduleIdentifier = TreeMaker.instance(context).Ident(module);
+
+    assertThat(memberSelect.unify(moduleIdentifier, unifier).findFirst()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
`UMemberSelect#visitIdentifier` unconditionally dereferences `sym.owner`, but module symbols have no owner: `Symbol.ModuleSymbol#create` always passes `null`. Any Refaster rule whose `@BeforeTemplate` is rooted at an instance member select then crashes the compiler as soon as it scans a `requires` directive whose module name is a single identifier.

Module names that contain a dot are parsed as member selects instead, and `#visitMemberSelect` is already null-safe; as every JDK module name contains a dot, this has so far gone unnoticed.

Reported at
https://github.com/PicnicSupermarket/error-prone-support/issues/2316.