### PR TITLE
Skip the check when parameters have duplicate names

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/OverridingMethodInconsistentArgumentNamesChecker.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/OverridingMethodInconsistentArgumentNamesChecker.java
@@ -49,16 +49,21 @@ public class OverridingMethodInconsistentArgumentNamesChecker extends BugChecker
       return Description.NO_MATCH;
     }
 
-    ImmutableBiMap<Name, Integer> params = getParams(methodSymbol);
-    ImmutableBiMap<Name, Integer> superParams = getParams(superMethod.get());
+    Optional<ImmutableBiMap<Name, Integer>> params = getParams(methodSymbol);
+    Optional<ImmutableBiMap<Name, Integer>> superParams = getParams(superMethod.get());
+    if (params.isEmpty() || superParams.isEmpty()) {
+      return Description.NO_MATCH;
+    }
+    ImmutableBiMap<Name, Integer> paramsMap = params.get();
+    ImmutableBiMap<Name, Integer> superParamsMap = superParams.get();
 
-    for (Name param : params.keySet()) {
-      int position = params.get(param);
-      if (!superParams.containsKey(param) || position == superParams.get(param)) {
+    for (Name param : paramsMap.keySet()) {
+      int position = paramsMap.get(param);
+      if (!superParamsMap.containsKey(param) || position == superParamsMap.get(param)) {
         continue;
       }
-      Name samePositionSuperParam = superParams.inverse().get(position);
-      if (params.containsKey(samePositionSuperParam)) {
+      Name samePositionSuperParam = superParamsMap.inverse().get(position);
+      if (paramsMap.containsKey(samePositionSuperParam)) {
         return buildDescription(methodTree).setMessage(getDescription(superMethod.get())).build();
       }
     }
@@ -66,10 +71,17 @@ public class OverridingMethodInconsistentArgumentNamesChecker extends BugChecker
     return Description.NO_MATCH;
   }
 
-  private static ImmutableBiMap<Name, Integer> getParams(MethodSymbol methodSymbol) {
-    return range(0, methodSymbol.getParameters().size())
-        .boxed()
-        .collect(toImmutableBiMap(i -> methodSymbol.getParameters().get(i).name, i -> i));
+  private static Optional<ImmutableBiMap<Name, Integer>> getParams(MethodSymbol methodSymbol) {
+    // Obfuscators sometimes rename all parameters of a method to the same name. A name-to-position
+    // map is not well-defined in that case, so there is nothing sensible to compare against.
+    if (methodSymbol.getParameters().stream().map(p -> p.name).distinct().count()
+        != methodSymbol.getParameters().size()) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        range(0, methodSymbol.getParameters().size())
+            .boxed()
+            .collect(toImmutableBiMap(i -> methodSymbol.getParameters().get(i).name, i -> i)));
   }
 
   /**

--- a/core/src/test/java/com/google/errorprone/bugpatterns/OverridingMethodInconsistentArgumentNamesCheckerTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/OverridingMethodInconsistentArgumentNamesCheckerTest.java
@@ -16,7 +16,16 @@
 
 package com.google.errorprone.bugpatterns;
 
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
 import com.google.errorprone.CompilationTestHelper;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -112,5 +121,101 @@ public class OverridingMethodInconsistentArgumentNamesCheckerTest {
             }
             """)
         .doTest();
+  }
+
+  @Test
+  public void duplicateParameterNamesInSuperMethod() throws Exception {
+    Path dir = Files.createTempDirectory("ep-dup-param-names");
+    try {
+      Path source = dir.resolve("A.java");
+      Files.write(source, List.of("class A {", "  void m(int p1, int p2) {}", "}"));
+      JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+      assertEquals(
+          "compiling the superclass failed",
+          0,
+          compiler.run(
+              null,
+              null,
+              null,
+              "--release",
+              "21",
+              "-parameters",
+              "-d",
+              dir.toString(),
+              source.toString()));
+      // Obfuscators sometimes rewrite every parameter of a method to the same name. javac is fine
+      // with that when reading a class file, so emulate it by renaming the second parameter.
+      Path classFile = dir.resolve("A.class");
+      Files.write(classFile, mangleParameterNames(Files.readAllBytes(classFile)));
+
+      testHelper
+          .addSourceLines(
+              "B.java",
+              """
+              class B extends A {
+                @Override
+                void m(int p1, int p2) {}
+              }
+              """)
+          .setArgs("-classpath", dir.toString())
+          .doTest();
+    } finally {
+      MoreFiles.deleteRecursively(dir, RecursiveDeleteOption.ALLOW_INSECURE);
+    }
+  }
+
+  private static byte[] mangleParameterNames(byte[] classFile) {
+    // Rewrites the constant-pool entry for "p2" to "p1" (same length), so both parameters of A.m
+    // end up with the same name in the MethodParameters attribute.
+    int offset = 8; // magic, minor version, major version
+    int constantPoolCount = readU2(classFile, offset);
+    offset += 2;
+    for (int i = 1; i < constantPoolCount; i++) {
+      int tag = classFile[offset++] & 0xff;
+      switch (tag) {
+        case 1: // Utf8
+          int length = readU2(classFile, offset);
+          offset += 2;
+          if (length == 2 && classFile[offset] == 'p' && classFile[offset + 1] == '2') {
+            classFile[offset + 1] = '1';
+          }
+          offset += length;
+          break;
+        case 3: // Integer
+        case 4: // Float
+          offset += 4;
+          break;
+        case 5: // Long
+        case 6: // Double
+          offset += 8;
+          i++;
+          break;
+        case 7: // Class
+        case 8: // String
+        case 16: // MethodType
+        case 19: // Module
+        case 20: // Package
+          offset += 2;
+          break;
+        case 9: // Fieldref
+        case 10: // Methodref
+        case 11: // InterfaceMethodref
+        case 12: // NameAndType
+        case 17: // Dynamic
+        case 18: // InvokeDynamic
+          offset += 4;
+          break;
+        case 15: // MethodHandle
+          offset += 3;
+          break;
+        default:
+          throw new AssertionError("Unexpected constant pool tag: " + tag);
+      }
+    }
+    return classFile;
+  }
+
+  private static int readU2(byte[] bytes, int offset) {
+    return ((bytes[offset] & 0xff) << 8) | (bytes[offset + 1] & 0xff);
   }
 }


### PR DESCRIPTION
OverridingMethodInconsistentArgumentNamesChecker can crash with 'Multiple entries with same key' when you override a method that was compiled by something which renamed every parameter to the same name (obfuscated Minecraft libs etc. do this). javac happily loads such a class file, but the check then tries to build a name->position ImmutableBiMap for the super method and blows up.

There's nothing to compare when a method has duplicate parameter names, so I made it skip the check in that case.

Added a regression test that compiles a normal superclass, rewrites its MethodParameters attribute so both params are named p1, and overrides it. It failed with the reported stack before the fix.