### PR TITLE
Don't allocate a VisitorState when a memoized lookup hits the cache

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/VisitorState.java
+++ b/check_api/src/main/java/com/google/errorprone/VisitorState.java
@@ -172,6 +172,9 @@ public final class VisitorState {
   }
 
   private VisitorState withNoPathForMemoization() {
+    if (path == null) {
+      return this;
+    }
     return new VisitorState(context, null, suppressedState, sharedState);
   }
 
@@ -624,18 +627,12 @@ public final class VisitorState {
 
     @Override
     public synchronized T get(VisitorState state) {
-      /*
-       * Don't let callers rely on the TreePath: The Cache is shared across the whole compilation,
-       * not just the current VisitorState's TreePath's CompilationUnit.
-       */
-      state = state.withNoPathForMemoization();
-
       /* javac is single-threaded, so in principle we don't really need to lock.
       But in practice it's cheap enough to be worth getting peace of mind that this is
       always correct. */
       T value = cache.get();
       if (value == null) {
-        value = impl.get(state);
+        value = compute(state);
         if (value != null) {
           cache = new SoftReference<>(value);
           provenance = state.sharedState.javacInvocationInstance;
@@ -643,12 +640,20 @@ public final class VisitorState {
       } else {
         JavacInvocationInstance current = state.sharedState.javacInvocationInstance;
         if (provenance != current) {
-          value = impl.get(state);
+          value = compute(state);
           cache = new SoftReference<>(value);
           provenance = current;
         }
       }
       return value;
+    }
+
+    private T compute(VisitorState state) {
+      /*
+       * Don't let callers rely on the TreePath: The Cache is shared across the whole compilation,
+       * not just the current VisitorState's TreePath's CompilationUnit.
+       */
+      return impl.get(state.withNoPathForMemoization());
     }
   }
 


### PR DESCRIPTION
## Why

`VisitorState.Cache.get` replaced the caller's state with a pathless copy before it looked in the cache:

```java
public synchronized T get(VisitorState state) {
  state = state.withNoPathForMemoization();

  T value = cache.get();
  if (value == null) {
    value = impl.get(state);
    ...
```

The copy keeps a memoized supplier from reading a `TreePath` that belongs to one compilation unit while its result is cached for the whole compilation, so `impl.get` is the only caller that needs it. The cache answers most reads without calling `impl`, and those reads allocated a `VisitorState` and dropped it.

The scanner reaches memoized suppliers through `TypePredicates`, `Suppliers.typeFromString`, `Matchers`, and `MethodMatchers`, once per matcher per AST node, so the reads are frequent: compiling the 948 sources of `error_prone_core` with Error Prone enabled runs `Cache.get` 25448504 times and answers 17019874 of those from the cache.

## What

`compute` now makes the pathless copy, and it runs only when the value has to be computed. `withNoPathForMemoization` returns `this` when the path is already null, so a memoized supplier that reads another memoized value allocates nothing either.

`impl` still receives a state whose `getPath()` throws, and the `provenance` bookkeeping reads `sharedState`, which the copy shares with the original.

## How to verify

```bash
mvn -pl check_api,core test
```

Allocation was measured with an in-process `javac` compiling the 948 sources of `error_prone_core` with Error Prone enabled on JDK 24, reading `ThreadMXBean.getThreadAllocatedBytes` for the compiling thread. Steady state over six compilations in one JVM: 8.251 GiB before, 7.744 GiB after. The 17019874 cached reads at 32 bytes per `VisitorState` come to 0.507 GiB, which is the whole difference.
