### PR TITLE
Recognize compile-time constants in LoopConditionChecker

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/LoopConditionChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/LoopConditionChecker.java
@@ -93,7 +93,7 @@ public class LoopConditionChecker extends BugChecker
         .build();
   }
 
-  /** Scan for loop conditions that are determined entirely by the state of local variables. */
+  /** Scan for loop conditions determined entirely by local variables and compile-time constants. */
   private static class LoopConditionVisitor extends SimpleTreeVisitor<Boolean, Void> {
 
     static ImmutableSet<Symbol.VarSymbol> scan(Tree tree) {
@@ -112,6 +112,9 @@ public class LoopConditionChecker extends BugChecker
 
     @Override
     public Boolean visitIdentifier(IdentifierTree tree, Void unused) {
+      if (ASTHelpers.constValue(tree) != null) {
+        return true;
+      }
       Symbol sym = ASTHelpers.getSymbol(tree);
       if (sym instanceof Symbol.VarSymbol varSymbol) {
         switch (sym.getKind()) {
@@ -128,6 +131,11 @@ public class LoopConditionChecker extends BugChecker
     @Override
     public Boolean visitLiteral(LiteralTree tree, Void unused) {
       return true;
+    }
+
+    @Override
+    protected Boolean defaultAction(Tree node, Void unused) {
+      return ASTHelpers.constValue(node) != null;
     }
 
     @Override

--- a/core/src/test/java/com/google/errorprone/bugpatterns/LoopConditionCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/LoopConditionCheckerTest.java
@@ -176,6 +176,112 @@ public class LoopConditionCheckerTest {
   }
 
   @Test
+  public void compileTimeConstantBounds_areEquivalentToLiterals() {
+    compilationTestHelper
+        .expectErrorMessage(
+            "ONLY_I",
+            message ->
+                message.contains("condition variable(s) never modified in loop body: i")
+                    && !message.contains("i,"))
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              static final int ZERO = 0;
+              static final int ONE = 1;
+              static final boolean TRUE = true;
+              static final boolean FALSE = false;
+
+              void sink() {}
+
+              void f() {
+                final int localOne = 1;
+                // BUG: Diagnostic matches: ONLY_I
+                for (int i = 0; i < 1; sink()) {}
+                // BUG: Diagnostic matches: ONLY_I
+                for (int i = 0; i < localOne; sink()) {}
+                // BUG: Diagnostic matches: ONLY_I
+                for (int i = 0; i < ONE; sink()) {}
+                // BUG: Diagnostic matches: ONLY_I
+                for (int i = 0; i < ZERO; sink()) {}
+                // BUG: Diagnostic matches: ONLY_I
+                for (int i = 0; TRUE && i < ONE; sink()) {}
+                // BUG: Diagnostic matches: ONLY_I
+                for (int i = 0; FALSE || i < ONE; sink()) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void compileTimeConstantExpressions() {
+    compilationTestHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Bounds {
+              static final int ZERO = 0;
+              static final int ONE = 1;
+              static final int TWO = ONE + 1;
+            }
+
+            class Test {
+              static final boolean TRUE = true;
+
+              void sink() {}
+
+              void f() {
+                // BUG: Diagnostic contains:
+                for (int i = 0; i < Bounds.ONE; sink()) {}
+                // BUG: Diagnostic contains:
+                for (int i = 0; i < Bounds.TWO; sink()) {}
+                // BUG: Diagnostic contains:
+                for (int i = 0; i < Bounds.ONE + 1; sink()) {}
+                // BUG: Diagnostic contains:
+                for (int i = 0; i < (int) Bounds.ONE; sink()) {}
+                // BUG: Diagnostic contains:
+                for (int i = 0; i < (TRUE ? Bounds.ONE : Bounds.ZERO); sink()) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
+  public void nonConstantFieldsRemainOutOfScope() {
+    compilationTestHelper
+        .addSourceLines(
+            "Test.java",
+            """
+            class Test {
+              static final Integer BOXED_ONE = 1;
+              static final int RUNTIME_ONE = Integer.parseInt("1");
+              static final Boolean BOXED_TRUE = true;
+              static final boolean RUNTIME_TRUE = Boolean.parseBoolean("true");
+              static final boolean RUNTIME_FALSE = Boolean.parseBoolean("false");
+              static int mutableOne = 1;
+              static boolean mutableTrue = true;
+              static boolean mutableFalse = false;
+
+              void sink() {}
+
+              void f() {
+                for (int i = 0; i < BOXED_ONE; sink()) {}
+                for (int i = 0; i < RUNTIME_ONE; sink()) {}
+                for (int i = 0; i < mutableOne; sink()) {}
+                for (int i = 0; BOXED_TRUE && i < 1; sink()) {}
+                for (int i = 0; RUNTIME_TRUE && i < 1; sink()) {}
+                for (int i = 0; RUNTIME_FALSE || i < 1; sink()) {}
+                for (int i = 0; mutableTrue && i < 1; sink()) {}
+                for (int i = 0; mutableFalse || i < 1; sink()) {}
+              }
+            }
+            """)
+        .doTest();
+  }
+
+  @Test
   public void negative_field() {
     compilationTestHelper
         .addSourceLines(


### PR DESCRIPTION
`LoopConditionChecker` currently handles literal loop bounds but rejects equivalent javac compile-time constants. Local constant variables can be reported as if they were mutable condition variables, while static constants, member selects, casts, and conditional constant expressions can stop analysis entirely. This causes the checker to miss genuine loops whose only changing-looking operand is actually constant.

Use javac's attributed constant value through `ASTHelpers.constValue` instead of inferring constants from modifiers or initializer syntax. Constant identifiers are ignored as condition variables, and otherwise unsupported expression kinds are accepted only when javac has assigned them a compile-time constant value.

This intentionally does not treat boxed constants, method-call initializers, mutable fields, or other runtime values as constants.

Fixes #5826

The tests were first applied without the production change. `LoopConditionCheckerTest` ran 12 tests with 2 failures: local/static constant bounds were not treated like literals, and member-select/cast/conditional constant expressions produced no diagnostic.

The regression tests cover local, static, and externally declared primitive constants; constant initializer, cast, and conditional expressions; and negative controls for boxed, runtime, and mutable values. They also verify that only the genuinely mutable variable is reported.

`LoopConditionCheckerTest` and the full `core -am` test suite pass. A full reactor `clean install -DskipTests` also succeeds.
